### PR TITLE
Fix avatar persistence and cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Make sure the `.env` file with your Supabase credentials exists before running e
 
 Create a public storage bucket named `avatars` in Supabase. The `profiles`
 table includes an `avatar_url` column where uploaded image paths are stored.
-When viewing your profile, click the picture to choose a new image. The file is
-uploaded to Supabase and immediately displayed in the modal.
+When viewing your profile, click the picture to choose a new image. The image
+can now be cropped before uploading and the final picture is persisted across
+sessions. After pulling new changes be sure to run `npm install` so the
+`react-easy-crop` dependency is available.
 
 
 Uploaded filenames are automatically sanitized to avoid characters that

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-easy-crop": "^5.0.1",
         "styled-components": "^6.1.18"
       },
       "devDependencies": {
@@ -2658,6 +2659,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -2810,6 +2817,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.4.2.tgz",
+      "integrity": "sha512-V+GQUTkNWD8gK0mbZQfwTvcDxyCB4GS0cM36is8dAcvnsHY7DMEDP2D5IqHju55TOiCHwElJPVOYDgiu8BEiHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-refresh": {
@@ -3160,7 +3181,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "styled-components": "^6.1.18",
+    "react-easy-crop": "^5.0.1",
     "@supabase/supabase-js": "^2"
   },
   "devDependencies": {

--- a/src/AvatarUploadModal.jsx
+++ b/src/AvatarUploadModal.jsx
@@ -1,15 +1,50 @@
 import React, { useEffect, useRef, useState } from 'react';
+import Cropper from 'react-easy-crop';
 import { supabase } from './supabaseClient';
 import './note-modal.css';
 import './avatar-upload-modal.css';
 
 const BUCKET = 'avatars';
 
+const createImage = (url) =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = url;
+  });
+
+async function getCroppedImg(imageSrc, crop) {
+  const img = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  canvas.width = crop.width;
+  canvas.height = crop.height;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(
+    img,
+    crop.x,
+    crop.y,
+    crop.width,
+    crop.height,
+    0,
+    0,
+    crop.width,
+    crop.height
+  );
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), 'image/jpeg');
+  });
+}
+
 export default function AvatarUploadModal({ onClose, onUploaded }) {
   const inputRef = useRef(null);
   const [recents, setRecents] = useState([]);
   const [uploading, setUploading] = useState(false);
   const [errorMsg, setErrorMsg] = useState(null);
+  const [imageSrc, setImageSrc] = useState(null);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedArea, setCroppedArea] = useState(null);
 
   useEffect(() => {
     const load = async () => {
@@ -39,7 +74,10 @@ export default function AvatarUploadModal({ onClose, onUploaded }) {
     if (user) {
       await supabase.from('profiles').update({ avatar_url: path }).eq('id', user.id);
       const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
-      onUploaded(path, url || urlData.publicUrl);
+      const finalUrl = url || urlData.publicUrl;
+      localStorage.setItem(`avatarPath_${user.id}`, path);
+      localStorage.setItem(`avatarUrl_${user.id}`, finalUrl);
+      onUploaded(path, finalUrl);
     }
   };
 
@@ -48,9 +86,20 @@ export default function AvatarUploadModal({ onClose, onUploaded }) {
     onClose();
   };
 
-  const handleFileChange = async (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  const handleCropComplete = (_, area) => {
+    setCroppedArea(area);
+  };
+
+  const handleCropCancel = () => {
+    URL.revokeObjectURL(imageSrc);
+    setImageSrc(null);
+    setCroppedArea(null);
+    setZoom(1);
+    setCrop({ x: 0, y: 0 });
+  };
+
+  const handleCropSave = async () => {
+    if (!imageSrc || !croppedArea) return;
     setUploading(true);
     const {
       data: { user },
@@ -59,58 +108,92 @@ export default function AvatarUploadModal({ onClose, onUploaded }) {
       setUploading(false);
       return;
     }
-    const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+    const safeName = 'avatar.jpg';
     const filePath = `${user.id}/${Date.now()}-${safeName}`;
+    const blob = await getCroppedImg(imageSrc, croppedArea);
     const { error } = await supabase.storage
       .from(BUCKET)
-      .upload(filePath, file, {
+      .upload(filePath, blob, {
         upsert: true,
         cacheControl: '3600',
-        contentType: file.type,
+        contentType: 'image/jpeg',
       });
     if (error) {
       console.error('Avatar upload failed', error);
-      if (error.message.includes('row-level security')) {
-        setErrorMsg(
-          'Upload failed due to bucket permissions. Check RLS policies.'
-        );
-      } else if (error.message.includes('Invalid key')) {
-        setErrorMsg('Filename contains invalid characters.');
-      } else {
-        setErrorMsg(error.message);
-      }
-    } else {
-      await finish(filePath);
-      onClose();
+      setErrorMsg(error.message);
+      setUploading(false);
+      return;
     }
+    await finish(filePath);
     setUploading(false);
+    handleCropCancel();
+    onClose();
+  };
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    setImageSrc(url);
+    inputRef.current.value = '';
   };
 
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal avatar-upload-modal" onClick={(e) => e.stopPropagation()}>
-      <div className="avatar-drop-area" onClick={() => inputRef.current?.click()}>
-        {uploading ? 'Uploading...' : 'Click to upload image'}
-      </div>
-      {errorMsg && <div className="upload-error">{errorMsg}</div>}
-      <input
-          ref={inputRef}
-          type="file"
-          accept="image/*"
-          style={{ display: 'none' }}
-          onChange={handleFileChange}
-        />
-        {recents.length > 0 && <div className="avatar-recents-header">Avatar recents</div>}
-        <div className="recents-grid">
-          {recents.map((r) => (
-            <img
-              key={r.path}
-              className="recent-avatar"
-              src={r.url}
-              onClick={() => handleSelectRecent(r.path)}
-            />
-          ))}
+      {imageSrc ? (
+        <div className="crop-wrapper">
+          <Cropper
+            image={imageSrc}
+            crop={crop}
+            zoom={zoom}
+            aspect={1}
+            cropShape="round"
+            showGrid={false}
+            onCropChange={setCrop}
+            onZoomChange={setZoom}
+            onCropComplete={handleCropComplete}
+          />
+          <input
+            className="zoom-slider"
+            type="range"
+            min="1"
+            max="3"
+            step="0.1"
+            value={zoom}
+            onChange={(e) => setZoom(Number(e.target.value))}
+          />
+          <div className="crop-actions">
+            <button onClick={handleCropCancel}>Cancel</button>
+            <button onClick={handleCropSave}>Save</button>
+          </div>
         </div>
+      ) : (
+        <>
+          <div className="avatar-drop-area" onClick={() => inputRef.current?.click()}>
+            {uploading ? 'Uploading...' : 'Click to upload image'}
+          </div>
+          {errorMsg && <div className="upload-error">{errorMsg}</div>}
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+          {recents.length > 0 && <div className="avatar-recents-header">Avatar recents</div>}
+          <div className="recents-grid">
+            {recents.map((r) => (
+              <img
+                key={r.path}
+                className="recent-avatar"
+                src={r.url}
+                onClick={() => handleSelectRecent(r.path)}
+              />
+            ))}
+          </div>
+        </>
+      )}
       </div>
     </div>
   );

--- a/src/ProfileModal.jsx
+++ b/src/ProfileModal.jsx
@@ -40,6 +40,12 @@ export default function ProfileModal({ onClose }) {
         data: { user },
       } = await supabase.auth.getUser();
       if (!user) return;
+
+      const stored = localStorage.getItem(`avatarUrl_${user.id}`);
+      if (stored) {
+        setImgSrc(stored);
+      }
+
       const { data: profile } = await supabase
         .from('profiles')
         .select('avatar_url')
@@ -52,12 +58,15 @@ export default function ProfileModal({ onClose }) {
         if (downloadData) {
           const url = URL.createObjectURL(downloadData);
           setImgSrc(url);
+          localStorage.setItem(`avatarUrl_${user.id}`, url);
         } else {
           const { data } = supabase.storage
             .from(BUCKET)
             .getPublicUrl(profile.avatar_url);
           setImgSrc(data.publicUrl);
+          localStorage.setItem(`avatarUrl_${user.id}`, data.publicUrl);
         }
+        localStorage.setItem(`avatarPath_${user.id}`, profile.avatar_url);
       }
     };
     fetchAvatar();

--- a/src/avatar-upload-modal.css
+++ b/src/avatar-upload-modal.css
@@ -42,3 +42,21 @@
   background: #1e1e1e;
   color: #fff;
 }
+
+.crop-wrapper {
+  position: relative;
+  width: 270px;
+  height: 270px;
+  margin: 0 auto 15px;
+}
+
+.crop-wrapper .zoom-slider {
+  width: 100%;
+  margin-top: 10px;
+}
+
+.crop-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- store avatar path & URL locally so profile image persists
- crop avatars with `react-easy-crop` before upload
- remember latest avatar on profile load
- include basic styles for cropping UI
- note the cropping dependency in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685870ff5f98832286810d75a0f303a8