### PR TITLE
Add Fullscreen Toggle

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -30,6 +30,7 @@ function createWindow() {
             if (mainWindow) mainWindow.webContents.send('go-home');
           },
         },
+        { role: 'togglefullscreen' },
         { role: 'quit' },
       ],
     },


### PR DESCRIPTION
## Summary
- restore electron's full screen feature by adding `togglefullscreen` role to menu

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849db1593008322a5bfafbebb05ac5a