### PR TITLE
Add configurable window sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,20 @@ And make it social so people can make friends (School
 It will hold all the spiritual lore, 
 The idea of mazed is to make a map, that people can use to find themselves, god, and there version of it
 
+
+## Window sizes
+
+You can define the initial window size when launching the Electron app by setting the `APP_SIZE` environment variable. The value must be one of the supported resolutions:
+
+- `1024x575`
+- `1280x720`
+- `1600x900`
+- `1920x1080`
+
+Example:
+
+```bash
+APP_SIZE=1280x720 npm start
+```
+
+If `APP_SIZE` is not provided or has an invalid value, the default size of `800x600` is used.

--- a/electron-main.js
+++ b/electron-main.js
@@ -1,10 +1,34 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 
+function getWindowSize() {
+  const defaultSize = { width: 800, height: 600 };
+  const sizeEnv = process.env.APP_SIZE;
+  if (!sizeEnv) {
+    return defaultSize;
+  }
+  const match = sizeEnv.match(/^(\d+)x(\d+)$/);
+  if (!match) {
+    return defaultSize;
+  }
+  const width = parseInt(match[1], 10);
+  const height = parseInt(match[2], 10);
+  // Allow only predefined sizes for now
+  const allowed = [
+    [1024, 575],
+    [1280, 720],
+    [1600, 900],
+    [1920, 1080],
+  ];
+  if (allowed.some(([w, h]) => w === width && h === height)) {
+    return { width, height };
+  }
+  return defaultSize;
+}
+
 function createWindow() {
   const win = new BrowserWindow({
-    width: 800,
-    height: 600,
+    ...getWindowSize(),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
     },


### PR DESCRIPTION
## Summary
- allow passing APP_SIZE environment variable to set the initial window size
- document supported window sizes in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68494b8802d88322860b2f78cbcd8162