### PR TITLE
Add basic resource counter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
+import ResourceIndicator from './ResourceIndicator.jsx';
 
 
 const tabs = [
@@ -45,6 +46,7 @@ export default function QuadrantPage({ initialTab }) {
             </div>
           )
         )}
+        {activeTab === 'World' && <ResourceIndicator />}
       </div>
     </div>
   );

--- a/src/ResourceContext.jsx
+++ b/src/ResourceContext.jsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ResourceContext = createContext();
+
+export function ResourceProvider({ children }) {
+  const [resource, setResource] = useState(() => {
+    const stored = localStorage.getItem('worldResource');
+    return stored ? parseInt(stored, 10) : 0;
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setResource((r) => r + 1);
+    }, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('worldResource', resource);
+  }, [resource]);
+
+  const add = (amount) => setResource((r) => r + amount);
+  const spend = (amount) => setResource((r) => Math.max(0, r - amount));
+
+  return (
+    <ResourceContext.Provider value={{ resource, add, spend }}>
+      {children}
+    </ResourceContext.Provider>
+  );
+}
+
+export function useResource() {
+  return useContext(ResourceContext);
+}

--- a/src/ResourceIndicator.jsx
+++ b/src/ResourceIndicator.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useResource } from './ResourceContext.jsx';
+import './resource-indicator.css';
+
+export default function ResourceIndicator() {
+  const { resource } = useResource();
+
+  return (
+    <div className="resource-box">
+      <div className="resource-circle">{resource}</div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import PageRouter from './PageRouter.jsx';
+import { ResourceProvider } from './ResourceContext.jsx';
 
-ReactDOM.createRoot(document.getElementById('root')).render(<PageRouter />);
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <ResourceProvider>
+    <PageRouter />
+  </ResourceProvider>
+);

--- a/src/resource-indicator.css
+++ b/src/resource-indicator.css
@@ -1,0 +1,20 @@
+.resource-box {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.resource-circle {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: #333;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
## Summary
- set up `ResourceContext` and provider
- show `ResourceIndicator` on the World page
- wrap `PageRouter` with the provider
- add styles for the resource indicator

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685016a76ebc8322beec5cd6693e6822