### PR TITLE
Add configurable window sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,25 @@ And make it social so people can make friends (School
 It will hold all the spiritual lore, 
 The idea of mazed is to make a map, that people can use to find themselves, god, and there version of it
 
+
+## Window sizes
+
+You can define the initial window size when launching the Electron app by setting the `APP_SIZE` environment variable. The value must be one of the supported resolutions:
+
+- `1024x575`
+- `1280x720`
+- `1600x900`
+- `1920x1080`
+
+Example:
+
+```bash
+APP_SIZE=1280x720 npm start
+```
+
+If `APP_SIZE` is not provided or has an invalid value, the default size of `800x600` is used.
+
+After launching the application you can change the size at any time using the
+size selector located in the sidebar. Choose one of the supported resolutions
+and press **Apply Size**. The selected dimensions are stored so that the app
+opens with the same size on the next launch.

--- a/electron-main.js
+++ b/electron-main.js
@@ -1,10 +1,72 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
+const fs = require('fs');
 const path = require('path');
 
+let mainWindow;
+
+const allowedSizes = [
+  [1024, 575],
+  [1280, 720],
+  [1600, 900],
+  [1920, 1080],
+];
+
+function configPath() {
+  return path.join(app.getPath('userData'), 'window-size.json');
+}
+
+function readSavedWindowSize() {
+  try {
+    const data = fs.readFileSync(configPath(), 'utf-8');
+    const parsed = JSON.parse(data);
+    if (
+      parsed &&
+      Number.isInteger(parsed.width) &&
+      Number.isInteger(parsed.height)
+    ) {
+      return parsed;
+    }
+  } catch (err) {
+    // ignore
+  }
+  return null;
+}
+
+function saveWindowSize(size) {
+  try {
+    fs.writeFileSync(configPath(), JSON.stringify(size));
+  } catch (err) {
+    // ignore
+  }
+}
+
+function parseEnvSize() {
+  const sizeEnv = process.env.APP_SIZE;
+  if (sizeEnv) {
+    const match = sizeEnv.match(/^(\d+)x(\d+)$/);
+    if (match) {
+      const width = parseInt(match[1], 10);
+      const height = parseInt(match[2], 10);
+      if (allowedSizes.some(([w, h]) => w === width && h === height)) {
+        return { width, height };
+      }
+    }
+  }
+  return null;
+}
+
+function getWindowSize() {
+  const defaultSize = { width: 800, height: 600 };
+  const envSize = parseEnvSize();
+  if (envSize) return envSize;
+  const saved = readSavedWindowSize();
+  if (saved) return saved;
+  return defaultSize;
+}
+
 function createWindow() {
-  const win = new BrowserWindow({
-    width: 800,
-    height: 600,
+  mainWindow = new BrowserWindow({
+    ...getWindowSize(),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
     },
@@ -12,13 +74,24 @@ function createWindow() {
 
   const devServerURL = process.env.VITE_DEV_SERVER_URL;
   if (devServerURL) {
-    win.loadURL(devServerURL);
+    mainWindow.loadURL(devServerURL);
   } else {
-    win.loadFile(path.join(__dirname, 'dist/index.html'));
+    mainWindow.loadFile(path.join(__dirname, 'dist/index.html'));
   }
 }
 
 app.whenReady().then(createWindow);
+
+ipcMain.handle('set-window-size', (_event, width, height) => {
+  if (mainWindow) {
+    mainWindow.setSize(width, height);
+    saveWindowSize({ width, height });
+  }
+});
+
+ipcMain.handle('get-saved-window-size', () => {
+  return readSavedWindowSize();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/preload.js
+++ b/preload.js
@@ -1,3 +1,6 @@
-window.addEventListener('DOMContentLoaded', () => {
-  // Preload can expose APIs to renderer here if needed
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('api', {
+  setWindowSize: (width, height) => ipcRenderer.invoke('set-window-size', width, height),
+  getSavedWindowSize: () => ipcRenderer.invoke('get-saved-window-size'),
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import './styles.css';
 import QuadrantButton from './QuadrantButton.jsx';
+import SizeSelector from './SizeSelector.jsx';
 
 const tabs = [
   { label: 'Training', icon: '🧠' },
@@ -39,6 +40,7 @@ export default function App() {
             <span>{tab.label}</span>
           </div>
         ))}
+        <SizeSelector />
       </aside>
       <div className="content">
         <h1>{activeTab}</h1>

--- a/src/SizeSelector.jsx
+++ b/src/SizeSelector.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useEffect } from 'react';
+
+const options = [
+  { label: '1024x575', width: 1024, height: 575 },
+  { label: '1280x720', width: 1280, height: 720 },
+  { label: '1600x900', width: 1600, height: 900 },
+  { label: '1920x1080', width: 1920, height: 1080 },
+];
+
+export default function SizeSelector() {
+  const [selected, setSelected] = useState(options[0].label);
+
+  useEffect(() => {
+    if (window.api && window.api.getSavedWindowSize) {
+      window.api.getSavedWindowSize().then((size) => {
+        if (size) {
+          const match = options.find(
+            (o) => o.width === size.width && o.height === size.height
+          );
+          if (match) {
+            setSelected(match.label);
+          }
+        }
+      });
+    }
+  }, []);
+
+  function applySize() {
+    const opt = options.find((o) => o.label === selected);
+    if (opt && window.api && window.api.setWindowSize) {
+      window.api.setWindowSize(opt.width, opt.height);
+    }
+  }
+
+  return (
+    <div className="size-selector">
+      <select value={selected} onChange={(e) => setSelected(e.target.value)}>
+        {options.map((o) => (
+          <option key={o.label} value={o.label}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <button onClick={applySize}>Apply Size</button>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -57,3 +57,15 @@ body {
 .icon {
   font-size: 1.2em;
 }
+
+.size-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 0 20px;
+}
+
+.size-selector button {
+  padding: 5px 10px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- allow passing APP_SIZE environment variable to set the initial window size
- document supported window sizes in README
- add size selector UI to resize the window from the sidebar and persist the choice
- persist window dimensions in a file under userData

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68494b8802d88322860b2f78cbcd8162