### PR TITLE
Add Deezer music card component

### DIFF
--- a/MusicCard.test.js
+++ b/MusicCard.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MusicCard from './src/MusicCard.jsx';
+
+describe('MusicCard', () => {
+  const track = {
+    title: 'Test Song',
+    preview: 'preview.mp3',
+    artist: { name: 'Test Artist' },
+    album: { cover_small: 'cover.jpg' },
+  };
+
+  test('displays track info', () => {
+    render(<MusicCard track={track} />);
+    expect(screen.getByText('Test Song')).toBeInTheDocument();
+    expect(screen.getByText('Test Artist')).toBeInTheDocument();
+    const audio = screen.getByTestId('audio-preview');
+    expect(audio).toHaveAttribute('src', 'preview.mp3');
+  });
+});

--- a/src/MusicCard.jsx
+++ b/src/MusicCard.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import './music-card.css';
+
+export default function MusicCard({ track, onLike }) {
+  if (!track) return null;
+  const { title, preview, artist, album } = track;
+  return (
+    <div className="music-card">
+      <img
+        className="album-cover"
+        src={album?.cover_small}
+        alt={title + ' cover'}
+      />
+      <div className="music-info">
+        <div className="track-title">{title}</div>
+        <div className="artist-name">{artist?.name}</div>
+        <audio
+          data-testid="audio-preview"
+          className="audio-preview"
+          controls
+          src={preview}
+        />
+        <button className="like-button" onClick={onLike}>Like</button>
+      </div>
+    </div>
+  );
+}

--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -57,6 +57,9 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
 
   return (
     <div className="character-scroll">
+      <section className="header-section">
+        <h2 className="character-title">Character</h2>
+      </section>
       <section className="stats-section">
         <div className="stats-quadrant">
         {stats.map((stat, i) => (

--- a/src/identity-card.css
+++ b/src/identity-card.css
@@ -2,7 +2,7 @@
   width: 1200px;
   height: 600px;
   max-width: 80%;
-  margin: 0 auto;
+  margin: 10vh auto 0;
   perspective: 1000px;
 }
 

--- a/src/music-card.css
+++ b/src/music-card.css
@@ -1,0 +1,52 @@
+.music-card {
+  display: flex;
+  align-items: center;
+  background: #222;
+  color: #fff;
+  border-radius: 10px;
+  padding: 12px;
+  gap: 16px;
+  max-width: 500px;
+}
+
+.album-cover {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.music-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 8px;
+}
+
+.track-title {
+  font-size: 1.1em;
+  font-weight: bold;
+}
+
+.artist-name {
+  font-size: 0.9em;
+  color: #ccc;
+}
+
+.audio-preview {
+  width: 100%;
+}
+
+.like-button {
+  align-self: flex-start;
+  background: #5865f2;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.like-button:hover {
+  background: #4752d3;
+}

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -155,6 +155,7 @@ body.character-page {
   scroll-behavior: smooth;
 }
 
+.header-section,
 .stats-section,
 .identity-section {
   width: 100%;
@@ -167,4 +168,12 @@ body.character-page {
   position: relative;
   scroll-snap-align: start;
   scroll-snap-stop: always;
+  padding: 40px 20px;
+  box-sizing: border-box;
+}
+
+.character-title {
+  font-size: 3rem;
+  color: #fff;
+  text-shadow: 2px 2px 4px #000;
 }


### PR DESCRIPTION
## Summary
- add `MusicCard` component for displaying Deezer track info
- style music cards with dark theme
- test music card rendering

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c3da8149883228f13ee9140692a07