### PR TITLE
Fix login password field width and heading font

### DIFF
--- a/src/auth.css
+++ b/src/auth.css
@@ -5,6 +5,13 @@
   font-style: normal;
 }
 
+@font-face {
+  font-family: 'ExodiusD-regular';
+  src: url('./assets/fonts/ExodusD-Regular.otf') format('opentype');
+  font-weight: normal;
+  font-style: normal;
+}
+
 .auth-container {
   position: relative;
   height: 100vh;
@@ -47,6 +54,7 @@
 .auth-box h2 {
   margin: 0 0 20px;
   font-size: 28px;
+  font-family: 'ExodiusD-regular', sans-serif;
 }
 
 .auth-box input {
@@ -109,20 +117,21 @@
 }
 
 .password-wrapper {
-  display: flex;
-  align-items: center;
+  position: relative;
   width: 100%;
   margin-bottom: 15px;
 }
 
 .password-wrapper input {
-  flex: 1;
   width: 100%;
-  min-width: 0;
+  padding-right: 36px;
 }
 
 .toggle-password {
-  margin-left: 8px;
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
   background: none;
   border: none;
   color: #ccc;


### PR DESCRIPTION
## Summary
- add `ExodiusD-regular` font-face and use it for the Welcome heading
- make password input the full width of other fields by overlaying the toggle button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dbda7f3448322b1ca8e3c61226adb