### PR TITLE
Add username login support and profile prompt

### DIFF
--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -3,9 +3,11 @@ import { supabase } from './supabaseClient';
 import './auth.css';
 
 export default function Auth() {
+  const [mode, setMode] = useState('signin');
+  const [identifier, setIdentifier] = useState('');
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
   const [errorMsg, setErrorMsg] = useState(null);
 
   const handleSignUp = async (e) => {
@@ -26,11 +28,31 @@ export default function Auth() {
       });
     }
     setErrorMsg(null);
+    setMode('signin');
   };
 
   const handleSignIn = async (e) => {
     e.preventDefault();
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    let usedEmail = identifier;
+    let { error } = await supabase.auth.signInWithPassword({
+      email: usedEmail,
+      password,
+    });
+    if (error) {
+      // maybe identifier is a username
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('username, user:auth.users(email)')
+        .eq('username', identifier)
+        .single();
+      if (profile?.user?.email) {
+        usedEmail = profile.user.email;
+        ({ error } = await supabase.auth.signInWithPassword({
+          email: usedEmail,
+          password,
+        }));
+      }
+    }
     if (error) {
       setErrorMsg(error.message);
     } else {
@@ -42,29 +64,49 @@ export default function Auth() {
     <div className="auth-container">
       <div className="auth-box">
         <h2>Welcome</h2>
-        <form onSubmit={handleSignIn}>
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <input
-            type="text"
-            placeholder="Username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <button type="submit" className="primary-btn">Sign In</button>
-          <button type="button" className="secondary-btn" onClick={handleSignUp}>Sign Up</button>
-          {errorMsg && <div className="auth-error">{errorMsg}</div>}
-        </form>
+        {mode === 'signin' ? (
+          <form onSubmit={handleSignIn}>
+            <input
+              type="text"
+              placeholder="Username or Email"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <button type="submit" className="primary-btn">Sign In</button>
+            <button type="button" className="secondary-btn" onClick={() => setMode('signup')}>Sign Up</button>
+            {errorMsg && <div className="auth-error">{errorMsg}</div>}
+          </form>
+        ) : (
+          <form onSubmit={handleSignUp}>
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <input
+              type="text"
+              placeholder="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <button type="submit" className="primary-btn">Create Account</button>
+            <button type="button" className="secondary-btn" onClick={() => setMode('signin')}>Back to Sign In</button>
+            {errorMsg && <div className="auth-error">{errorMsg}</div>}
+          </form>
+        )}
       </div>
     </div>
   );

--- a/src/ProfileModal.jsx
+++ b/src/ProfileModal.jsx
@@ -15,6 +15,8 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
   const [imgSrc, setImgSrc] = useState(placeholderImg);
   const [showMenu, setShowMenu] = useState(false);
   const [showUpload, setShowUpload] = useState(false);
+  const [showUsernamePrompt, setShowUsernamePrompt] = useState(false);
+  const [newUsername, setNewUsername] = useState('');
 
   useEffect(() => {
     const load = async () => {
@@ -72,6 +74,19 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
     if (onAvatarUpdated) onAvatarUpdated(_, url);
   };
 
+  const handleUsernameSave = async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user || !newUsername) return;
+    const { error } = await supabase
+      .from('profiles')
+      .update({ username: newUsername })
+      .eq('id', user.id);
+    if (!error) {
+      setUsername(newUsername);
+      setShowUsernamePrompt(false);
+    }
+  };
+
   return (
     <div className="modal-overlay profile-overlay" onClick={onClose}>
       <div className="modal profile-modal" onClick={(e) => e.stopPropagation()}>
@@ -92,14 +107,39 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
             </div>
           )}
         </div>
-        {email && <div className="profile-name">{email}</div>}
-        {username && <div className="profile-username">@{username}</div>}
+        {username ? (
+          <div className="profile-name">@{username}</div>
+        ) : (
+          <>
+            {email && <div className="profile-name">{email}</div>}
+            <div className="get-username-line">
+              <button className="get-username-btn" onClick={() => setShowUsernamePrompt(true)}>
+                Get username
+              </button>
+            </div>
+          </>
+        )}
       </div>
       {showUpload && (
         <AvatarUploadModal
           onClose={() => setShowUpload(false)}
           onUploaded={handleUploadComplete}
         />
+      )}
+      {showUsernamePrompt && (
+        <div className="modal-overlay" onClick={() => setShowUsernamePrompt(false)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <input
+              className="note-title"
+              placeholder="Choose a username"
+              value={newUsername}
+              onChange={(e) => setNewUsername(e.target.value)}
+            />
+            <div className="actions">
+              <button className="save-button" onClick={handleUsernameSave}>Save</button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/profile-modal.css
+++ b/src/profile-modal.css
@@ -18,6 +18,23 @@
   text-align: center;
 }
 
+.get-username-line {
+  text-align: center;
+  margin-top: 10px;
+}
+
+.get-username-btn {
+  background: #5865f2;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+}
+.get-username-btn:hover {
+  background: #4752d3;
+}
+
 .profile-overlay {
   background: transparent;
 }


### PR DESCRIPTION
## Summary
- enable sign in with either username or email
- show username in profile and prompt for one if missing
- add styling for the username prompt

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685955f8f69c8322b5c1a25912199704