### PR TITLE
Add Supabase tables and sync quests/nofap data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@ The idea of mazed is to make a map, that people can use to find themselves, god,
 4. Run the SQL in `supabase-tables.sql` to create the `quests` and `runs`
    tables used by the application.
 
+## Running the App
+
+For development with live reload:
+
+```bash
+npm run dev
+```
+
+To build for production and start Electron:
+
+```bash
+npm run build
+npm start
+```
+
+Make sure the `.env` file with your Supabase credentials exists before running either command.
+

--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ The idea of mazed is to make a map, that people can use to find themselves, god,
 
 3. Run the SQL in `profiles.sql` on your Supabase instance to create the
    `profiles` table that stores user data.
+4. Run the SQL in `supabase-tables.sql` to create the `quests` and `runs`
+   tables used by the application.
 

--- a/supabase-tables.sql
+++ b/supabase-tables.sql
@@ -1,0 +1,21 @@
+create extension if not exists pgcrypto;
+
+create table if not exists quests (
+  id bigint primary key,
+  user_id uuid references auth.users(id),
+  name text,
+  description text,
+  quadrant text,
+  resource int default 0,
+  accepted boolean default false,
+  completed boolean default false
+);
+
+create table if not exists runs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id),
+  start bigint,
+  end bigint,
+  relapsed boolean,
+  reason text
+);

--- a/supabase-tables.sql
+++ b/supabase-tables.sql
@@ -15,7 +15,7 @@ create table if not exists runs (
   id uuid primary key default gen_random_uuid(),
   user_id uuid references auth.users(id),
   start bigint,
-  end bigint,
+  "end" bigint,
   relapsed boolean,
   reason text
 );


### PR DESCRIPTION
## Summary
- add `supabase-tables.sql` defining `quests` and `runs`
- document running the SQL to create new tables
- sync quests with Supabase in `World` and `AcceptedQuestList`
- store nofap runs in Supabase with offline fallback

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685270b16f6083229d50cf6f01e29011