### PR TITLE
Improve avatar modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,10 @@ npm start
 
 Make sure the `.env` file with your Supabase credentials exists before running either command.
 
+### Profile Pictures
+
+Create a public storage bucket named `avatars` in Supabase. The `profiles`
+table includes an `avatar_url` column where uploaded image paths are stored.
+When viewing your profile, click the picture to choose a new image. The file is
+uploaded to Supabase and immediately displayed in the modal.
+

--- a/profiles.sql
+++ b/profiles.sql
@@ -1,6 +1,7 @@
 create table if not exists profiles (
   id uuid references auth.users(id) primary key,
   username text unique not null,
+  avatar_url text,
   resources int default 0,
   streaks int default 0,
   stats jsonb default '[5,5,5,5]'

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import VersionRating from './VersionRating.jsx';
 import QuestJournal from './QuestJournal.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
+import ProfileModal from './ProfileModal.jsx';
 
 const tabs = [
   { label: 'Training', icon: '🧠' },
@@ -19,6 +20,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showJournal, setShowJournal] = useState(false);
   const [showNofap, setShowNofap] = useState(false);
   const [showRatings, setShowRatings] = useState(false);
+  const [showProfile, setShowProfile] = useState(false);
 
   return (
     <div className="app-container">
@@ -32,8 +34,13 @@ export default function QuadrantPage({ initialTab }) {
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
-        <div className="home-button" onClick={() => window.location.reload()}>
-          🏠
+        <div className="bottom-buttons">
+          <div className="profile-button" onClick={() => setShowProfile(true)}>
+            👤
+          </div>
+          <div className="home-button" onClick={() => window.location.reload()}>
+            🏠
+          </div>
         </div>
       </aside>
       <div className="content">
@@ -68,6 +75,7 @@ export default function QuadrantPage({ initialTab }) {
         {activeTab === 'World' && <World />}
         {activeTab === 'Friends' && <FriendsList />}
       </div>
+      {showProfile && <ProfileModal onClose={() => setShowProfile(false)} />}
     </div>
   );
 }

--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -19,6 +19,7 @@ export default function Auth() {
       await supabase.from('profiles').insert({
         id: data.user.id,
         username,
+        avatar_url: null,
         resources: 0,
         streaks: 0,
         stats: [5, 5, 5, 5],

--- a/src/AvatarUploadModal.jsx
+++ b/src/AvatarUploadModal.jsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { supabase } from './supabaseClient';
+import './note-modal.css';
+import './avatar-upload-modal.css';
+
+const BUCKET = 'avatars';
+
+export default function AvatarUploadModal({ onClose, onUploaded }) {
+  const inputRef = useRef(null);
+  const [recents, setRecents] = useState([]);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      const { data } = await supabase.storage
+        .from(BUCKET)
+        .list(`${user.id}`, { limit: 5, sortBy: { column: 'created_at', order: 'desc' } });
+      if (data) {
+        const mapped = data.map((item) => {
+          const path = `${user.id}/${item.name}`;
+          const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+          return { path, url: urlData.publicUrl };
+        });
+        setRecents(mapped);
+      }
+    };
+    load();
+  }, []);
+
+  const finish = async (path) => {
+    const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      await supabase.from('profiles').update({ avatar_url: path }).eq('id', user.id);
+      onUploaded(path, urlData.publicUrl);
+    }
+  };
+
+  const handleSelectRecent = async (path) => {
+    await finish(path);
+    onClose();
+  };
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) { setUploading(false); return; }
+    const filePath = `${user.id}/${Date.now()}-${file.name}`;
+    const { error } = await supabase.storage.from(BUCKET).upload(filePath, file, { upsert: true });
+    if (!error) {
+      await finish(filePath);
+      onClose();
+    }
+    setUploading(false);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal avatar-upload-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="avatar-drop-area" onClick={() => inputRef.current?.click()}>
+          {uploading ? 'Uploading...' : 'Click to upload image'}
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
+        {recents.length > 0 && <div className="avatar-recents-header">Avatar recents</div>}
+        <div className="recents-grid">
+          {recents.map((r) => (
+            <img
+              key={r.path}
+              className="recent-avatar"
+              src={r.url}
+              onClick={() => handleSelectRecent(r.path)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ProfileModal.jsx
+++ b/src/ProfileModal.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { supabase } from './supabaseClient';
+import AvatarUploadModal from './AvatarUploadModal.jsx';
+import './note-modal.css';
+import './profile-modal.css';
+
+const placeholderImg =
+  "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'120'%20height%3D'120'%3E%3Crect%20width%3D'120'%20height%3D'120'%20rx%3D'60'%20fill%3D'%23444'%2F%3E%3Ctext%20x%3D'60'%20y%3D'78'%20font-size%3D'60'%20text-anchor%3D'middle'%20fill%3D'%23aaa'%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E";
+
+const BUCKET = 'avatars';
+
+export default function ProfileModal({ onClose }) {
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [imgSrc, setImgSrc] = useState(placeholderImg);
+  const [showMenu, setShowMenu] = useState(false);
+  const [showUpload, setShowUpload] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        setEmail(user.email);
+        const { data: profile } = await supabase
+          .from('profiles')
+          .select('username')
+          .eq('id', user.id)
+          .single();
+        if (profile) {
+          setUsername(profile.username);
+        }
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    const fetchAvatar = async () => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('avatar_url')
+        .eq('id', user.id)
+        .single();
+      if (profile?.avatar_url) {
+        const { data } = supabase.storage
+          .from(BUCKET)
+          .getPublicUrl(profile.avatar_url);
+        setImgSrc(data.publicUrl);
+      }
+    };
+    fetchAvatar();
+  }, []);
+
+  const handleUploadComplete = (_, url) => {
+    setImgSrc(url);
+  };
+
+  return (
+    <div className="modal-overlay profile-overlay" onClick={onClose}>
+      <div className="modal profile-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="avatar-container">
+          <img className="profile-pic" src={imgSrc} alt="Profile" />
+          <div className="avatar-edit" onClick={() => setShowMenu(!showMenu)}>✏️</div>
+          {showMenu && (
+            <div className="avatar-menu">
+              <div
+                className="avatar-menu-item"
+                onClick={() => {
+                  setShowMenu(false);
+                  setShowUpload(true);
+                }}
+              >
+                Modify profile picture
+              </div>
+            </div>
+          )}
+        </div>
+        {email && <div className="profile-name">{email}</div>}
+        {username && <div className="profile-username">@{username}</div>}
+      </div>
+      {showUpload && (
+        <AvatarUploadModal
+          onClose={() => setShowUpload(false)}
+          onUploaded={handleUploadComplete}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/avatar-upload-modal.css
+++ b/src/avatar-upload-modal.css
@@ -1,0 +1,37 @@
+.avatar-upload-modal .avatar-drop-area {
+  width: 300px;
+  height: 300px;
+  border: 2px dashed #888;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin: 0 auto 15px;
+  font-size: 1.5em;
+}
+
+.avatar-upload-modal .avatar-recents-header {
+  font-weight: bold;
+  margin-top: 15px;
+  font-size: 1.2em;
+}
+
+.avatar-upload-modal .recents-grid {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.avatar-upload-modal .recent-avatar {
+  width: 90px;
+  height: 90px;
+  border-radius: 45px;
+  object-fit: cover;
+  cursor: pointer;
+}
+
+.avatar-upload-modal {
+  background: #1e1e1e;
+  color: #fff;
+}

--- a/src/profile-modal.css
+++ b/src/profile-modal.css
@@ -1,0 +1,94 @@
+.profile-pic {
+  width: 120px;
+  height: 120px;
+  border-radius: 60px;
+  object-fit: cover;
+  margin: 0 auto;
+}
+
+.profile-name {
+  font-size: 1.4em;
+  font-weight: bold;
+  text-align: center;
+}
+
+.profile-username {
+  font-size: 1em;
+  color: #ccc;
+  text-align: center;
+}
+
+.profile-overlay {
+  background: transparent;
+}
+
+.avatar-container {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin: 0 auto;
+}
+
+.avatar-container:hover .avatar-edit {
+  opacity: 1;
+}
+
+.avatar-edit {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 60px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+  cursor: pointer;
+}
+
+.avatar-menu {
+  position: absolute;
+  left: 130px;
+  top: 10px;
+  background: #333;
+  color: #fff;
+  padding: 9px 15px;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  animation: profile-slide 0.2s ease-out;
+  white-space: nowrap;
+  font-size: 1.5em;
+}
+
+.avatar-menu-item {
+  cursor: pointer;
+}
+.avatar-menu-item:hover {
+  text-decoration: underline;
+}
+
+.profile-modal {
+  position: fixed;
+  left: 80px;
+  bottom: 110px;
+  width: 250px;
+  transform-origin: bottom left;
+  animation: profile-slide 0.2s ease-out;
+  background: #1e1e1e;
+  color: #fff;
+}
+
+@keyframes profile-slide {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,7 +60,8 @@ body {
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
 }
 
-.home-button {
+.home-button,
+.profile-button {
   width: 50px;
   height: 50px;
   background: white;
@@ -69,10 +70,17 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: auto;
   cursor: pointer;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+.bottom-buttons {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
 }
 
 .app-card {


### PR DESCRIPTION
## Summary
- keep profile picture dropdown visible and darken profile styling
- add dark theme for avatar upload modal and enlarge controls
- use a simple grey question mark placeholder avatar

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685803a4d1b88322868930220dad3449