### PR TITLE
Add profile button modal sans image

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import VersionRating from './VersionRating.jsx';
 import QuestJournal from './QuestJournal.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
+import ProfileModal from './ProfileModal.jsx';
 
 const tabs = [
   { label: 'Training', icon: '🧠' },
@@ -19,6 +20,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showJournal, setShowJournal] = useState(false);
   const [showNofap, setShowNofap] = useState(false);
   const [showRatings, setShowRatings] = useState(false);
+  const [showProfile, setShowProfile] = useState(false);
 
   return (
     <div className="app-container">
@@ -32,8 +34,13 @@ export default function QuadrantPage({ initialTab }) {
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
-        <div className="home-button" onClick={() => window.location.reload()}>
-          🏠
+        <div className="bottom-buttons">
+          <div className="profile-button" onClick={() => setShowProfile(true)}>
+            👤
+          </div>
+          <div className="home-button" onClick={() => window.location.reload()}>
+            🏠
+          </div>
         </div>
       </aside>
       <div className="content">
@@ -68,6 +75,7 @@ export default function QuadrantPage({ initialTab }) {
         {activeTab === 'World' && <World />}
         {activeTab === 'Friends' && <FriendsList />}
       </div>
+      {showProfile && <ProfileModal onClose={() => setShowProfile(false)} />}
     </div>
   );
 }

--- a/src/ProfileModal.jsx
+++ b/src/ProfileModal.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+import './profile-modal.css';
+import profileImg from './assets/profile.png';
+
+export default function ProfileModal({ onClose }) {
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        setEmail(user.email);
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('username')
+          .eq('id', user.id)
+          .single();
+        if (profile) {
+          setUsername(profile.username);
+        }
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <img className="profile-pic" src={profileImg} alt="Profile" />
+        {email && <div className="profile-name">{email}</div>}
+        {username && <div className="profile-username">@{username}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/profile-modal.css
+++ b/src/profile-modal.css
@@ -1,0 +1,19 @@
+.profile-pic {
+  width: 120px;
+  height: 120px;
+  border-radius: 60px;
+  object-fit: cover;
+  margin: 0 auto;
+}
+
+.profile-name {
+  font-size: 1.4em;
+  font-weight: bold;
+  text-align: center;
+}
+
+.profile-username {
+  font-size: 1em;
+  color: #555;
+  text-align: center;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,7 +60,8 @@ body {
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
 }
 
-.home-button {
+.home-button,
+.profile-button {
   width: 50px;
   height: 50px;
   background: white;
@@ -69,10 +70,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: auto;
   cursor: pointer;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+.bottom-buttons {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
 }
 
 .app-card {


### PR DESCRIPTION
## Summary
- introduce a new `ProfileModal` with placeholder profile picture import
- style the modal and sidebar profile button
- include profile button above the home button
- remove `src/assets/profile.png` so it can be added later

## Testing
- `npm install`
- `npm run build` *(fails: Could not resolve `./assets/profile.png`)*

------
https://chatgpt.com/codex/tasks/task_e_685803a4d1b88322868930220dad3449