### PR TITLE
Fix persistent username login and add password toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # mazed
 
-
 The idea is to build the Mazed app for PC, it will be built in react electron, so it's useable through web, app. mobile, while being highly customizable and alive
 
 It will ressemble sopmething like discord or steam , but for the whole mazed project
@@ -10,10 +9,9 @@ There are 4 aspects that we need to hold
 Make that people can find, their character ( Find function meaning..
 Provide tools to elevate their character and themselves (God
 Make and HUD for the world, and make it alive, using imagination (POkemon go..
-And make it social so people can make friends (School 
+And make it social so people can make friends (School
 
-
-It will hold all the spiritual lore, 
+It will hold all the spiritual lore,
 The idea of mazed is to make a map, that people can use to find themselves, god, and there version of it
 
 ## Setup
@@ -23,18 +21,29 @@ The idea of mazed is to make a map, that people can use to find themselves, god,
    npm install
    ```
 2. Create a `.env` file in the project root with your Supabase credentials:
+
    ```
    VITE_SUPABASE_URL=your-supabase-url
    VITE_SUPABASE_ANON_KEY=your-anon-key
    ```
 
-3. Run the SQL in `profiles.sql` on your Supabase instance to create the
-   `profiles` table that stores user data. Each profile now includes a
-   unique `username` chosen during sign up.
+3. Run the SQL in `profiles.sql` on your Supabase instance. This file creates
+   or updates the `profiles` table so it contains an `email` column and a
+   unique `username` for each user. The script also backfills the column with
+   existing emails, so simply executing it keeps your database in sync with the
+   application.
+
 4. Run the SQL in `supabase-tables.sql` to create the `quests` and `runs`
    tables used by the application.
 5. Run the SQL in `friendships.sql` to create the `friendships` table used for
    managing friend requests.
+6. If row-level security is enabled on `profiles`, create a policy so the
+   app can look up an email address by username when signing in:
+
+   ```sql
+   create policy "Public read for login" on profiles
+     for select using (true);
+   ```
 
 ## Running the App
 
@@ -62,9 +71,13 @@ can now be cropped before uploading and the final picture is persisted across
 sessions. After pulling new changes be sure to run `npm install` so the
 `react-easy-crop` dependency is available.
 
-
 Uploaded filenames are automatically sanitized to avoid characters that
 Supabase storage rejects. If you see a "row-level security" error when uploading,
 check that your `avatars` bucket allows authenticated users to insert and select
 files.
 
+## Versioning
+
+The displayed version comes from `src/version.js`. After each update to the
+codebase, bump the patch number (the last digit) and commit the file so
+releases are easy to track.

--- a/profiles.sql
+++ b/profiles.sql
@@ -1,8 +1,22 @@
 create table if not exists profiles (
   id uuid references auth.users(id) primary key,
+  email text not null,
   username text unique not null,
   avatar_url text,
   resources int default 0,
   streaks int default 0,
   stats jsonb default '[5,5,5,5]'
 );
+
+-- Upgrade existing installations
+alter table profiles
+  add column if not exists email text;
+
+update profiles
+set email = auth.users.email
+from auth.users
+where profiles.email is null
+  and profiles.id = auth.users.id;
+
+alter table profiles
+  alter column email set not null;

--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -2,10 +2,60 @@ import React, { useState } from 'react';
 import { supabase } from './supabaseClient';
 import './auth.css';
 
+function EyeShow() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3.5868 13.7788C5.36623 15.5478 8.46953 17.9999 12.0002 17.9999C15.5308 17.9999 18.6335 15.5478 20.413 13.7788C20.8823 13.3123 21.1177 13.0782 21.2671 12.6201C21.3738 12.2933 21.3738 11.7067 21.2671 11.3799C21.1177 10.9218 20.8823 10.6877 20.413 10.2211C18.6335 8.45208 15.5308 6 12.0002 6C8.46953 6 5.36623 8.45208 3.5868 10.2211C3.11714 10.688 2.88229 10.9216 2.7328 11.3799C2.62618 11.7067 2.62618 12.2933 2.7328 12.6201C2.88229 13.0784 3.11714 13.3119 3.5868 13.7788Z"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10 12C10 13.1046 10.8954 14 12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12Z"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function EyeHide() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3.99989 4L19.9999 20M16.4999 16.7559C15.1473 17.4845 13.6185 17.9999 11.9999 17.9999C8.46924 17.9999 5.36624 15.5478 3.5868 13.7788C3.1171 13.3119 2.88229 13.0784 2.7328 12.6201C2.62619 12.2933 2.62616 11.7066 2.7328 11.3797C2.88233 10.9215 3.11763 10.6875 3.58827 10.2197C4.48515 9.32821 5.71801 8.26359 7.17219 7.42676M19.4999 14.6335C19.8329 14.3405 20.138 14.0523 20.4117 13.7803L20.4146 13.7772C20.8832 13.3114 21.1182 13.0779 21.2674 12.6206C21.374 12.2938 21.3738 11.7068 21.2672 11.38C21.1178 10.9219 20.8827 10.6877 20.4133 10.2211C18.6338 8.45208 15.5305 6 11.9999 6C11.6624 6 11.3288 6.02241 10.9999 6.06448M13.3228 13.5C12.9702 13.8112 12.5071 14 11.9999 14C10.8953 14 9.99989 13.1046 9.99989 12C9.99989 11.4605 10.2135 10.9711 10.5608 10.6113"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export default function Auth() {
+  const [mode, setMode] = useState('signin');
+  const [identifier, setIdentifier] = useState('');
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [errorMsg, setErrorMsg] = useState(null);
 
   const handleSignUp = async (e) => {
@@ -16,25 +66,68 @@ export default function Auth() {
       return;
     }
     if (data?.user) {
-      await supabase.from('profiles').insert({
-        id: data.user.id,
-        username,
-        avatar_url: null,
-        resources: 0,
-        streaks: 0,
-        stats: [5, 5, 5, 5],
-      });
+      const cleanName = username.trim().toLowerCase();
+      await supabase
+        .from('profiles')
+        .upsert({
+          id: data.user.id,
+          email,
+          username: cleanName,
+          avatar_url: null,
+          resources: 0,
+          streaks: 0,
+          stats: [5, 5, 5, 5],
+        });
+      localStorage.setItem(`username_${data.user.id}`, cleanName);
     }
     setErrorMsg(null);
+    setMode('signin');
   };
 
   const handleSignIn = async (e) => {
     e.preventDefault();
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setErrorMsg(null);
+    let usedEmail = identifier.trim();
+
+    if (!usedEmail.includes('@')) {
+      // identifier is likely a username, resolve it to an email first
+      const lookup = usedEmail.toLowerCase();
+      const { data: profile, error } = await supabase
+        .from('profiles')
+        .select('email')
+        .eq('username', lookup)
+        .single();
+      if (error || !profile) {
+        setErrorMsg('Invalid login credentials');
+        return;
+      }
+      usedEmail = profile.email;
+    }
+
+    const { error } = await supabase.auth.signInWithPassword({
+      email: usedEmail,
+      password,
+    });
     if (error) {
       setErrorMsg(error.message);
-    } else {
-      setErrorMsg(null);
+      return;
+    }
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user) {
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('username')
+        .eq('id', user.id)
+        .single();
+      if (profile?.username) {
+        localStorage.setItem(
+          `username_${user.id}`,
+          profile.username.toLowerCase()
+        );
+      }
     }
   };
 
@@ -42,29 +135,67 @@ export default function Auth() {
     <div className="auth-container">
       <div className="auth-box">
         <h2>Welcome</h2>
-        <form onSubmit={handleSignIn}>
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <input
-            type="text"
-            placeholder="Username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-          />
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <button type="submit" className="primary-btn">Sign In</button>
-          <button type="button" className="secondary-btn" onClick={handleSignUp}>Sign Up</button>
-          {errorMsg && <div className="auth-error">{errorMsg}</div>}
-        </form>
+        {mode === 'signin' ? (
+          <form onSubmit={handleSignIn}>
+            <input
+              type="text"
+              placeholder="Username or Email"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+            />
+            <div className="password-wrapper">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <button
+                type="button"
+                className="toggle-password"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? <EyeHide /> : <EyeShow />}
+              </button>
+            </div>
+            <button type="submit" className="primary-btn">Sign In</button>
+            <button type="button" className="secondary-btn" onClick={() => setMode('signup')}>Sign Up</button>
+            {errorMsg && <div className="auth-error">{errorMsg}</div>}
+          </form>
+        ) : (
+          <form onSubmit={handleSignUp}>
+            <input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <input
+              type="text"
+              placeholder="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+            <div className="password-wrapper">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <button
+                type="button"
+                className="toggle-password"
+                onClick={() => setShowPassword(!showPassword)}
+              >
+                {showPassword ? <EyeHide /> : <EyeShow />}
+              </button>
+            </div>
+            <button type="submit" className="primary-btn">Create Account</button>
+            <button type="button" className="secondary-btn" onClick={() => setMode('signin')}>Back to Sign In</button>
+            {errorMsg && <div className="auth-error">{errorMsg}</div>}
+          </form>
+        )}
       </div>
     </div>
   );

--- a/src/auth.css
+++ b/src/auth.css
@@ -97,3 +97,25 @@
   color: #ff8080;
   margin-top: 10px;
 }
+
+.password-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.password-wrapper input {
+  width: 100%;
+  padding-right: 40px;
+}
+
+.toggle-password {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #ccc;
+  cursor: pointer;
+  padding: 0;
+}

--- a/src/profile-modal.css
+++ b/src/profile-modal.css
@@ -18,6 +18,23 @@
   text-align: center;
 }
 
+.get-username-line {
+  text-align: center;
+  margin-top: 10px;
+}
+
+.get-username-btn {
+  background: #5865f2;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+}
+.get-username-btn:hover {
+  background: #4752d3;
+}
+
 .profile-overlay {
   background: transparent;
 }

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.3.4';
+export const APP_VERSION = '0.3.10';


### PR DESCRIPTION
## Summary
- allow sign in using a username (case-insensitive lookup)
- save usernames in lowercase for consistency
- add password visibility toggle with eye button
- document optional profile read policy
- bump version to 0.3.9

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685955f8f69c8322b5c1a25912199704