### PR TITLE
Add profile avatar uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ npm start
 
 Make sure the `.env` file with your Supabase credentials exists before running either command.
 
+### Profile Pictures
+
+Create a public storage bucket named `avatars` in Supabase. The `profiles`
+table includes an `avatar_url` column where uploaded image paths are stored.
+When viewing your profile, click the picture to choose a new image. The file is
+uploaded to Supabase and immediately displayed in the modal.
+

--- a/profiles.sql
+++ b/profiles.sql
@@ -1,6 +1,7 @@
 create table if not exists profiles (
   id uuid references auth.users(id) primary key,
   username text unique not null,
+  avatar_url text,
   resources int default 0,
   streaks int default 0,
   stats jsonb default '[5,5,5,5]'

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import VersionRating from './VersionRating.jsx';
 import QuestJournal from './QuestJournal.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
+import ProfileModal from './ProfileModal.jsx';
 
 const tabs = [
   { label: 'Training', icon: '🧠' },
@@ -19,6 +20,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showJournal, setShowJournal] = useState(false);
   const [showNofap, setShowNofap] = useState(false);
   const [showRatings, setShowRatings] = useState(false);
+  const [showProfile, setShowProfile] = useState(false);
 
   return (
     <div className="app-container">
@@ -32,8 +34,13 @@ export default function QuadrantPage({ initialTab }) {
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
-        <div className="home-button" onClick={() => window.location.reload()}>
-          🏠
+        <div className="bottom-buttons">
+          <div className="profile-button" onClick={() => setShowProfile(true)}>
+            👤
+          </div>
+          <div className="home-button" onClick={() => window.location.reload()}>
+            🏠
+          </div>
         </div>
       </aside>
       <div className="content">
@@ -68,6 +75,7 @@ export default function QuadrantPage({ initialTab }) {
         {activeTab === 'World' && <World />}
         {activeTab === 'Friends' && <FriendsList />}
       </div>
+      {showProfile && <ProfileModal onClose={() => setShowProfile(false)} />}
     </div>
   );
 }

--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -19,6 +19,7 @@ export default function Auth() {
       await supabase.from('profiles').insert({
         id: data.user.id,
         username,
+        avatar_url: null,
         resources: 0,
         streaks: 0,
         stats: [5, 5, 5, 5],

--- a/src/AvatarUploadModal.jsx
+++ b/src/AvatarUploadModal.jsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { supabase } from './supabaseClient';
+import './note-modal.css';
+import './avatar-upload-modal.css';
+
+const BUCKET = 'avatars';
+
+export default function AvatarUploadModal({ onClose, onUploaded }) {
+  const inputRef = useRef(null);
+  const [recents, setRecents] = useState([]);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      const { data } = await supabase.storage
+        .from(BUCKET)
+        .list(`${user.id}`, { limit: 5, sortBy: { column: 'created_at', order: 'desc' } });
+      if (data) {
+        const mapped = data.map((item) => {
+          const path = `${user.id}/${item.name}`;
+          const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+          return { path, url: urlData.publicUrl };
+        });
+        setRecents(mapped);
+      }
+    };
+    load();
+  }, []);
+
+  const finish = async (path) => {
+    const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      await supabase.from('profiles').update({ avatar_url: path }).eq('id', user.id);
+      onUploaded(path, urlData.publicUrl);
+    }
+  };
+
+  const handleSelectRecent = async (path) => {
+    await finish(path);
+    onClose();
+  };
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) { setUploading(false); return; }
+    const filePath = `${user.id}/${Date.now()}-${file.name}`;
+    const { error } = await supabase.storage.from(BUCKET).upload(filePath, file, { upsert: true });
+    if (!error) {
+      await finish(filePath);
+      onClose();
+    }
+    setUploading(false);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal avatar-upload-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="avatar-drop-area" onClick={() => inputRef.current?.click()}>
+          {uploading ? 'Uploading...' : 'Click to upload image'}
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
+        {recents.length > 0 && <div className="avatar-recents-header">Avatar recents</div>}
+        <div className="recents-grid">
+          {recents.map((r) => (
+            <img
+              key={r.path}
+              className="recent-avatar"
+              src={r.url}
+              onClick={() => handleSelectRecent(r.path)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ProfileModal.jsx
+++ b/src/ProfileModal.jsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+import './note-modal.css';
+import './profile-modal.css';
+
+const placeholderImg =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAB4CAYAAABx6D+YAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAGcSURBVHja7NqxTtNAEMbx2xMsBYbiKOBSIviCSiVkZLFmyh0cYbiPvIzAm8gEmko0RsrGTvytOHnTi4/cRnMQfJ3NnMNjTTOnP1tjNzhklVsxZmS7+wJJr4WLvm1H7S6BT6X2nr1kudhfMDcbY3WhtnoVnoVYyu0Mbh3YqfTp5GrQbrXajAV9BpurFexfp4G+1iGP70D873wVfT9DflPVfRR0/xuv1F6lcdw5fX3VXkl4K16YU9OSXCHVsJT4Yoe6AGXdZEPqthlxq7YlbtJ9RHltcgv1QylV0MkdUMQ9txD43tZOtVN6OymwNdrGzWcbGdKd541H1yqf66iPYdR6ffBNdbSwWW/6IG2DZUY5pcVrjQ9E+bTGHRB1Rz77LQfr+fpDWajD6E7VmPxq2Jbq+Qq1H4xZc4qRp/GrmZ+bs6MKP2jul9jeqL/d/4FS1VnEae6ofum6vmwqsY1sp6kW5jWdUtp2I7q9tShwtfvnyO4F+E0qK/eJ2dNTD/96qRRhnPySnLdS2mPp9wkegdtqMOdsagH3a8Kv6SjEwDWNpUhyLg8a9YBdrq1Ipw1prcf9A6tcAayggVpNP46Yq7SVF+WMstaDDuVXqlViGWuANlD818r4rmU1MseilV2nNf4u1cMGkcIvY/XVRRYP4seU8eB4/ZsJJtjLTkRdg2hrG5NBrcL2q9t7frDb1Ab2KlZ6jrHctvM9S80uADwvvPA7zFk45lHAAAAAElFTkSuQmCC';
+
+const BUCKET = 'avatars';
+
+export default function ProfileModal({ onClose }) {
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [imgSrc, setImgSrc] = useState(placeholderImg);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        setEmail(user.email);
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('username')
+          .eq('id', user.id)
+          .single();
+        if (profile) {
+          setUsername(profile.username);
+        }
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    const fetchAvatar = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('avatar_url')
+        .eq('id', user.id)
+        .single();
+      if (profile?.avatar_url) {
+        const { data } = supabase.storage
+          .from(BUCKET)
+          .getPublicUrl(profile.avatar_url);
+        setImgSrc(data.publicUrl);
+      }
+    };
+    fetchAvatar();
+  }, []);
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setUploading(false);
+      return;
+    }
+    const filePath = `${user.id}/${Date.now()}-${file.name}`;
+    const { error } = await supabase.storage
+      .from(BUCKET)
+      .upload(filePath, file, { upsert: true });
+    if (!error) {
+      await supabase
+        .from('profiles')
+        .update({ avatar_url: filePath })
+        .eq('id', user.id);
+      const { data } = supabase.storage.from(BUCKET).getPublicUrl(filePath);
+      setImgSrc(data.publicUrl);
+    }
+    setUploading(false);
+  };
+
+  return (
+    <div className="modal-overlay profile-overlay" onClick={onClose}>
+      <div className="modal profile-modal" onClick={(e) => e.stopPropagation()}>
+        <label htmlFor="avatar-upload">
+          <img className="profile-pic" src={imgSrc} alt="Profile" />
+        </label>
+        <input
+          id="avatar-upload"
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          style={{ display: 'none' }}
+        />
+        {email && <div className="profile-name">{email}</div>}
+        {username && <div className="profile-username">@{username}</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/avatar-upload-modal.css
+++ b/src/avatar-upload-modal.css
@@ -1,0 +1,30 @@
+.avatar-upload-modal .avatar-drop-area {
+  width: 200px;
+  height: 200px;
+  border: 2px dashed #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin: 0 auto 10px;
+}
+
+.avatar-upload-modal .avatar-recents-header {
+  font-weight: bold;
+  margin-top: 10px;
+}
+
+.avatar-upload-modal .recents-grid {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.avatar-upload-modal .recent-avatar {
+  width: 60px;
+  height: 60px;
+  border-radius: 30px;
+  object-fit: cover;
+  cursor: pointer;
+}

--- a/src/profile-modal.css
+++ b/src/profile-modal.css
@@ -22,6 +22,53 @@
   background: transparent;
 }
 
+.avatar-container {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin: 0 auto;
+}
+
+.avatar-container:hover .avatar-edit {
+  opacity: 1;
+}
+
+.avatar-edit {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 60px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+  cursor: pointer;
+}
+
+.avatar-menu {
+  position: absolute;
+  left: 130px;
+  top: 10px;
+  background: #fff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  animation: profile-slide 0.2s ease-out;
+  white-space: nowrap;
+}
+
+.avatar-menu-item {
+  cursor: pointer;
+}
+.avatar-menu-item:hover {
+  text-decoration: underline;
+}
+
 .profile-modal {
   position: fixed;
   left: 80px;

--- a/src/profile-modal.css
+++ b/src/profile-modal.css
@@ -1,0 +1,43 @@
+.profile-pic {
+  width: 120px;
+  height: 120px;
+  border-radius: 60px;
+  object-fit: cover;
+  margin: 0 auto;
+}
+
+.profile-name {
+  font-size: 1.4em;
+  font-weight: bold;
+  text-align: center;
+}
+
+.profile-username {
+  font-size: 1em;
+  color: #555;
+  text-align: center;
+}
+
+.profile-overlay {
+  background: transparent;
+}
+
+.profile-modal {
+  position: fixed;
+  left: 80px;
+  bottom: 110px;
+  width: 250px;
+  transform-origin: bottom left;
+  animation: profile-slide 0.2s ease-out;
+}
+
+@keyframes profile-slide {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,7 +60,8 @@ body {
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
 }
 
-.home-button {
+.home-button,
+.profile-button {
   width: 50px;
   height: 50px;
   background: white;
@@ -69,10 +70,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: auto;
   cursor: pointer;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+.bottom-buttons {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
 }
 
 .app-card {


### PR DESCRIPTION
## Summary
- add `avatar_url` column to profiles table
- store null `avatar_url` on signup
- fetch and upload avatar images from a Supabase `avatars` bucket
- update README with instructions for profile pictures

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685803a4d1b88322868930220dad3449