### PR TITLE
Bring back feature cards with Quest Journal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
 import VersionRating from './VersionRating.jsx';
+import QuestJournal from './QuestJournal.jsx';
 import World from './World.jsx';
-import AcceptedQuestList from './AcceptedQuestList.jsx';
 import FriendsList from './FriendsList.jsx';
-
 
 const tabs = [
   { label: 'Training', icon: '🧠' },
@@ -17,8 +16,17 @@ const tabs = [
 
 export default function QuadrantPage({ initialTab }) {
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
+  const [showJournal, setShowJournal] = useState(false);
   const [showNofap, setShowNofap] = useState(false);
   const [showRatings, setShowRatings] = useState(false);
+
+  useEffect(() => {
+    if (activeTab !== 'Training') {
+      setShowJournal(false);
+      setShowNofap(false);
+      setShowRatings(false);
+    }
+  }, [activeTab]);
 
   return (
     <div className="app-container">
@@ -32,7 +40,7 @@ export default function QuadrantPage({ initialTab }) {
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
-                <div className="home-button" onClick={() => window.location.reload()}>
+        <div className="home-button" onClick={() => window.location.reload()}>
           🏠
         </div>
       </aside>
@@ -41,13 +49,18 @@ export default function QuadrantPage({ initialTab }) {
         {activeTab === 'Character' && <StatsQuadrant />}
         {activeTab === 'Training' && (
           <div className="training-layout">
-            <AcceptedQuestList />
-            {showNofap ? (
+            {showJournal ? (
+              <QuestJournal onBack={() => setShowJournal(false)} />
+            ) : showNofap ? (
               <NofapCalendar onBack={() => setShowNofap(false)} />
             ) : showRatings ? (
               <VersionRating onBack={() => setShowRatings(false)} />
             ) : (
               <div className="feature-cards">
+                <div className="app-card" onClick={() => setShowJournal(true)}>
+                  <div className="journal-icon">📓</div>
+                  <span>Quest Journal</span>
+                </div>
                 <div className="app-card" onClick={() => setShowNofap(true)}>
                   <div className="calendar-preview" />
                   <span>NoFap Calendar</span>

--- a/src/QuestJournal.jsx
+++ b/src/QuestJournal.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import AcceptedQuestList from './AcceptedQuestList.jsx';
+import NofapCalendar from './NofapCalendar.jsx';
+import VersionRating from './VersionRating.jsx';
+import './styles.css';
+
+export default function QuestJournal({ onBack }) {
+  const [active, setActive] = useState('quests');
+
+  return (
+    <div className="quest-journal">
+      {onBack && (
+        <button className="back-button" onClick={onBack}>
+          Back
+        </button>
+      )}
+      <div className="journal-tabs">
+        <button
+          className={active === 'quests' ? 'active' : ''}
+          onClick={() => setActive('quests')}
+        >
+          Accepted Quests
+        </button>
+        <button
+          className={active === 'nofap' ? 'active' : ''}
+          onClick={() => setActive('nofap')}
+        >
+          NoFap Calendar
+        </button>
+        <button
+          className={active === 'ratings' ? 'active' : ''}
+          onClick={() => setActive('ratings')}
+        >
+          Version Ratings
+        </button>
+      </div>
+      <div className="journal-content">
+        {active === 'quests' && <AcceptedQuestList />}
+        {active === 'nofap' && <NofapCalendar onBack={() => setActive('quests')} />}
+        {active === 'ratings' && <VersionRating onBack={() => setActive('quests')} />}
+      </div>
+    </div>
+  );
+}

--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -82,8 +82,8 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
             <svg
               key={idx}
               viewBox="0 0 24 24"
-              width="66"
-              height="66"
+              width="40"
+              height="40"
               style={{ opacity: idx < starsUnlocked ? 1 : 0.3 }}
             >
               <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" fill="#FFFFFF" stroke="#000000" strokeWidth="1" />

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -52,7 +52,7 @@ body.character-page {
   font-size: 3.2em;
   font-family:'ExodusD-Regular', sans-serif ;
   cursor: pointer;
-  text-shadow: 2px 2px 4px #000
+  text-shadow: 2px 2px 4px #000;
 }
 
 .quadrant input {
@@ -63,7 +63,7 @@ body.character-page {
   text-align: center;
   font-size: inherit;
   font-family: 'ExodusD-Regular', sans-serif;
-  text-shadow: 2px 2px 4px #000
+  text-shadow: 2px 2px 4px #000;
 }
 
 .quadrant input:focus {
@@ -101,12 +101,13 @@ body.character-page {
   color: white;
   font-size: 45px;
   margin-bottom: 5px;
-  text-shadow: 2px 2px 4x #000;
+  text-shadow: 2px 2px 4px #000;
 }
 
 .stars {
   display: flex;
   justify-content: center;
+  align-items: center;
   margin-bottom: 5px;
   filter: drop-shadow(2px 2px 4px #000)
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,7 +33,7 @@ body {
   border-radius: 10px;
   user-select: none;
   transition: background-color 0.2s;
-  box-shadow: 2px 2px 4px rgba(0, 0, 0.5);
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
 }
 
@@ -42,9 +42,8 @@ body {
 }
 
 .tab:hover {
-  background-color: #222;
-  color: #fff;
-  background-color: #e0e0e0
+  background-color: #e0e0e0;
+  color: #222;
 }
 
 .content {
@@ -116,7 +115,48 @@ body {
 }
 
 .star-icon {
+  font-size: 1.5em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.journal-icon {
   font-size: 2em;
   display: flex;
   justify-content: center;
+  align-items: center;
+}
+
+.back-button {
+  background: #333;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.quest-journal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.journal-tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.journal-tabs button {
+  background: #333;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.journal-tabs button.active {
+  background: #555;
 }


### PR DESCRIPTION
## Summary
- restore original feature card layout on the Training screen
- add new Quest Journal card that opens the tabbed quest interface
- keep star icons small and centered
- style journal icon and back button
- reset extra Training views when switching tabs
- fix style typos that broke some layout

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856c92fe8808322a9fb425c667abd39