### PR TITLE
Introduce QuestContext

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
 import { supabase } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
+import { QuestProvider } from './QuestContext.jsx';
 
 const placeholderImg =
   "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'50'%20height%3D'50'%3E%3Crect%20width%3D'50'%20height%3D'50'%20rx%3D'25'%20fill%3D'%23444'%2F%3E%3Ctext%20x%3D'25'%20y%3D'33'%20font-size%3D'26'%20text-anchor%3D'middle'%20fill%3D'%23aaa'%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E";
@@ -65,7 +66,8 @@ export default function QuadrantPage({ initialTab }) {
   };
 
   return (
-    <div className="app-container">
+    <QuestProvider>
+      <div className="app-container">
       <aside className="sidebar">
         {tabs.map((tab) => (
           <div
@@ -129,7 +131,8 @@ export default function QuadrantPage({ initialTab }) {
           onAvatarUpdated={handleAvatarUpdated}
         />
       )}
-      <VersionLabel />
-    </div>
+        <VersionLabel />
+      </div>
+    </QuestProvider>
   );
 }

--- a/src/CompletedQuestList.jsx
+++ b/src/CompletedQuestList.jsx
@@ -1,40 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { supabase } from './supabaseClient';
+import React from 'react';
+import { useQuests } from './QuestContext.jsx';
 import './world.css';
 
 export default function CompletedQuestList() {
-  const [quests, setQuests] = useState([]);
-  // load quests from local storage and keep in sync
-  useEffect(() => {
-    const stored = localStorage.getItem('quests');
-    setQuests(stored ? JSON.parse(stored) : []);
-    const handler = () => {
-      const updated = localStorage.getItem('quests');
-      setQuests(updated ? JSON.parse(updated) : []);
-    };
-    window.addEventListener('questsChange', handler);
-    return () => window.removeEventListener('questsChange', handler);
-  }, []);
-
-  // fetch quests from supabase on mount
-  useEffect(() => {
-    const loadQuests = async () => {
-      if (!navigator.onLine) return;
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) return;
-      const { data } = await supabase
-        .from('quests')
-        .select('*')
-        .eq('user_id', user.id);
-      if (data) {
-        setQuests(data);
-        localStorage.setItem('quests', JSON.stringify(data));
-      }
-    };
-    loadQuests();
-  }, []);
+  const { quests } = useQuests();
 
   const completed = quests.filter((q) => q.completed);
 

--- a/src/QuestContext.jsx
+++ b/src/QuestContext.jsx
@@ -1,0 +1,97 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { supabase } from './supabaseClient';
+
+export const QuestContext = createContext();
+
+export function QuestProvider({ children }) {
+  const [quests, setQuests] = useState(() => {
+    const stored = localStorage.getItem('quests');
+    return stored ? JSON.parse(stored) : [];
+  });
+  const [userId, setUserId] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!navigator.onLine) return;
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      setUserId(user.id);
+      const { data } = await supabase
+        .from('quests')
+        .select('*')
+        .eq('user_id', user.id);
+      if (data) {
+        setQuests(data);
+        localStorage.setItem('quests', JSON.stringify(data));
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('quests', JSON.stringify(quests));
+    window.dispatchEvent(new Event('questsChange'));
+    if (userId && navigator.onLine) {
+      quests.forEach((q) =>
+        supabase.from('quests').upsert({ ...q, user_id: userId })
+      );
+    }
+  }, [quests, userId]);
+
+  const addQuest = (q) => {
+    setQuests([...quests, q]);
+    if (userId && navigator.onLine) {
+      supabase.from('quests').insert({ ...q, user_id: userId });
+    }
+  };
+
+  const acceptQuest = (id) => {
+    setQuests(quests.map((q) => (q.id === id ? { ...q, accepted: true } : q)));
+    if (userId && navigator.onLine) {
+      supabase
+        .from('quests')
+        .update({ accepted: true })
+        .eq('user_id', userId)
+        .eq('id', id);
+    }
+  };
+
+  const completeQuest = (id) => {
+    const updated = quests.map((q) => {
+      if (q.id === id) {
+        const newResource =
+          parseInt(localStorage.getItem('resourceR') || '0', 10) +
+          (q.resource || 0);
+        localStorage.setItem('resourceR', newResource);
+        if (userId && navigator.onLine) {
+          supabase.from('profiles').update({ resources: newResource }).eq('id', userId);
+        }
+        window.dispatchEvent(
+          new CustomEvent('resourceChange', { detail: { resource: newResource } })
+        );
+        return { ...q, completed: true };
+      }
+      return q;
+    });
+    setQuests(updated);
+    if (userId && navigator.onLine) {
+      supabase
+        .from('quests')
+        .update({ completed: true })
+        .eq('user_id', userId)
+        .eq('id', id);
+    }
+  };
+
+  return (
+    <QuestContext.Provider value={{ quests, addQuest, acceptQuest, completeQuest }}>
+      {children}
+    </QuestContext.Provider>
+  );
+}
+
+export function useQuests() {
+  return useContext(QuestContext);
+}


### PR DESCRIPTION
## Summary
- add new `QuestContext` to hold and sync quests
- wrap UI in `QuestProvider`
- use context in `World`, `AcceptedQuestList`, and `CompletedQuestList`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c17cd283c8322ac0b67b13a7206f9