### PR TITLE
Add official Riot bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
+import TopBar from './TopBar.jsx';
 
 
 const tabs = [
@@ -14,7 +15,9 @@ export default function QuadrantPage({ initialTab }) {
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
 
   return (
-    <div className="app-container">
+    <>
+      <TopBar />
+      <div className="app-container">
       <aside className="sidebar">
         {tabs.map((tab) => (
           <div
@@ -30,7 +33,8 @@ export default function QuadrantPage({ initialTab }) {
       <div className="content">
         <h1>{activeTab}</h1>
         {activeTab === 'Character' && <StatsQuadrant />}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/TopBar.jsx
+++ b/src/TopBar.jsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+
+export default function TopBar() {
+  useEffect(() => {
+    const id = 'riotbar-script';
+    let script;
+
+    const enhanceMenu = () => {
+      const attempt = setInterval(() => {
+        // Locate the "Actualités" dropdown created by the Riot Bar script
+        const newsLink = Array.from(
+          document.querySelectorAll('#riotbar-header a')
+        ).find((a) => /Actualit\u00e9s/i.test(a.textContent));
+
+        const menu = newsLink?.closest('li')?.querySelector('ul');
+        if (!menu) {
+          return;
+        }
+
+        clearInterval(attempt);
+
+        // Remove the "Médias" item if present
+        for (const item of menu.querySelectorAll('li')) {
+          const a = item.querySelector('a');
+          if (a && /M\u00e9dias/i.test(a.textContent)) {
+            item.remove();
+          }
+        }
+
+        // Add "Mazed" pointing to the home page if it doesn't already exist
+        const exists = Array.from(menu.querySelectorAll('a')).some((a) =>
+          /mazed/i.test(a.textContent)
+        );
+        if (!exists) {
+          const sample = menu.querySelector('li');
+          if (sample) {
+            const newItem = sample.cloneNode(true);
+            const link = newItem.querySelector('a');
+            if (link) {
+              link.textContent = 'Mazed';
+              link.href = '/';
+            }
+            menu.appendChild(newItem);
+          }
+        }
+      }, 100);
+    };
+
+    if (!document.getElementById(id)) {
+      script = document.createElement('script');
+      script.id = id;
+      script.src =
+        'https://cdn.rgpub.io/public/live/riotbar/latest/lol.fr-fr.js';
+      script.crossOrigin = 'anonymous';
+      script.async = true;
+      script.addEventListener('load', enhanceMenu);
+      document.head.appendChild(script);
+    } else {
+      enhanceMenu();
+    }
+
+    return () => {
+      if (script) script.removeEventListener('load', enhanceMenu);
+    };
+  }, []);
+
+  return <div id="riotbar-header" />;
+}


### PR DESCRIPTION
## Summary
- load the production Riot Bar script so the UI matches League of Legends
- add script that removes the Media link and adds a Mazed item to the Actualités menu
- ensure the script loads asynchronously from the document head

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d9d5670fc832284a0118e7174e97f