### PR TITLE
Add Supabase profiles and auth

### DIFF
--- a/sql/create_profiles.sql
+++ b/sql/create_profiles.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  stats jsonb NOT NULL DEFAULT '[5,5,5,5]',
+  resources integer NOT NULL DEFAULT 0,
+  streaks integer NOT NULL DEFAULT 0
+);

--- a/src/AcceptedQuestList.jsx
+++ b/src/AcceptedQuestList.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './world.css';
+import { supabase } from './supabaseClient.js';
 
 export default function AcceptedQuestList() {
   const [quests, setQuests] = useState([]);
@@ -15,19 +16,29 @@ export default function AcceptedQuestList() {
     return () => window.removeEventListener('questsChange', handler);
   }, []);
 
-  const completeQuest = (id) => {
-    const all = quests.map((q) => {
-      if (q.id === id) {
-        const newResource = (parseInt(localStorage.getItem('resourceR') || '0', 10) + (q.resource || 0));
-        localStorage.setItem('resourceR', newResource);
-        window.dispatchEvent(new CustomEvent('resourceChange', { detail: { resource: newResource } }));
-        return { ...q, completed: true };
-      }
-      return q;
-    });
+  const completeQuest = async (id) => {
+    const completed = quests.find((q) => q.id === id);
+    const all = quests.map((q) => (q.id === id ? { ...q, completed: true } : q));
     setQuests(all);
     localStorage.setItem('quests', JSON.stringify(all));
     window.dispatchEvent(new Event('questsChange'));
+
+    if (!completed) return;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      const { data } = await supabase
+        .from('profiles')
+        .select('resources')
+        .eq('id', user.id)
+        .single();
+      const current = (data && data.resources) || 0;
+      const newResource = current + (completed.resource || 0);
+      await supabase
+        .from('profiles')
+        .update({ resources: newResource })
+        .eq('id', user.id);
+      window.dispatchEvent(new CustomEvent('resourceChange', { detail: { resource: newResource } }));
+    }
   };
 
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { supabase } from './supabaseClient.js';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
@@ -29,8 +30,11 @@ export default function QuadrantPage({ initialTab }) {
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
-                <div className="home-button" onClick={() => window.location.reload()}>
+        <div className="home-button" onClick={() => window.location.reload()}>
           🏠
+        </div>
+        <div className="home-button" onClick={() => supabase.auth.signOut()}>
+          🚪
         </div>
       </aside>
       <div className="content">

--- a/src/AuthPage.jsx
+++ b/src/AuthPage.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { supabase } from './supabaseClient.js';
+
+export default function AuthPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [signUp, setSignUp] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    if (signUp) {
+      const { data, error } = await supabase.auth.signUp({ email, password });
+      if (error) {
+        setError(error.message);
+        return;
+      }
+      if (data.user) {
+        await supabase
+          .from('profiles')
+          .insert({ id: data.user.id });
+      }
+    } else {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) {
+        setError(error.message);
+        return;
+      }
+    }
+  };
+
+  return (
+    <div className="auth-container">
+      <h2>{signUp ? 'Sign Up' : 'Sign In'}</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <div className="error">{error}</div>}
+        <button type="submit">{signUp ? 'Sign Up' : 'Sign In'}</button>
+      </form>
+      <button onClick={() => setSignUp((s) => !s)}>
+        {signUp ? 'Have an account? Sign In' : 'Need an account? Sign Up'}
+      </button>
+    </div>
+  );
+}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -4,15 +4,30 @@ import IImain from './IImain.jsx';
 import IEmain from './IEmain.jsx';
 import EImain from './EImain.jsx';
 import EEmain from './EEmain.jsx';
+import AuthPage from './AuthPage.jsx';
+import { supabase } from './supabaseClient.js';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
+  const [session, setSession] = useState(null);
 
   useEffect(() => {
     if (window.electronAPI && window.electronAPI.onGoHome) {
       window.electronAPI.onGoHome(() => setPage('5th'));
     }
   }, []);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => setSession(session));
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, sess) => {
+      setSession(sess);
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+
+  if (!session) {
+    return <AuthPage />;
+  }
 
   switch (page) {
     case 'II':


### PR DESCRIPTION
## Summary
- create `profiles` table schema with stats, resources, streaks
- add authentication page that signs up/in and inserts profile rows
- gate main router on Supabase auth
- allow logout
- load/update stats and resources from Supabase
- persist quest resource rewards through Supabase

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685067c8d0088322b955fedd2f4e07e6