### PR TITLE
Fix username sign-in and password input width

### DIFF
--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -96,8 +96,8 @@ export default function Auth() {
         .from('profiles')
         .select('email')
         .eq('username', lookup)
-        .single();
-      if (error || !profile) {
+        .maybeSingle();
+      if (error || !profile?.email) {
         setErrorMsg('Invalid login credentials');
         return;
       }

--- a/src/auth.css
+++ b/src/auth.css
@@ -101,6 +101,8 @@
 .password-wrapper {
   display: flex;
   align-items: center;
+  width: 100%;
+  margin-bottom: 15px;
 }
 
 .password-wrapper input {

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.3.12';
+export const APP_VERSION = '0.3.13';


### PR DESCRIPTION
## Summary
- adjust Supabase lookup to ignore missing usernames
- expand password input wrapper to match other fields
- bump app version to 0.3.13

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68598db339d08322bcf3ca4ee4f4763c