### PR TITLE
Add quest management

### DIFF
--- a/src/AcceptedQuestList.jsx
+++ b/src/AcceptedQuestList.jsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import './world.css';
+
+export default function AcceptedQuestList() {
+  const [quests, setQuests] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('quests');
+    setQuests(stored ? JSON.parse(stored) : []);
+    const handler = () => {
+      const updated = localStorage.getItem('quests');
+      setQuests(updated ? JSON.parse(updated) : []);
+    };
+    window.addEventListener('questsChange', handler);
+    return () => window.removeEventListener('questsChange', handler);
+  }, []);
+
+  const completeQuest = (id) => {
+    const all = quests.map((q) => {
+      if (q.id === id) {
+        const newResource = (parseInt(localStorage.getItem('resourceR') || '0', 10) + (q.resource || 0));
+        localStorage.setItem('resourceR', newResource);
+        window.dispatchEvent(new CustomEvent('resourceChange', { detail: { resource: newResource } }));
+        return { ...q, completed: true };
+      }
+      return q;
+    });
+    setQuests(all);
+    localStorage.setItem('quests', JSON.stringify(all));
+    window.dispatchEvent(new Event('questsChange'));
+  };
+
+  return (
+    <div>
+      <h4>Accepted Quest</h4>
+      <div className="quest-list">
+        {quests.filter((q) => q.accepted && !q.completed).map((q) => (
+          <div key={q.id} className="quest-banner">
+            <div className="quest-info">
+              <div className="quest-name">{q.name}</div>
+              <div className="quest-quadrant">{q.quadrant}</div>
+              {q.resource !== 0 && (
+                <div className="quest-resource">
+                  {q.resource > 0 ? '+' : ''}{q.resource} R
+                </div>
+              )}
+            </div>
+            <button className="accept-button" onClick={() => completeQuest(q.id)}>
+              Complete
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
 import World from './World.jsx';
+import AcceptedQuestList from './AcceptedQuestList.jsx';
 
 
 const tabs = [
@@ -36,14 +37,17 @@ export default function QuadrantPage({ initialTab }) {
         <h1>{activeTab}</h1>
         {activeTab === 'Character' && <StatsQuadrant />}
         {activeTab === 'Training' && (
-          showNofap ? (
-            <NofapCalendar onBack={() => setShowNofap(false)} />
-          ) : (
-            <div className="app-card" onClick={() => setShowNofap(true)}>
-              <div className="calendar-preview" />
-              <span>NoFap Calendar</span>
-            </div>
-          )
+          <>
+            {showNofap ? (
+              <NofapCalendar onBack={() => setShowNofap(false)} />
+            ) : (
+              <div className="app-card" onClick={() => setShowNofap(true)}>
+                <div className="calendar-preview" />
+                <span>NoFap Calendar</span>
+              </div>
+            )}
+            <AcceptedQuestList />
+          </>
         )}
         {activeTab === 'World' && <World />}
       </div>

--- a/src/QuestModal.jsx
+++ b/src/QuestModal.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import './note-modal.css';
+
+export default function QuestModal({ onAdd, onClose }) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [quadrant, setQuadrant] = useState('II');
+  const [resource, setResource] = useState(0);
+
+  const handlePublish = () => {
+    onAdd({
+      id: Date.now(),
+      name: name || 'Untitled',
+      description,
+      quadrant,
+      resource: parseInt(resource, 10) || 0,
+      accepted: false,
+      completed: false,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <input
+          className="note-title"
+          placeholder="Quest name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <select
+          className="note-tag"
+          value={quadrant}
+          onChange={(e) => setQuadrant(e.target.value)}
+        >
+          <option value="II">II</option>
+          <option value="IE">IE</option>
+          <option value="EI">EI</option>
+          <option value="EE">EE</option>
+        </select>
+        <input
+          className="note-title"
+          type="number"
+          placeholder="Resource (+/-)"
+          value={resource}
+          onChange={(e) => setResource(e.target.value)}
+        />
+        <div className="actions">
+          <button className="save-button" onClick={onClose}>Cancel</button>
+          <button className="save-button" onClick={handlePublish}>Publish Quest</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import QuestModal from './QuestModal.jsx';
 import './world.css';
 
 export default function World() {
@@ -6,6 +7,11 @@ export default function World() {
     const stored = localStorage.getItem('resourceR');
     return stored ? parseInt(stored, 10) : 0;
   });
+  const [quests, setQuests] = useState(() => {
+    const stored = localStorage.getItem('quests');
+    return stored ? JSON.parse(stored) : [];
+  });
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -15,11 +21,65 @@ export default function World() {
   }, []);
 
   useEffect(() => {
+    const handler = (e) => {
+      if (e.detail && typeof e.detail.resource === 'number') {
+        setResource(e.detail.resource);
+      }
+    };
+    window.addEventListener('resourceChange', handler);
+    return () => window.removeEventListener('resourceChange', handler);
+  }, []);
+
+  useEffect(() => {
     localStorage.setItem('resourceR', resource);
   }, [resource]);
 
+  useEffect(() => {
+    localStorage.setItem('quests', JSON.stringify(quests));
+    window.dispatchEvent(new Event('questsChange'));
+  }, [quests]);
+
+  const addQuest = (q) => {
+    setQuests([...quests, q]);
+  };
+
+  const acceptQuest = (id) => {
+    setQuests(
+      quests.map((q) => (q.id === id ? { ...q, accepted: true } : q))
+    );
+  };
+
   return (
     <div className="world-container">
+      <h3 className="quest-header">
+        Quest
+        <button className="add-quest" onClick={() => setShowModal(true)}>+
+        </button>
+      </h3>
+      <div className="quest-list">
+        {quests.filter((q) => !q.accepted && !q.completed).map((q) => (
+          <div key={q.id} className="quest-banner">
+            <div className="quest-info">
+              <div className="quest-name">{q.name}</div>
+              <div className="quest-quadrant">{q.quadrant}</div>
+              {q.resource !== 0 && (
+                <div className="quest-resource">
+                  {q.resource > 0 ? '+' : ''}{q.resource} R
+                </div>
+              )}
+            </div>
+            <button
+              className="accept-button"
+              onClick={() => acceptQuest(q.id)}
+            >
+              ✔
+            </button>
+          </div>
+        ))}
+      </div>
+      {showModal && (
+        <QuestModal onAdd={addQuest} onClose={() => setShowModal(false)} />
+      )}
       <div className="resource-box">{resource} R</div>
     </div>
   );

--- a/src/world.css
+++ b/src/world.css
@@ -14,3 +14,47 @@
   color: white;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
 }
+
+.quest-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 0;
+}
+
+.add-quest {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+.quest-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 60px;
+}
+
+.quest-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: white;
+}
+
+.accept-button {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- let the world tab create and store quests
- accept quests and show them in the training tab
- allow completing quests and adjust resources
- style quest widgets

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685023554520832298618422049e8049