### PR TITLE
Improve Character page scroll layout

### DIFF
--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -57,6 +57,9 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
 
   return (
     <div className="character-scroll">
+      <section className="header-section">
+        <h2 className="character-title">Character</h2>
+      </section>
       <section className="stats-section">
         <div className="stats-quadrant">
         {stats.map((stat, i) => (

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -155,6 +155,7 @@ body.character-page {
   scroll-behavior: smooth;
 }
 
+.header-section,
 .stats-section,
 .identity-section {
   width: 100%;
@@ -167,4 +168,12 @@ body.character-page {
   position: relative;
   scroll-snap-align: start;
   scroll-snap-stop: always;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+.character-title {
+  font-size: 3rem;
+  color: #fff;
+  text-shadow: 2px 2px 4px #000;
 }


### PR DESCRIPTION
## Summary
- add a header section to the Character page
- give each section 100vh with scroll snap points

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c3da8149883228f13ee9140692a07