### PR TITLE
Add power level display with star rating

### DIFF
--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -8,6 +8,9 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
   });
   const [editing, setEditing] = useState(null);
 
+  const total = stats.reduce((sum, val) => sum + Number(val), 0);
+  const starsUnlocked = Math.min(5, Math.floor(total / 100));
+
   useEffect(() => {
     localStorage.setItem('characterStats', JSON.stringify(stats));
   }, [stats]);
@@ -19,26 +22,45 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
   };
 
   return (
-    <div className="stats-quadrant">
-      {stats.map((stat, i) => (
-        <div
-          key={i}
-          className={`quadrant ${['top-left', 'top-right', 'bottom-left', 'bottom-right'][i]}`}
-          onClick={() => setEditing(i)}
-        >
-          {editing === i ? (
-            <input
-              type="number"
-              autoFocus
-              value={stat}
-              onChange={(e) => handleChange(i, parseInt(e.target.value, 10))}
-              onBlur={() => setEditing(null)}
-            />
-          ) : (
-            <span>{stat}</span>
-          )}
+    <>
+      <div className="stats-quadrant">
+        {stats.map((stat, i) => (
+          <div
+            key={i}
+            className={`quadrant ${['top-left', 'top-right', 'bottom-left', 'bottom-right'][i]}`}
+            onClick={() => setEditing(i)}
+          >
+            {editing === i ? (
+              <input
+                type="number"
+                autoFocus
+                value={stat}
+                onChange={(e) => handleChange(i, parseInt(e.target.value, 10))}
+                onBlur={() => setEditing(null)}
+              />
+            ) : (
+              <span>{stat}</span>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="total-display">
+        <div className="power-label">POWER LEVEL</div>
+        <div className="stars">
+          {[...Array(5)].map((_, idx) => (
+            <svg
+              key={idx}
+              viewBox="0 0 24 24"
+              width="40"
+              height="40"
+              style={{ opacity: idx < starsUnlocked ? 1 : 0.3 }}
+            >
+              <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" fill="#FFFFFF" stroke="#000000" strokeWidth="1" />
+            </svg>
+          ))}
         </div>
-      ))}
-    </div>
+        <div className="total-number">{total}</div>
+      </div>
+    </>
   );
 }

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -72,3 +72,27 @@
   bottom: 0;
   right: 0;
 }
+
+.total-display {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  text-align: center;
+}
+
+.power-label {
+  color: white;
+  font-size: 45px;
+  margin-bottom: 5px;
+}
+
+.stars {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 5px;
+}
+
+.total-number {
+  font-size: 150px;
+  color: #FCFCFC;
+}


### PR DESCRIPTION
## Summary
- compute total stats for character
- show power level in bottom-right with large font
- display a star rating that fills based on total points

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c07a710dc83229773d94b49e3c0cc