### PR TITLE
Add friendships table and show user ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The idea of mazed is to make a map, that people can use to find themselves, god,
    `profiles` table that stores user data.
 4. Run the SQL in `supabase-tables.sql` to create the `quests` and `runs`
    tables used by the application.
+5. Run the SQL in `friendships.sql` to create the `friendships` table used for
+   managing friend requests.
 
 ## Running the App
 

--- a/friendships.sql
+++ b/friendships.sql
@@ -1,0 +1,6 @@
+create table if not exists friendships (
+  user_id uuid references auth.users(id),
+  friend_id uuid references auth.users(id),
+  status text check (status in ('pending','accepted')) default 'pending',
+  primary key (user_id, friend_id)
+);

--- a/src/FriendsList.jsx
+++ b/src/FriendsList.jsx
@@ -91,6 +91,11 @@ export default function FriendsList() {
           Send
         </button>
       </div>
+      {userId && (
+        <div style={{ marginTop: '4px', fontSize: '0.9em' }}>
+          Your ID: {userId}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `friendships.sql` with table definition
- show the current user's ID below the friend input field
- document running `friendships.sql` in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857ec8284508322a6f5055ee80114dc