### PR TITLE
Integrate Supabase profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ The idea of mazed is to make a map, that people can use to find themselves, god,
    VITE_SUPABASE_ANON_KEY=your-anon-key
    ```
 
+3. Run the SQL in `profiles.sql` on your Supabase instance to create the
+   `profiles` table that stores user data.
+

--- a/profiles.sql
+++ b/profiles.sql
@@ -1,0 +1,6 @@
+create table if not exists profiles (
+  id uuid references auth.users(id) primary key,
+  resources int default 0,
+  streaks int default 0,
+  stats jsonb default '[5,5,5,5]'
+);

--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -9,12 +9,20 @@ export default function Auth() {
 
   const handleSignUp = async (e) => {
     e.preventDefault();
-    const { error } = await supabase.auth.signUp({ email, password });
+    const { data, error } = await supabase.auth.signUp({ email, password });
     if (error) {
       setErrorMsg(error.message);
-    } else {
-      setErrorMsg(null);
+      return;
     }
+    if (data?.user) {
+      await supabase.from('profiles').insert({
+        id: data.user.id,
+        resources: 0,
+        streaks: 0,
+        stats: [5, 5, 5, 5],
+      });
+    }
+    setErrorMsg(null);
   };
 
   const handleSignIn = async (e) => {


### PR DESCRIPTION
## Summary
- provide SQL to create a `profiles` table and mention it in the setup docs
- insert a `profiles` row when signing up
- load/update stats from Supabase in `StatsQuadrant`
- sync quest resources with Supabase in world components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685069c9bb9c8322b8347d5ab6ad07b0