### PR TITLE
Improve character page snap scrolling

### DIFF
--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -166,4 +166,5 @@ body.character-page {
   justify-content: center;
   position: relative;
   scroll-snap-align: start;
+  scroll-snap-stop: always;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -75,6 +75,15 @@ body {
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
 }
 
+body.character-page .content {
+  padding: 0;
+  height: 100vh;
+}
+
+body.character-page h1 {
+  display: none;
+}
+
 .sidebar-avatar {
   width: 50px;
   height: 50px;


### PR DESCRIPTION
## Summary
- ensure sections on character page snap cleanly and take full viewport
- remove header padding on character page to prevent partial sections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c39468f6883228b1bd7e4ae36348d