### PR TITLE
Rename supabase variable references

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,4 +1,4 @@
-import { supabase } from './supabase.js';
+import { supabaseClient } from './supabase.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('sing-btn');
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
       url: tab.url || '',
       timestamp: new Date().toISOString(),
     };
-    const { error } = await supabase.from('sing_logs').insert(payload);
+    const { error } = await supabaseClient.from('sing_logs').insert(payload);
     if (error) {
       console.error('Supabase error:', error);
     } else {

--- a/extension/supabase.js
+++ b/extension/supabase.js
@@ -3,4 +3,4 @@ const { createClient } = supabase;
 const supabaseUrl = 'https://eecayyclgpheqhdvrrnz.supabase.co';
 const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVlY2F5eWNsZ3BoZXFoZHZycm56Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAwODgyMjksImV4cCI6MjA2NTY2NDIyOX0.cC5XZQFARZ1S8AzDWZ2ISpmi0W0IS3GzMyFtxcqz8ms';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabaseClient = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import Typomancy from './Typomancy.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
 
@@ -45,22 +45,22 @@ export default function QuadrantPage({ initialTab }) {
     const loadAvatar = async () => {
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (!user) return;
 
       const storedPath = localStorage.getItem(`avatarPath_${user.id}`);
       if (storedPath) {
-        const { data } = supabase.storage.from('avatars').getPublicUrl(storedPath);
+        const { data } = supabaseClient.storage.from('avatars').getPublicUrl(storedPath);
         setAvatarUrl(data.publicUrl);
       }
 
-      const { data: profile } = await supabase
+      const { data: profile } = await supabaseClient
         .from('profiles')
         .select('avatar_url')
         .eq('id', user.id)
         .single();
       if (profile?.avatar_url) {
-        const { data } = supabase.storage
+        const { data } = supabaseClient.storage
           .from('avatars')
           .getPublicUrl(profile.avatar_url);
         setAvatarUrl(data.publicUrl);

--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import './auth.css';
 
 function EyeShow() {
@@ -60,14 +60,14 @@ export default function Auth() {
 
   const handleSignUp = async (e) => {
     e.preventDefault();
-    const { data, error } = await supabase.auth.signUp({ email, password });
+    const { data, error } = await supabaseClient.auth.signUp({ email, password });
     if (error) {
       setErrorMsg(error.message);
       return;
     }
     if (data?.user) {
       const cleanName = username.trim().toLowerCase();
-      await supabase
+      await supabaseClient
         .from('profiles')
         .upsert({
           id: data.user.id,
@@ -88,7 +88,7 @@ export default function Auth() {
     e.preventDefault();
     setErrorMsg(null);
     const userInput = identifier.trim();
-    let { error } = await supabase.auth.signInWithPassword({
+    let { error } = await supabaseClient.auth.signInWithPassword({
       email: userInput,
       password,
     });
@@ -96,7 +96,7 @@ export default function Auth() {
     if (error && !userInput.includes('@')) {
       // maybe the user entered a username; resolve it to an email and retry
       const lookup = userInput.toLowerCase();
-      const { data: profile } = await supabase
+      const { data: profile } = await supabaseClient
         .from('profiles')
         .select('email')
         .eq('username', lookup)
@@ -108,7 +108,7 @@ export default function Auth() {
       }
 
       if (profile.email) {
-        ({ error } = await supabase.auth.signInWithPassword({
+        ({ error } = await supabaseClient.auth.signInWithPassword({
           email: profile.email,
           password,
         }));
@@ -122,9 +122,9 @@ export default function Auth() {
 
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await supabaseClient.auth.getUser();
     if (user) {
-      const { data: profile } = await supabase
+      const { data: profile } = await supabaseClient
         .from('profiles')
         .select('username')
         .eq('id', user.id)

--- a/src/AvatarUploadModal.jsx
+++ b/src/AvatarUploadModal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import Cropper from 'react-easy-crop';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import './note-modal.css';
 import './avatar-upload-modal.css';
 import './auth.css';
@@ -50,15 +50,15 @@ export default function AvatarUploadModal({ onClose, onUploaded }) {
 
   useEffect(() => {
     const load = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { user } } = await supabaseClient.auth.getUser();
       if (!user) return;
-      const { data } = await supabase.storage
+      const { data } = await supabaseClient.storage
         .from(BUCKET)
         .list(`${user.id}`, { limit: 5, sortBy: { column: 'created_at', order: 'desc' } });
       if (data) {
         const mapped = data.map((item) => {
           const path = `${user.id}/${item.name}`;
-          const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+          const { data: urlData } = supabaseClient.storage.from(BUCKET).getPublicUrl(path);
           return { path, url: urlData.publicUrl };
         });
         setRecents(mapped);
@@ -70,11 +70,11 @@ export default function AvatarUploadModal({ onClose, onUploaded }) {
   const finish = async (path) => {
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await supabaseClient.auth.getUser();
     if (!user) return;
 
-    await supabase.from('profiles').update({ avatar_url: path }).eq('id', user.id);
-    const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+    await supabaseClient.from('profiles').update({ avatar_url: path }).eq('id', user.id);
+    const { data: urlData } = supabaseClient.storage.from(BUCKET).getPublicUrl(path);
     const finalUrl = urlData.publicUrl;
     localStorage.setItem(`avatarPath_${user.id}`, path);
     localStorage.setItem(`avatarUrl_${user.id}`, finalUrl);
@@ -107,7 +107,7 @@ export default function AvatarUploadModal({ onClose, onUploaded }) {
     setUploading(true);
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await supabaseClient.auth.getUser();
     if (!user) {
       setUploading(false);
       return;
@@ -117,7 +117,7 @@ export default function AvatarUploadModal({ onClose, onUploaded }) {
       : 'avatar.jpg';
     const filePath = `${user.id}/${Date.now()}-${safeName}`;
     const blob = await getCroppedImg(imageSrc, croppedArea);
-    const { error } = await supabase.storage
+    const { error } = await supabaseClient.storage
       .from(BUCKET)
       .upload(filePath, blob, {
         upsert: true,

--- a/src/FriendsList.jsx
+++ b/src/FriendsList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import './world.css';
 
 export default function FriendsList() {
@@ -13,10 +13,10 @@ export default function FriendsList() {
     const load = async () => {
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (user) {
         setUserId(user.id);
-        const { data: profile } = await supabase
+        const { data: profile } = await supabaseClient
           .from('profiles')
           .select('username')
           .eq('id', user.id)
@@ -31,13 +31,13 @@ export default function FriendsList() {
   }, []);
 
   const fetchFriendships = async (id) => {
-    const { data } = await supabase
+    const { data } = await supabaseClient
       .from('friendships')
       .select('*')
       .or(`user_id.eq.${id},friend_id.eq.${id}`);
     if (data) {
       const otherIds = data.map((f) => (f.user_id === id ? f.friend_id : f.user_id));
-      const { data: profiles } = await supabase
+      const { data: profiles } = await supabaseClient
         .from('profiles')
         .select('id, username')
         .in('id', otherIds);
@@ -63,13 +63,13 @@ export default function FriendsList() {
 
   const sendRequest = async () => {
     if (!newFriendName || !userId) return;
-    const { data: profile } = await supabase
+    const { data: profile } = await supabaseClient
       .from('profiles')
       .select('id')
       .eq('username', newFriendName)
       .single();
     if (profile) {
-      await supabase
+      await supabaseClient
         .from('friendships')
         .insert({ user_id: userId, friend_id: profile.id, status: 'pending' });
       setNewFriendName('');
@@ -79,7 +79,7 @@ export default function FriendsList() {
 
   const acceptRequest = async (requesterId) => {
     if (!userId) return;
-    await supabase
+    await supabaseClient
       .from('friendships')
       .update({ status: 'accepted' })
       .eq('user_id', requesterId)

--- a/src/MainQuestModal.jsx
+++ b/src/MainQuestModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import './note-modal.css';
 
 export default function MainQuestModal({ onClose, onSaved, initialMbti = '', initialEnneagram = '', initialInstinct = '' }) {
@@ -20,9 +20,9 @@ export default function MainQuestModal({ onClose, onSaved, initialMbti = '', ini
   const instincts = ['sx', 'sp', 'so'];
 
   const handleSave = async () => {
-    const { data: { user } } = await supabase.auth.getUser();
+    const { data: { user } } = await supabaseClient.auth.getUser();
     if (!user) return;
-    await supabase
+    await supabaseClient
       .from('profiles')
       .update({ mbti, enneagram, instinct })
       .eq('id', user.id);

--- a/src/NofapCalendar.jsx
+++ b/src/NofapCalendar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './nofap-calendar.css';
 import RunEndModal from './RunEndModal.jsx';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -37,10 +37,10 @@ export default function NofapCalendar({ onBack }) {
       if (!navigator.onLine) return;
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (!user) return;
       setUserId(user.id);
-      const { data } = await supabase
+      const { data } = await supabaseClient
         .from('runs')
         .select('*')
         .eq('user_id', user.id);
@@ -118,7 +118,7 @@ export default function NofapCalendar({ onBack }) {
   const startRun = async () => {
     const newRun = { start: Date.now() };
     if (userId && navigator.onLine) {
-      const { data } = await supabase
+      const { data } = await supabaseClient
         .from('runs')
         .insert({ user_id: userId, start: newRun.start })
         .select()
@@ -151,12 +151,12 @@ export default function NofapCalendar({ onBack }) {
     const entry = { ...run, end: nowTime, relapsed, reason };
     if (userId && navigator.onLine) {
       if (run.id) {
-        await supabase
+        await supabaseClient
           .from('runs')
           .update({ end: nowTime, relapsed, reason })
           .eq('id', run.id);
       } else {
-        await supabase.from('runs').insert({
+        await supabaseClient.from('runs').insert({
           user_id: userId,
           start: run.start,
           end: nowTime,

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -5,7 +5,7 @@ import IEmain from './IEmain.jsx';
 import EImain from './EImain.jsx';
 import EEmain from './EEmain.jsx';
 import Auth from './Auth.jsx';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
@@ -13,14 +13,14 @@ export default function PageRouter() {
 
   useEffect(() => {
     const fetchUser = async () => {
-      const { data } = await supabase.auth.getUser();
+      const { data } = await supabaseClient.auth.getUser();
       setUser(data.user);
     };
     fetchUser();
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabaseClient.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null);
     });
     return () => {
@@ -34,7 +34,7 @@ export default function PageRouter() {
     }
     if (window.electronAPI && window.electronAPI.onDisconnect) {
       window.electronAPI.onDisconnect(async () => {
-        await supabase.auth.signOut();
+        await supabaseClient.auth.signOut();
       });
     }
   }, []);

--- a/src/ProfileModal.jsx
+++ b/src/ProfileModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import AvatarUploadModal from './AvatarUploadModal.jsx';
 import './note-modal.css';
 import './profile-modal.css';
@@ -22,7 +22,7 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
     const load = async () => {
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (!user) return;
       setEmail(user.email);
 
@@ -30,7 +30,7 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
       if (stored) {
         setUsername(stored);
       } else {
-        const { data: profile } = await supabase
+        const { data: profile } = await supabaseClient
           .from('profiles')
           .select('username')
           .eq('id', user.id)
@@ -49,25 +49,25 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
     const fetchAvatar = async () => {
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (!user) return;
 
       const storedPath = localStorage.getItem(`avatarPath_${user.id}`);
       if (storedPath) {
-        const { data } = supabase.storage.from(BUCKET).getPublicUrl(storedPath);
+        const { data } = supabaseClient.storage.from(BUCKET).getPublicUrl(storedPath);
         setImgSrc(data.publicUrl);
       } else {
         const storedUrl = localStorage.getItem(`avatarUrl_${user.id}`);
         if (storedUrl) setImgSrc(storedUrl);
       }
 
-      const { data: profile } = await supabase
+      const { data: profile } = await supabaseClient
         .from('profiles')
         .select('avatar_url')
         .eq('id', user.id)
         .single();
       if (profile?.avatar_url) {
-        const { data } = supabase.storage
+        const { data } = supabaseClient.storage
           .from(BUCKET)
           .getPublicUrl(profile.avatar_url);
         setImgSrc(data.publicUrl);
@@ -86,10 +86,10 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
   const handleUsernameSave = async () => {
     const {
       data: { user },
-    } = await supabase.auth.getUser();
+    } = await supabaseClient.auth.getUser();
     if (!user || !newUsername) return;
     const clean = newUsername.trim().toLowerCase();
-    const { error } = await supabase
+    const { error } = await supabaseClient
       .from('profiles')
       .update({ username: clean })
       .eq('id', user.id);

--- a/src/QuestContext.jsx
+++ b/src/QuestContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 
 export const QuestContext = createContext();
 
@@ -15,10 +15,10 @@ export function QuestProvider({ children }) {
       if (!navigator.onLine) return;
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (!user) return;
       setUserId(user.id);
-      const { data } = await supabase
+      const { data } = await supabaseClient
         .from('quests')
         .select('*')
         .eq('user_id', user.id);
@@ -36,7 +36,7 @@ export function QuestProvider({ children }) {
     if (userId && navigator.onLine) {
       quests.forEach((q) => {
         if (q.type === 'main' || q.urgent) {
-          supabase.from('quests').upsert({ ...q, user_id: userId });
+          supabaseClient.from('quests').upsert({ ...q, user_id: userId });
         }
       });
     }
@@ -50,7 +50,7 @@ export function QuestProvider({ children }) {
     };
     setQuests((prev) => [...prev, quest]);
     if (userId && navigator.onLine && (quest.type === 'main' || quest.urgent)) {
-      supabase.from('quests').insert({ ...quest, user_id: userId });
+      supabaseClient.from('quests').insert({ ...quest, user_id: userId });
     }
   };
 
@@ -61,7 +61,7 @@ export function QuestProvider({ children }) {
     if (userId && navigator.onLine) {
       const quest = quests.find((q) => q.id === id);
       if (quest && (quest.type === 'main' || quest.urgent)) {
-        supabase
+        supabaseClient
           .from('quests')
           .update({ accepted: true })
           .eq('user_id', userId)
@@ -79,7 +79,7 @@ export function QuestProvider({ children }) {
             (q.resource || 0);
           localStorage.setItem('resourceR', newResource);
           if (userId && navigator.onLine) {
-            supabase.from('profiles').update({ resources: newResource }).eq('id', userId);
+            supabaseClient.from('profiles').update({ resources: newResource }).eq('id', userId);
           }
           window.dispatchEvent(
             new CustomEvent('resourceChange', { detail: { resource: newResource } })
@@ -92,7 +92,7 @@ export function QuestProvider({ children }) {
     if (userId && navigator.onLine) {
       const quest = quests.find((q) => q.id === id);
       if (quest && (quest.type === 'main' || quest.urgent)) {
-        supabase
+        supabaseClient
           .from('quests')
           .update({ completed: true })
           .eq('user_id', userId)

--- a/src/Singing.jsx
+++ b/src/Singing.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import './music-search.css';
 
 export default function Singing({ onBack }) {
@@ -7,7 +7,7 @@ export default function Singing({ onBack }) {
 
   useEffect(() => {
     const load = async () => {
-      const { data, error } = await supabase
+      const { data, error } = await supabaseClient
         .from('sing_logs')
         .select('*')
         .order('timestamp', { ascending: false });

--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import IdentityCard from './IdentityCard.jsx';
 import './stats-quadrant.css';
 
@@ -18,7 +18,7 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
   useEffect(() => {
     localStorage.setItem('characterStats', JSON.stringify(stats));
     if (userId) {
-      supabase.from('profiles').update({ stats }).eq('id', userId);
+      supabaseClient.from('profiles').update({ stats }).eq('id', userId);
     }
   }, [stats, userId]);
 
@@ -33,10 +33,10 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
     const fetchStats = async () => {
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (!user) return;
       setUserId(user.id);
-      const { data } = await supabase
+      const { data } = await supabaseClient
         .from('profiles')
         .select('stats, mbti, enneagram, username')
         .eq('id', user.id)

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import QuestModal from './QuestModal.jsx';
 import MainQuestModal from './MainQuestModal.jsx';
-import { supabase } from './supabaseClient';
+import { supabaseClient } from './supabaseClient';
 import { useQuests } from './QuestContext.jsx';
 import './world.css';
 
@@ -30,10 +30,10 @@ export default function World() {
       if (!navigator.onLine) return;
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await supabaseClient.auth.getUser();
       if (!user) return;
       setUserId(user.id);
-      const { data: profileData } = await supabase
+      const { data: profileData } = await supabaseClient
         .from('profiles')
         .select('resources, mbti, enneagram, instinct')
         .eq('id', user.id)
@@ -63,7 +63,7 @@ export default function World() {
   useEffect(() => {
     localStorage.setItem('resourceR', resource);
     if (userId && navigator.onLine) {
-      supabase.from('profiles').update({ resources: resource }).eq('id', userId);
+      supabaseClient.from('profiles').update({ resources: resource }).eq('id', userId);
     }
   }, [resource, userId]);
 

--- a/src/__mocks__/supabaseClient.js
+++ b/src/__mocks__/supabaseClient.js
@@ -2,7 +2,7 @@ export const signInWithPassword = jest.fn().mockResolvedValue({ error: { message
 export const getUser = jest.fn();
 export const maybeSingle = jest.fn().mockResolvedValue({ data: null });
 
-export const supabase = {
+export const supabaseClient = {
   auth: {
     signInWithPassword,
     getUser,

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -2,4 +2,4 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnon = import.meta.env.VITE_SUPABASE_ANON_KEY;
-export const supabase = createClient(supabaseUrl, supabaseAnon);
+export const supabaseClient = createClient(supabaseUrl, supabaseAnon);


### PR DESCRIPTION
## Summary
- rename `supabase` export to `supabaseClient`
- update all imports to use the new variable name
- adjust mock and extension scripts accordingly
- keep DOMContentLoaded logic in the extension popup

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c8c3806ac8322bebaac15ab2071b6