### PR TITLE
Add Identity Card to Character page

### DIFF
--- a/src/IdentityCard.jsx
+++ b/src/IdentityCard.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import './identity-card.css';
+
+export default function IdentityCard() {
+  const [flipped, setFlipped] = useState(false);
+  const [moon, setMoon] = useState({ mbti: '', enneagram: '', quadrants: '', photo: null });
+  const [sun, setSun] = useState({ name: '', age: '', place: '', photo: null });
+
+  useEffect(() => {
+    const stored = localStorage.getItem('identityCard');
+    if (stored) {
+      const { moon: m, sun: s } = JSON.parse(stored);
+      if (m) setMoon(m);
+      if (s) setSun(s);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('identityCard', JSON.stringify({ moon, sun }));
+  }, [moon, sun]);
+
+  const handleImage = (side, e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (side === 'moon') setMoon({ ...moon, photo: reader.result });
+      else setSun({ ...sun, photo: reader.result });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="identity-card-wrapper" onClick={() => setFlipped(!flipped)}>
+      <div className={`identity-card ${flipped ? 'flipped' : ''}`}>
+        <div className="identity-face moon-face">
+          <div className="face-label">Moon</div>
+          {moon.photo && <img className="id-photo" src={moon.photo} alt="moon" />}
+          <input
+            type="text"
+            placeholder="MBTI"
+            value={moon.mbti}
+            onChange={(e) => setMoon({ ...moon, mbti: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="Enneagram"
+            value={moon.enneagram}
+            onChange={(e) => setMoon({ ...moon, enneagram: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="Quadrants frequencies"
+            value={moon.quadrants}
+            onChange={(e) => setMoon({ ...moon, quadrants: e.target.value })}
+          />
+          <input type="file" accept="image/*" onChange={(e) => handleImage('moon', e)} />
+        </div>
+        <div className="identity-face sun-face">
+          <div className="face-label">Sun</div>
+          {sun.photo && <img className="id-photo" src={sun.photo} alt="sun" />}
+          <input
+            type="text"
+            placeholder="Name"
+            value={sun.name}
+            onChange={(e) => setSun({ ...sun, name: e.target.value })}
+          />
+          <input
+            type="number"
+            placeholder="Age"
+            value={sun.age}
+            onChange={(e) => setSun({ ...sun, age: e.target.value })}
+          />
+          <input
+            type="text"
+            placeholder="City / Place born"
+            value={sun.place}
+            onChange={(e) => setSun({ ...sun, place: e.target.value })}
+          />
+          <input type="file" accept="image/*" onChange={(e) => handleImage('sun', e)} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { supabase } from './supabaseClient';
+import IdentityCard from './IdentityCard.jsx';
 import './stats-quadrant.css';
 
 export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
@@ -53,7 +54,7 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
   };
 
   return (
-    <>
+    <div className="character-scroll">
       <div className="stats-quadrant">
         {stats.map((stat, i) => (
           <div
@@ -96,6 +97,7 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
         <button className="square" />
         <button className="round" />
       </div>
-    </>
+      <IdentityCard />
+    </div>
   );
 }

--- a/src/identity-card.css
+++ b/src/identity-card.css
@@ -1,0 +1,70 @@
+.identity-card-wrapper {
+  width: 70%;
+  max-width: 500px;
+  height: 320px;
+  margin: 40px auto 0;
+  perspective: 1000px;
+}
+
+.identity-card {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.6s;
+}
+
+.identity-card.flipped {
+  transform: rotateY(180deg);
+}
+
+.identity-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  border-radius: 40px;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+  color: white;
+}
+
+.face-label {
+  position: absolute;
+  top: 10px;
+  right: 20px;
+  font-weight: bold;
+}
+
+.identity-face input[type="text"],
+.identity-face input[type="number"] {
+  width: 80%;
+  margin-bottom: 8px;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 6px;
+  color: white;
+}
+
+.identity-face input[type="file"] {
+  margin-top: 8px;
+}
+
+.id-photo {
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 8px;
+}
+
+.sun-face {
+  transform: rotateY(180deg);
+}

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -142,3 +142,13 @@ body.character-page {
 .extra-buttons .round {
   border-radius: 30px;
 }
+
+.character-scroll {
+  flex: 1;
+  overflow-y: auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 200px;
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.4.0';
+export const APP_VERSION = '0.4.1';


### PR DESCRIPTION
## Summary
- extend Character tab with an identity card component
- allow storing MBTI, Enneagram, Quadrant frequency and other details
- enable flipping card between Moon and Sun sides
- store card data locally and allow picture upload
- update version to 0.4.1

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c23075e44832298145a48c35ace49