### PR TITLE
Add placeholder timeline app

### DIFF
--- a/Timeline.test.js
+++ b/Timeline.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Timeline from './src/Timeline.jsx';
+
+test('shows timeline placeholder', () => {
+  render(<Timeline onBack={() => {}} />);
+  expect(screen.getByText(/timeline coming soon/i)).toBeInTheDocument();
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import MusicSearch from './MusicSearch.jsx';
 import Singing from './Singing.jsx';
 import ShadowWork from './ShadowWork.jsx';
 import Calendar from './Calendar.jsx';
+import Timeline from './Timeline.jsx';
 import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import World from './World.jsx';
@@ -38,6 +39,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showSinging, setShowSinging] = useState(false);
   const [showShadowWork, setShowShadowWork] = useState(false);
   const [showCalendarApp, setShowCalendarApp] = useState(false);
+  const [showTimeline, setShowTimeline] = useState(false);
   const [showTypomancy, setShowTypomancy] = useState(false);
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
@@ -120,6 +122,8 @@ export default function QuadrantPage({ initialTab }) {
               <ShadowWork onBack={() => setShowShadowWork(false)} />
             ) : showCalendarApp ? (
               <Calendar onBack={() => setShowCalendarApp(false)} />
+            ) : showTimeline ? (
+              <Timeline onBack={() => setShowTimeline(false)} />
             ) : showTypomancy ? (
               <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : showMoodtracker ? (
@@ -157,6 +161,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowCalendarApp(true)}>
                   <div className="star-icon">📅</div>
                   <span>Calendar</span>
+                </div>
+                <div className="app-card" onClick={() => setShowTimeline(true)}>
+                  <div className="star-icon">🕒</div>
+                  <span>Timeline</span>
                 </div>
                 <div className="app-card" onClick={() => setShowTypomancy(true)}>
                   <div className="star-icon">⌨️</div>

--- a/src/Timeline.jsx
+++ b/src/Timeline.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './placeholder-app.css';
+
+export default function Timeline({ onBack }) {
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <p>Timeline coming soon...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple `Timeline` component
- show the Timeline placeholder via state in `App.jsx`
- add Timeline card to the feature grid
- test the Timeline placeholder

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d9c457b408322a353109e1ef25cf2