### PR TITLE
Add quest types

### DIFF
--- a/src/AcceptedQuestList.jsx
+++ b/src/AcceptedQuestList.jsx
@@ -5,27 +5,44 @@ import './world.css';
 export default function AcceptedQuestList() {
   const { quests, completeQuest } = useQuests();
 
+  const accepted = quests.filter((q) => q.accepted && !q.completed);
+  const groups = accepted.reduce((acc, q) => {
+    const t = q.type || 'user';
+    if (!acc[t]) acc[t] = [];
+    acc[t].push(q);
+    return acc;
+  }, {});
+
   return (
     <div>
       <h4>Accepted Quest</h4>
-      <div className="quest-list">
-        {quests.filter((q) => q.accepted && !q.completed).map((q) => (
-          <div key={q.id} className="quest-banner">
-            <div className="quest-info">
-              <div className="quest-name">{q.name}</div>
-              <div className="quest-quadrant">{q.quadrant}</div>
-              {q.resource !== 0 && (
-                <div className="quest-resource">
-                  {q.resource > 0 ? '+' : ''}{q.resource} R
+      {Object.entries(groups).map(([type, list]) => (
+        <div key={type}>
+          <h5>{type.charAt(0).toUpperCase() + type.slice(1)} Quests</h5>
+          <div className="quest-list">
+            {list.map((q) => (
+              <div key={q.id} className="quest-banner">
+                <div className="quest-info">
+                  <div className="quest-name">{q.name}</div>
+                  <div className="quest-quadrant">{q.quadrant}</div>
+                  {q.resource !== 0 && (
+                    <div className="quest-resource">
+                      {q.resource > 0 ? '+' : ''}
+                      {q.resource} R
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-            <button className="accept-button" onClick={() => completeQuest(q.id)}>
-              Complete
-            </button>
+                <button
+                  className="accept-button"
+                  onClick={() => completeQuest(q.id)}
+                >
+                  Complete
+                </button>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/CompletedQuestList.jsx
+++ b/src/CompletedQuestList.jsx
@@ -6,23 +6,36 @@ export default function CompletedQuestList() {
   const { quests } = useQuests();
 
   const completed = quests.filter((q) => q.completed);
+  const groups = completed.reduce((acc, q) => {
+    const t = q.type || 'user';
+    if (!acc[t]) acc[t] = [];
+    acc[t].push(q);
+    return acc;
+  }, {});
 
   return (
     <details className="completed-section">
       <summary className="completed-summary">Completed Quests</summary>
-      <div className="quest-list">
-        {completed.map((q) => (
-          <details key={q.id} className="quest-banner quest-details">
-            <summary>
-              <div className="quest-info">
-                <div className="quest-name">{q.name}</div>
-                <div className="quest-quadrant">{q.quadrant}</div>
-              </div>
-            </summary>
-            {q.description && <div className="quest-log">{q.description}</div>}
-          </details>
-        ))}
-      </div>
+      {Object.entries(groups).map(([type, list]) => (
+        <div key={type}>
+          <h5>{type.charAt(0).toUpperCase() + type.slice(1)} Quests</h5>
+          <div className="quest-list">
+            {list.map((q) => (
+              <details key={q.id} className="quest-banner quest-details">
+                <summary>
+                  <div className="quest-info">
+                    <div className="quest-name">{q.name}</div>
+                    <div className="quest-quadrant">{q.quadrant}</div>
+                  </div>
+                </summary>
+                {q.description && (
+                  <div className="quest-log">{q.description}</div>
+                )}
+              </details>
+            ))}
+          </div>
+        </div>
+      ))}
     </details>
   );
 }

--- a/src/QuestContext.jsx
+++ b/src/QuestContext.jsx
@@ -41,9 +41,10 @@ export function QuestProvider({ children }) {
   }, [quests, userId]);
 
   const addQuest = (q) => {
-    setQuests([...quests, q]);
+    const quest = { type: 'user', ...q };
+    setQuests([...quests, quest]);
     if (userId && navigator.onLine) {
-      supabase.from('quests').insert({ ...q, user_id: userId });
+      supabase.from('quests').insert({ ...quest, user_id: userId });
     }
   };
 

--- a/src/QuestModal.jsx
+++ b/src/QuestModal.jsx
@@ -16,6 +16,7 @@ export default function QuestModal({ onAdd, onClose }) {
       resource: parseInt(resource, 10) || 0,
       accepted: true,
       completed: false,
+      type: 'user',
     });
     onClose();
   };

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -123,6 +123,7 @@ export default function World() {
               resource: 0,
               accepted: true,
               completed: true,
+              type: 'main',
             });
           }}
           initialMbti={profile.mbti || ''}

--- a/supabase-tables.sql
+++ b/supabase-tables.sql
@@ -3,6 +3,7 @@ create extension if not exists pgcrypto;
 create table if not exists quests (
   id bigint primary key,
   user_id uuid references auth.users(id),
+  type text default 'user',
   name text,
   description text,
   quadrant text,


### PR DESCRIPTION
## Summary
- record quest type in the database
- default quest type in context
- mark quests from modal as `user`
- mark main quest as `main`
- group accepted and completed quests by quest type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c199ad27c8322ae18b3ec67293fb6