### PR TITLE
Add supabase Auth component

### DIFF
--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { supabase } from './supabaseClient';
+import './auth.css';
 
 export default function Auth() {
   const [email, setEmail] = useState('');
@@ -27,25 +28,27 @@ export default function Auth() {
   };
 
   return (
-    <div style={{ padding: '1rem' }}>
-      <h2>Login or Register</h2>
-      <form onSubmit={handleSignIn} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-        <input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button type="submit">Sign In</button>
-        <button type="button" onClick={handleSignUp}>Sign Up</button>
-        {errorMsg && <div style={{ color: 'red' }}>{errorMsg}</div>}
-      </form>
+    <div className="auth-container">
+      <div className="auth-box">
+        <h2>Welcome</h2>
+        <form onSubmit={handleSignIn}>
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button type="submit" className="primary-btn">Sign In</button>
+          <button type="button" className="secondary-btn" onClick={handleSignUp}>Sign Up</button>
+          {errorMsg && <div className="auth-error">{errorMsg}</div>}
+        </form>
+      </div>
     </div>
   );
 }

--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { supabase } from './supabaseClient';
+
+export default function Auth() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  const handleSignUp = async (e) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signUp({ email, password });
+    if (error) {
+      setErrorMsg(error.message);
+    } else {
+      setErrorMsg(null);
+    }
+  };
+
+  const handleSignIn = async (e) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setErrorMsg(error.message);
+    } else {
+      setErrorMsg(null);
+    }
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Login or Register</h2>
+      <form onSubmit={handleSignIn} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Sign In</button>
+        <button type="button" onClick={handleSignUp}>Sign Up</button>
+        {errorMsg && <div style={{ color: 'red' }}>{errorMsg}</div>}
+      </form>
+    </div>
+  );
+}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -4,15 +4,39 @@ import IImain from './IImain.jsx';
 import IEmain from './IEmain.jsx';
 import EImain from './EImain.jsx';
 import EEmain from './EEmain.jsx';
+import Auth from './Auth.jsx';
+import { supabase } from './supabaseClient';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const { data } = await supabase.auth.getUser();
+      setUser(data.user);
+    };
+    fetchUser();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     if (window.electronAPI && window.electronAPI.onGoHome) {
       window.electronAPI.onGoHome(() => setPage('5th'));
     }
   }, []);
+
+  if (!user) {
+    return <Auth />;
+  }
 
   switch (page) {
     case 'II':

--- a/src/auth.css
+++ b/src/auth.css
@@ -1,0 +1,91 @@
+@font-face {
+  font-family: 'Exodus';
+  src: url('./assets/fonts/ExodusD-Regular.otf') format('opentype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+.auth-container {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image: url('./assets/backgrounds/Viego_0.jpg');
+  background-size: cover;
+  background-position: center;
+  font-family: 'Exodus', sans-serif;
+  color: white;
+}
+
+.auth-box {
+  background: rgba(0, 0, 0, 0.7);
+  padding: 40px;
+  width: 360px;
+  border-radius: 8px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.auth-box form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-box h2 {
+  margin: 0 0 20px;
+  font-size: 28px;
+}
+
+.auth-box input {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 15px;
+  border: none;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+.auth-box input::placeholder {
+  color: #ccc;
+}
+
+.auth-box button {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 10px;
+  border: none;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+  color: white;
+  transition: background 0.2s;
+}
+
+.primary-btn {
+  background: #0052a3;
+}
+
+.primary-btn:hover {
+  background: #0066cc;
+}
+
+.secondary-btn {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.secondary-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.auth-box button:hover {
+  /* overridden by individual classes */
+}
+
+.auth-error {
+  color: #ff8080;
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- add a simple `Auth` page for signup/signin with Supabase
- check auth state in `PageRouter` and render `<Auth />` when no user is logged in

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68505c305b708322bbf0d96a15e9a9a9