### PR TITLE
Add sidebar navigation with icons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,30 @@
 import React, { useState } from 'react';
 import './styles.css';
 
-const tabs = ['Character', 'Training', 'World', 'Friends'];
+const tabs = [
+  { label: 'Training', icon: '🧠' },
+  { label: 'Character', icon: '👤' },
+  { label: 'World', icon: '🌍' },
+  { label: 'Friends', icon: '🤝' },
+];
 
 export default function App() {
-  const [activeTab, setActiveTab] = useState(tabs[0]);
+  const [activeTab, setActiveTab] = useState(tabs[0].label);
 
   return (
-    <div>
-      <nav className="nav-container">
+    <div className="app-container">
+      <aside className="sidebar">
         {tabs.map((tab) => (
           <div
-            key={tab}
-            className={`tab ${activeTab === tab ? 'active' : ''}`}
-            onClick={() => setActiveTab(tab)}
+            key={tab.label}
+            className={`tab ${activeTab === tab.label ? 'active' : ''}`}
+            onClick={() => setActiveTab(tab.label)}
           >
-            {tab}
+            <span className="icon">{tab.icon}</span>
+            <span>{tab.label}</span>
           </div>
         ))}
-      </nav>
+      </aside>
       <div className="content">
         <h1>{activeTab}</h1>
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,25 +5,48 @@ body {
   color: white;
 }
 
-.nav-container {
+
+.app-container {
   display: flex;
+  height: 100vh;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
   gap: 10px;
-  padding: 10px;
+  width: 200px;
+  background-color: #111;
+  padding: 20px 0;
 }
 
 .tab {
-  background-color: #fec76f;
-  color: white;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ccc;
   padding: 10px 20px;
   cursor: pointer;
   border-radius: 4px;
   user-select: none;
+  transition: background-color 0.2s, color 0.2s;
 }
 
 .tab.active {
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+  background-color: #333;
+  color: #fff;
+}
+
+.tab:hover {
+  background-color: #222;
+  color: #fff;
 }
 
 .content {
   padding: 20px;
+  flex: 1;
+}
+
+.icon {
+  font-size: 1.2em;
 }


### PR DESCRIPTION
## Summary
- replace top navigation with left sidebar in `App.jsx`
- add emoji icons for all 4 categories
- adjust styles to show sidebar layout

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684856f371988322952bb043e68e26cc