### PR TITLE
Use local top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mazed App</title>
+    <link
+      rel="stylesheet"
+      href="https://lolstatic-a.akamaihd.net/webfonts/live/css/riot/fonts.css"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
+import TopBar from './TopBar.jsx';
 
 
 const tabs = [
@@ -14,7 +15,9 @@ export default function QuadrantPage({ initialTab }) {
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
 
   return (
-    <div className="app-container">
+    <>
+      <TopBar />
+      <div className="app-container">
       <aside className="sidebar">
         {tabs.map((tab) => (
           <div
@@ -30,7 +33,8 @@ export default function QuadrantPage({ initialTab }) {
       <div className="content">
         <h1>{activeTab}</h1>
         {activeTab === 'Character' && <StatsQuadrant />}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/TopBar.jsx
+++ b/src/TopBar.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import './topbar.css';
+
+export default function TopBar() {
+  return (
+    <header className="riot-local-bar">
+      <nav className="riot-nav">
+        <a
+          href="https://www.leagueoflegends.com/fr-fr/"
+          className="logo"
+        >
+          League of Legends
+        </a>
+        <ul className="menu">
+          <li className="menu-item dropdown">
+            <span>Actualités</span>
+            <ul className="dropdown-menu">
+              <li>
+                <a href="https://www.leagueoflegends.com/fr-fr/news/">Tout</a>
+              </li>
+              <li>
+                <a href="https://www.leagueoflegends.com/fr-fr/news/game-updates/">
+                  Mises à jour du jeu
+                </a>
+              </li>
+              <li>
+                <a href="https://www.leagueoflegends.com/fr-fr/news/patch-notes/">
+                  Notes de patch
+                </a>
+              </li>
+              <li>
+                <a href="https://www.leagueoflegends.com/fr-fr/news/esports/">E-sport</a>
+              </li>
+              <li>
+                <a href="/">Mazed</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/src/topbar.css
+++ b/src/topbar.css
@@ -1,0 +1,67 @@
+.riot-local-bar {
+  background-color: #111;
+  color: #fff;
+  font-family: 'Beaufort for LOL', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+.riot-nav {
+  display: flex;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+  height: 64px;
+}
+
+.riot-nav .logo {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+  margin-right: 40px;
+}
+
+.menu {
+  list-style: none;
+  display: flex;
+  margin: 0;
+  padding: 0;
+  gap: 20px;
+}
+
+.menu-item {
+  position: relative;
+}
+
+.menu-item span,
+.menu-item > a {
+  cursor: pointer;
+  color: #fff;
+  text-decoration: none;
+}
+
+.dropdown-menu {
+  display: none;
+  position: absolute;
+  left: 0;
+  top: 100%;
+  background-color: #111;
+  list-style: none;
+  margin: 0;
+  padding: 10px 0;
+  border: 1px solid #333;
+  min-width: 200px;
+  z-index: 1000;
+}
+
+.dropdown-menu li {
+  padding: 5px 20px;
+}
+
+.dropdown-menu li a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.menu-item:hover .dropdown-menu {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- drop remote Riot Bar script and build a local copy
- style new menu with Riot fonts and simple CSS
- keep the Actualités dropdown but remove "Média" and add "Mazed"

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d9d5670fc832284a0118e7174e97f