### PR TITLE
Add Anima placeholder

### DIFF
--- a/Anima.test.js
+++ b/Anima.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Anima from './src/Anima.jsx';
+
+test('shows anima placeholder', () => {
+  render(<Anima onBack={() => {}} />);
+  expect(screen.getByText(/anima coming soon/i)).toBeInTheDocument();
+});

--- a/src/Anima.jsx
+++ b/src/Anima.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './placeholder-app.css';
+
+export default function Anima({ onBack }) {
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <p>Anima coming soon...</p>
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import Calendar from './Calendar.jsx';
 import Timeline from './Timeline.jsx';
 import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
+import Anima from './Anima.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -42,6 +43,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showTimeline, setShowTimeline] = useState(false);
   const [showTypomancy, setShowTypomancy] = useState(false);
   const [showMoodtracker, setShowMoodtracker] = useState(false);
+  const [showAnima, setShowAnima] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
 
@@ -128,6 +130,8 @@ export default function QuadrantPage({ initialTab }) {
               <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : showMoodtracker ? (
               <Moodtracker onBack={() => setShowMoodtracker(false)} />
+            ) : showAnima ? (
+              <Anima onBack={() => setShowAnima(false)} />
             ) : (
               <div className="feature-cards">
                 <div className="app-card" onClick={() => setShowJournal(true)}>
@@ -173,6 +177,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowMoodtracker(true)}>
                   <div className="star-icon">😊</div>
                   <span>Moodtracker</span>
+                </div>
+                <div className="app-card" onClick={() => setShowAnima(true)}>
+                  <div className="star-icon">💃</div>
+                  <span>Anima</span>
                 </div>
               </div>
             )}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.4.9';
+export const APP_VERSION = '0.4.10';


### PR DESCRIPTION
## Summary
- add Anima placeholder component
- display Anima in Training tab
- bump version to 0.4.10
- test that Anima placeholder renders

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_685db27b51dc8322ad5961c27ed21962