### PR TITLE
Fix training page overflow

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -137,6 +137,7 @@ body.character-page h1 {
 .feature-cards {
   display: flex;
   gap: 20px;
+  flex-wrap: wrap;
 }
 
 .star-icon {

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.4.7';
+export const APP_VERSION = '0.4.8';


### PR DESCRIPTION
## Summary
- wrap training page app cards so they flow to a new line
- bump app version

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d90d8fa308322a9f20f8869471ded