### PR TITLE
Add landing page with quadrant navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,51 @@
 import React, { useState } from 'react';
 import './styles.css';
 
-const tabs = ['Character', 'Training', 'World', 'Friends'];
+const tabs = [
+  { label: 'Training', icon: '🧠' },
+  { label: 'Character', icon: '👤' },
+  { label: 'World', icon: '🌍' },
+  { label: 'Friends', icon: '🤝' },
+];
+
+function Landing({ onSelect }) {
+  return (
+    <div className="landing">
+      <div className="main">
+        <div className="up">
+          <button className="card card1" onClick={() => onSelect('Training')}>🧠</button>
+          <button className="card card2" onClick={() => onSelect('Character')}>👤</button>
+        </div>
+        <div className="down">
+          <button className="card card3" onClick={() => onSelect('World')}>🌍</button>
+          <button className="card card4" onClick={() => onSelect('Friends')}>🤝</button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function App() {
-  const [activeTab, setActiveTab] = useState(tabs[0]);
+  const [activeTab, setActiveTab] = useState(null);
+
+  if (!activeTab) {
+    return <Landing onSelect={setActiveTab} />;
+  }
 
   return (
-    <div>
-      <nav className="nav-container">
+    <div className="app-container">
+      <aside className="sidebar">
         {tabs.map((tab) => (
           <div
-            key={tab}
-            className={`tab ${activeTab === tab ? 'active' : ''}`}
-            onClick={() => setActiveTab(tab)}
+            key={tab.label}
+            className={`tab ${activeTab === tab.label ? 'active' : ''}`}
+            onClick={() => setActiveTab(tab.label)}
           >
-            {tab}
+            <span className="icon">{tab.icon}</span>
+            <span>{tab.label}</span>
           </div>
         ))}
-      </nav>
+      </aside>
       <div className="content">
         <h1>{activeTab}</h1>
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,25 +5,117 @@ body {
   color: white;
 }
 
-.nav-container {
+.landing {
+  background-color: white;
+  color: black;
   display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.up,
+.down {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5em;
+}
+
+.card {
+  width: 90px;
+  height: 90px;
+  outline: none;
+  border: none;
+  background: white;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px,
+    rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+  transition: transform 0.2s ease-in-out;
+  font-size: 2em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card:hover {
+  cursor: pointer;
+  transform: scale(1.1);
+  background-color: #f0f0f0;
+}
+
+.card1 {
+  border-radius: 90px 5px 5px 5px;
+}
+
+.card2 {
+  border-radius: 5px 90px 5px 5px;
+}
+
+.card3 {
+  border-radius: 5px 5px 5px 90px;
+}
+
+.card4 {
+  border-radius: 5px 5px 90px 5px;
+}
+
+
+
+.app-container {
+  display: flex;
+  height: 100vh;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 200px;
+  background-color: #1e1e1e;
+  display: flex;
+  flex-direction: column;
   gap: 10px;
-  padding: 10px;
+  padding: 20px 0;
 }
 
 .tab {
-  background-color: #fec76f;
-  color: white;
-  padding: 10px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  color: #ccc;
+  padding: 15px 20px;
   cursor: pointer;
   border-radius: 4px;
   user-select: none;
+  text-align: center;
+  transition: background-color 0.2s, color 0.2s;
 }
 
 .tab.active {
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+  background-color: #333;
+  color: #fff;
+  border-left: 4px solid #fec76f;
+}
+
+.tab:hover {
+  background-color: #222;
+  color: #fff;
+  border-left: 4px solid #fec76f;
 }
 
 .content {
+  margin-left: 200px;
   padding: 20px;
+  flex: 1;
+}
+
+.icon {
+  font-size: 4em; /* bigger icon for clarity */
 }


### PR DESCRIPTION
## Summary
- add landing view with four quadrant buttons
- clicking a quadrant opens the existing sidebar layout
- style landing page with white background and square cards
- enlarge sidebar icons for clarity
- refine sidebar visuals and highlight active tab

## Testing
- `npm run build`
- `npm start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_684856f371988322952bb043e68e26cc