### PR TITLE
Fix world and friends tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
 import VersionRating from './VersionRating.jsx';
 import QuestJournal from './QuestJournal.jsx';
+import World from './World.jsx';
+import FriendsList from './FriendsList.jsx';
 
 const tabs = [
   { label: 'Training', icon: '🧠' },


### PR DESCRIPTION
## Summary
- import missing World and FriendsList components

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68573325fb008322a4534be7a88e1852