### PR TITLE
Add Quest Journal tabs and resize star icons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
-import NofapCalendar from './NofapCalendar.jsx';
-import VersionRating from './VersionRating.jsx';
 import World from './World.jsx';
-import AcceptedQuestList from './AcceptedQuestList.jsx';
 import FriendsList from './FriendsList.jsx';
+import QuestJournal from './QuestJournal.jsx';
 
 
 const tabs = [
@@ -17,8 +15,6 @@ const tabs = [
 
 export default function QuadrantPage({ initialTab }) {
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
-  const [showNofap, setShowNofap] = useState(false);
-  const [showRatings, setShowRatings] = useState(false);
 
   return (
     <div className="app-container">
@@ -39,27 +35,7 @@ export default function QuadrantPage({ initialTab }) {
       <div className="content">
         <h1>{activeTab}</h1>
         {activeTab === 'Character' && <StatsQuadrant />}
-        {activeTab === 'Training' && (
-          <div className="training-layout">
-            <AcceptedQuestList />
-            {showNofap ? (
-              <NofapCalendar onBack={() => setShowNofap(false)} />
-            ) : showRatings ? (
-              <VersionRating onBack={() => setShowRatings(false)} />
-            ) : (
-              <div className="feature-cards">
-                <div className="app-card" onClick={() => setShowNofap(true)}>
-                  <div className="calendar-preview" />
-                  <span>NoFap Calendar</span>
-                </div>
-                <div className="app-card" onClick={() => setShowRatings(true)}>
-                  <div className="star-icon">⭐⭐⭐⭐⭐</div>
-                  <span>Version Ratings</span>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
+        {activeTab === 'Training' && <QuestJournal />}
         {activeTab === 'World' && <World />}
         {activeTab === 'Friends' && <FriendsList />}
       </div>

--- a/src/QuestJournal.jsx
+++ b/src/QuestJournal.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import AcceptedQuestList from './AcceptedQuestList.jsx';
+import NofapCalendar from './NofapCalendar.jsx';
+import VersionRating from './VersionRating.jsx';
+import './styles.css';
+
+export default function QuestJournal() {
+  const [active, setActive] = useState('quests');
+
+  return (
+    <div className="quest-journal">
+      <div className="journal-tabs">
+        <button
+          className={active === 'quests' ? 'active' : ''}
+          onClick={() => setActive('quests')}
+        >
+          Accepted Quests
+        </button>
+        <button
+          className={active === 'nofap' ? 'active' : ''}
+          onClick={() => setActive('nofap')}
+        >
+          NoFap Calendar
+        </button>
+        <button
+          className={active === 'ratings' ? 'active' : ''}
+          onClick={() => setActive('ratings')}
+        >
+          Version Ratings
+        </button>
+      </div>
+      <div className="journal-content">
+        {active === 'quests' && <AcceptedQuestList />}
+        {active === 'nofap' && (
+          <NofapCalendar onBack={() => setActive('quests')} />
+        )}
+        {active === 'ratings' && (
+          <VersionRating onBack={() => setActive('quests')} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -82,8 +82,8 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
             <svg
               key={idx}
               viewBox="0 0 24 24"
-              width="66"
-              height="66"
+              width="40"
+              height="40"
               style={{ opacity: idx < starsUnlocked ? 1 : 0.3 }}
             >
               <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" fill="#FFFFFF" stroke="#000000" strokeWidth="1" />

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -107,6 +107,7 @@ body.character-page {
 .stars {
   display: flex;
   justify-content: center;
+  align-items: center;
   margin-bottom: 5px;
   filter: drop-shadow(2px 2px 4px #000)
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,7 +116,32 @@ body {
 }
 
 .star-icon {
-  font-size: 2em;
+  font-size: 1.5em;
   display: flex;
   justify-content: center;
+  align-items: center;
+}
+
+.quest-journal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.journal-tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.journal-tabs button {
+  background: #333;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.journal-tabs button.active {
+  background: #555;
 }


### PR DESCRIPTION
## Summary
- refactor Training screen into a new QuestJournal component with tabs
- show Accepted quests, Nofap calendar and Version Ratings under those tabs
- shrink big star icons and keep them centered

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856c92fe8808322a9fb425c667abd39