### PR TITLE
Fix CSP in extension manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,6 @@
   "permissions": ["activeTab", "tabs"],
   "host_permissions": ["https://eecayyclgpheqhdvrrnz.supabase.co/*"],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'"
     "extension_pages": "script-src 'self'; object-src 'self'; connect-src 'self' https://eecayyclgpheqhdvrrnz.supabase.co"
   }
 }


### PR DESCRIPTION
## Summary
- clean up duplicate CSP entry in the browser extension manifest
- ensure the `extension_pages` policy is a single string

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c8c3625f48322ab57844eca6016b4