### PR TITLE
Add placeholder Training apps

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,9 @@ import QuestJournal from './QuestJournal.jsx';
 import WhoAmI from './WhoAmI.jsx';
 import MusicSearch from './MusicSearch.jsx';
 import Singing from './Singing.jsx';
+import ShadowWork from './ShadowWork.jsx';
+import Calendar from './Calendar.jsx';
+import Typomancy from './Typomancy.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -32,6 +35,9 @@ export default function QuadrantPage({ initialTab }) {
   const [showWhoAmI, setShowWhoAmI] = useState(false);
   const [showMusic, setShowMusic] = useState(false);
   const [showSinging, setShowSinging] = useState(false);
+  const [showShadowWork, setShowShadowWork] = useState(false);
+  const [showCalendarApp, setShowCalendarApp] = useState(false);
+  const [showTypomancy, setShowTypomancy] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
 
@@ -108,6 +114,12 @@ export default function QuadrantPage({ initialTab }) {
               <MusicSearch onBack={() => setShowMusic(false)} />
             ) : showSinging ? (
               <Singing onBack={() => setShowSinging(false)} />
+            ) : showShadowWork ? (
+              <ShadowWork onBack={() => setShowShadowWork(false)} />
+            ) : showCalendarApp ? (
+              <Calendar onBack={() => setShowCalendarApp(false)} />
+            ) : showTypomancy ? (
+              <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : (
               <div className="feature-cards">
                 <div className="app-card" onClick={() => setShowJournal(true)}>
@@ -133,6 +145,18 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowSinging(true)}>
                   <div className="star-icon">🎤</div>
                   <span>Singing</span>
+                </div>
+                <div className="app-card" onClick={() => setShowShadowWork(true)}>
+                  <div className="star-icon">🌑</div>
+                  <span>Shadow Work</span>
+                </div>
+                <div className="app-card" onClick={() => setShowCalendarApp(true)}>
+                  <div className="star-icon">📅</div>
+                  <span>Calendar</span>
+                </div>
+                <div className="app-card" onClick={() => setShowTypomancy(true)}>
+                  <div className="star-icon">⌨️</div>
+                  <span>Typomancy</span>
                 </div>
               </div>
             )}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './placeholder-app.css';
+
+export default function Calendar({ onBack }) {
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <p>Calendar coming soon...</p>
+    </div>
+  );
+}

--- a/src/MusicCard.jsx
+++ b/src/MusicCard.jsx
@@ -15,7 +15,12 @@ export default function MusicCard({ track, liked, onToggle }) {
         <div className="music-title">{track.title}</div>
         <div className="music-artist">{track.artist?.name || track.artist}</div>
         {track.preview && (
-          <audio controls src={track.preview} className="preview" />
+          <audio
+            controls
+            src={track.preview}
+            className="preview"
+            data-testid="audio-preview"
+          />
         )}
       </div>
       <button className="action-button" onClick={() => onToggle(track)}>

--- a/src/ShadowWork.jsx
+++ b/src/ShadowWork.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './placeholder-app.css';
+
+export default function ShadowWork({ onBack }) {
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <p>Shadow Work coming soon...</p>
+    </div>
+  );
+}

--- a/src/Typomancy.jsx
+++ b/src/Typomancy.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './placeholder-app.css';
+
+export default function Typomancy({ onBack }) {
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <p>Typomancy coming soon...</p>
+    </div>
+  );
+}

--- a/src/placeholder-app.css
+++ b/src/placeholder-app.css
@@ -1,0 +1,6 @@
+.placeholder-app {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.4.5';
+export const APP_VERSION = '0.4.6';


### PR DESCRIPTION
## Summary
- add placeholder components for Shadow Work, Calendar and Typomancy
- wire them into the Training tab
- create simple placeholder-app.css style
- fix MusicCard test by adding test id
- bump app version

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c87b536948322a0cf466079e6705d