### PR TITLE
Restore QuadrantMenu at bottom of MainPage

### DIFF
--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import './main-page.css';
+import QuadrantMenu from './QuadrantMenu.jsx';
 
 export default function MainPage() {
   const MIN_WIDTH = 253;
@@ -58,6 +59,9 @@ export default function MainPage() {
       <div className="content-area" />
       <div className="side right" style={{ width: rightWidth }}>
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
+      </div>
+      <div className="bottom-menu">
+        <QuadrantMenu />
       </div>
     </div>
   );

--- a/src/QuadrantMenu.jsx
+++ b/src/QuadrantMenu.jsx
@@ -27,7 +27,6 @@ export default function QuadrantMenu({ onSelect }) {
 }
 
 const StyledWrapper = styled.div`
-  height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/main-page.css
+++ b/src/main-page.css
@@ -6,6 +6,7 @@ body {
 .main-page {
   display: flex;
   height: 100vh;
+  position: relative;
 }
 
 .side {
@@ -35,4 +36,11 @@ body {
 
 .right .drag-handle {
   left: 0;
+}
+
+.bottom-menu {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
 }


### PR DESCRIPTION
## Summary
- import `QuadrantMenu` in `MainPage`
- show the menu at the bottom center of the main page
- adjust layout styles to allow absolute positioning
- remove full-screen height from `QuadrantMenu`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849947128ec8322a2d90656c32b09f5