### PR TITLE
Add music card component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import NofapCalendar from './NofapCalendar.jsx';
 import VersionRating from './VersionRating.jsx';
 import QuestJournal from './QuestJournal.jsx';
 import WhoAmI from './WhoAmI.jsx';
+import MusicSearch from './MusicSearch.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -28,6 +29,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showNofap, setShowNofap] = useState(false);
   const [showRatings, setShowRatings] = useState(false);
   const [showWhoAmI, setShowWhoAmI] = useState(false);
+  const [showMusic, setShowMusic] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
 
@@ -100,6 +102,8 @@ export default function QuadrantPage({ initialTab }) {
               <VersionRating onBack={() => setShowRatings(false)} />
             ) : showWhoAmI ? (
               <WhoAmI onBack={() => setShowWhoAmI(false)} />
+            ) : showMusic ? (
+              <MusicSearch onBack={() => setShowMusic(false)} />
             ) : (
               <div className="feature-cards">
                 <div className="app-card" onClick={() => setShowJournal(true)}>
@@ -117,6 +121,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowWhoAmI(true)}>
                   <div className="question-icon">❓</div>
                   <span>Who Am I?</span>
+                </div>
+                <div className="app-card" onClick={() => setShowMusic(true)}>
+                  <div className="star-icon">🎵</div>
+                  <span>Music Search</span>
                 </div>
               </div>
             )}

--- a/src/MusicCard.jsx
+++ b/src/MusicCard.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import './music-search.css';
+
+export default function MusicCard({ track, liked, onToggle }) {
+  return (
+    <div className="music-card">
+      {track.cover || track.album?.cover_small ? (
+        <img
+          className="cover"
+          src={track.cover || track.album?.cover_small}
+          alt={track.title}
+        />
+      ) : null}
+      <div className="music-info">
+        <div className="music-title">{track.title}</div>
+        <div className="music-artist">{track.artist?.name || track.artist}</div>
+        {track.preview && (
+          <audio controls src={track.preview} className="preview" />
+        )}
+      </div>
+      <button className="action-button" onClick={() => onToggle(track)}>
+        {liked ? 'Unlike' : 'Like'}
+      </button>
+    </div>
+  );
+}

--- a/src/MusicSearch.jsx
+++ b/src/MusicSearch.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import MusicCard from './MusicCard.jsx';
+import './music-search.css';
+
+export default function MusicSearch({ onBack }) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+  const [liked, setLiked] = useState(() => {
+    const stored = localStorage.getItem('musicLikes');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  const search = async () => {
+    if (!query) return;
+    try {
+      const resp = await fetch(
+        `https://api.deezer.com/search?q=${encodeURIComponent(query)}`
+      );
+      if (!resp.ok) return;
+      const data = await resp.json();
+      setResults(data.data || []);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const toggleLike = (track) => {
+    const exists = liked.some((t) => t.id === track.id);
+    let updated;
+    if (exists) {
+      updated = liked.filter((t) => t.id !== track.id);
+    } else {
+      updated = [
+        ...liked,
+        {
+          id: track.id,
+          title: track.title,
+          artist: track.artist?.name,
+          preview: track.preview,
+          cover: track.album?.cover_small,
+        },
+      ];
+    }
+    setLiked(updated);
+    localStorage.setItem('musicLikes', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="music-search">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <div className="search-bar">
+        <input
+          className="search-input"
+          placeholder="Search songs"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button className="action-button" onClick={search}>Search</button>
+      </div>
+      <div className="results">
+        {results.map((t) => (
+          <MusicCard
+            key={t.id}
+            track={t}
+            liked={liked.some((l) => l.id === t.id)}
+            onToggle={toggleLike}
+          />
+        ))}
+      </div>
+      <h3>Liked Songs</h3>
+      <div className="liked-list">
+        {liked.map((t) => (
+          <MusicCard
+            key={t.id}
+            track={t}
+            liked={true}
+            onToggle={toggleLike}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/music-search.css
+++ b/src/music-search.css
@@ -1,0 +1,74 @@
+.music-search {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+}
+
+.search-bar {
+  display: flex;
+  gap: 8px;
+}
+
+.search-input {
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+
+.results,
+.liked-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 500px;
+}
+
+
+.music-card {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  background: #222;
+  padding: 8px 12px;
+  border-radius: 8px;
+  color: white;
+}
+
+.music-card img.cover {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 6px;
+}
+
+.music-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.music-title {
+  font-weight: bold;
+}
+
+.music-artist {
+  font-size: 0.9em;
+  color: #ccc;
+}
+
+.action-button {
+  background: #007bff;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.action-button:hover {
+  background: #0056b3;
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.4.3';
+export const APP_VERSION = '0.4.5';


### PR DESCRIPTION
## Summary
- show search results and liked tracks using new `MusicCard`
- style cards with album art and audio preview
- bump version to 0.4.5

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685c526bd268832284ace0d386fe2f57