### PR TITLE
Add basic resource tracker for world

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
+import World from './World.jsx';
 
 
 const tabs = [
@@ -44,6 +45,7 @@ export default function QuadrantPage({ initialTab }) {
             </div>
           )
         )}
+        {activeTab === 'World' && <World />}
       </div>
     </div>
   );

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -1,0 +1,26 @@
+import React, { useState, useEffect } from 'react';
+import './world.css';
+
+export default function World() {
+  const [resource, setResource] = useState(() => {
+    const stored = localStorage.getItem('resourceR');
+    return stored ? parseInt(stored, 10) : 0;
+  });
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setResource((prev) => prev + 1);
+    }, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('resourceR', resource);
+  }, [resource]);
+
+  return (
+    <div className="world-container">
+      <div className="resource-box">{resource} R</div>
+    </div>
+  );
+}

--- a/src/world.css
+++ b/src/world.css
@@ -1,0 +1,16 @@
+.world-container {
+  position: relative;
+  height: 100%;
+}
+
+.resource-box {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-size: 20px;
+  color: white;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
## Summary
- show World tab with resource counter
- implement `World` component that stores resource R in localStorage
- increment R every 10 seconds
- display counter in bottom-left with rounded rectangle style

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68501d1dc38483229fee875a52741f72