### PR TITLE
Add resizable side columns

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -3,8 +3,9 @@ const path = require('path');
 
 function createWindow() {
   const win = new BrowserWindow({
-    width: 800,
-    height: 600,
+    width: 1600,
+    height: 900,
+    resizable: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
     },

--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import './main-page.css';
+
+export default function MainPage() {
+  const MIN_WIDTH = 253;
+  const MAX_WIDTH = 523;
+
+  const [leftWidth, setLeftWidth] = useState(MIN_WIDTH);
+  const [rightWidth, setRightWidth] = useState(MIN_WIDTH);
+
+  const startLeftDrag = (e) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = leftWidth;
+
+    const onMouseMove = (ev) => {
+      let newWidth = startWidth + (ev.clientX - startX);
+      if (newWidth < MIN_WIDTH) newWidth = MIN_WIDTH;
+      if (newWidth > MAX_WIDTH) newWidth = MAX_WIDTH;
+      setLeftWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  };
+
+  const startRightDrag = (e) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = rightWidth;
+
+    const onMouseMove = (ev) => {
+      let newWidth = startWidth - (ev.clientX - startX);
+      if (newWidth < MIN_WIDTH) newWidth = MIN_WIDTH;
+      if (newWidth > MAX_WIDTH) newWidth = MAX_WIDTH;
+      setRightWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  };
+
+  return (
+    <div className="main-page">
+      <div className="side left" style={{ width: leftWidth }}>
+        <div className="drag-handle" onMouseDown={startLeftDrag}></div>
+      </div>
+      <div className="content-area" />
+      <div className="side right" style={{ width: rightWidth }}>
+        <div className="drag-handle" onMouseDown={startRightDrag}></div>
+      </div>
+    </div>
+  );
+}

--- a/src/main-page.css
+++ b/src/main-page.css
@@ -1,0 +1,38 @@
+body {
+  margin: 0;
+  background-color: #F5F5F5;
+}
+
+.main-page {
+  display: flex;
+  height: 100vh;
+}
+
+.side {
+  background-color: #2C2C2C;
+  box-shadow: 0 0 0 1px #424242;
+  position: relative;
+  height: 100%;
+  min-width: 253px;
+  max-width: 523px;
+}
+
+.content-area {
+  flex: 1;
+}
+
+.drag-handle {
+  width: 5px;
+  cursor: ew-resize;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+}
+
+.left .drag-handle {
+  right: 0;
+}
+
+.right .drag-handle {
+  left: 0;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
+import MainPage from './MainPage.jsx';
 
-ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+ReactDOM.createRoot(document.getElementById('root')).render(<MainPage />);


### PR DESCRIPTION
## Summary
- set Electron window to 1600x900
- create `MainPage` with drag-resizable side columns
- add styles for new layout
- render `MainPage` as app entry

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68496c62456c832297dc0f4ac2f20c1d