### PR TITLE
Add disconnect menu option

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -30,6 +30,12 @@ function createWindow() {
             if (mainWindow) mainWindow.webContents.send('go-home');
           },
         },
+        {
+          label: 'Disconnect',
+          click: () => {
+            if (mainWindow) mainWindow.webContents.send('disconnect');
+          },
+        },
         { role: 'quit' },
         { role: 'togglefullscreen' },
       ],

--- a/preload.js
+++ b/preload.js
@@ -2,4 +2,5 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   onGoHome: (callback) => ipcRenderer.on('go-home', callback),
+  onDisconnect: (callback) => ipcRenderer.on('disconnect', callback),
 });

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -32,6 +32,11 @@ export default function PageRouter() {
     if (window.electronAPI && window.electronAPI.onGoHome) {
       window.electronAPI.onGoHome(() => setPage('5th'));
     }
+    if (window.electronAPI && window.electronAPI.onDisconnect) {
+      window.electronAPI.onDisconnect(async () => {
+        await supabase.auth.signOut();
+      });
+    }
   }, []);
 
   if (!user) {


### PR DESCRIPTION
## Summary
- add `Disconnect` option to Electron app menu
- expose `onDisconnect` via `preload.js`
- handle `disconnect` event in `PageRouter.jsx`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68532cd7f73c8322817a4a01f97d86e0