### PR TITLE
Fix login container width and style

### DIFF
--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -151,7 +151,7 @@ export default function Auth() {
         <source src={loginVideo} type="video/mp4" />
       </video>
       <div className="auth-box">
-        <h2>Welcome</h2>
+        <h2>Mazed</h2>
         {mode === 'signin' ? (
           <form onSubmit={handleSignIn}>
             <input

--- a/src/auth.css
+++ b/src/auth.css
@@ -5,6 +5,13 @@
   font-style: normal;
 }
 
+@font-face {
+  font-family: 'ExodiusD-regular';
+  src: url('./assets/fonts/ExodusD-Regular.otf') format('opentype');
+  font-weight: normal;
+  font-style: normal;
+}
+
 .auth-container {
   position: relative;
   height: 100vh;
@@ -28,25 +35,30 @@
 }
 
 .auth-box {
-  background: rgba(0, 0, 0, 0.7);
-  padding: 40px;
-  width: 360px;
+  background: rgba(0, 0, 0, 0.48);
+  padding: 40px 5%;
+  width: calc(100% - 5%);
+  height: 100vh;
   border-radius: 8px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
   display: flex;
   flex-direction: column;
   align-items: center;
+  box-sizing: border-box;
 }
 
 .auth-box form {
-  width: 100%;
+  width: 360px;
   display: flex;
   flex-direction: column;
 }
 
 .auth-box h2 {
   margin: 0 0 20px;
-  font-size: 28px;
+  font-size: 49px;
+  font-family: 'ExodiusD-regular', sans-serif;
+  text-align: left;
+  align-self: flex-start;
 }
 
 .auth-box input {
@@ -57,6 +69,7 @@
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.1);
   color: white;
+  box-sizing: border-box;
 }
 
 .auth-box input::placeholder {
@@ -73,6 +86,7 @@
   cursor: pointer;
   color: white;
   transition: background 0.2s;
+  box-sizing: border-box;
 }
 
 .primary-btn {
@@ -109,6 +123,7 @@
 }
 
 .password-wrapper {
+  position: relative;
   display: flex;
   align-items: center;
   width: 100%;
@@ -116,13 +131,16 @@
 }
 
 .password-wrapper input {
-  flex: 1;
   width: 100%;
-  min-width: 0;
+  padding-right: 48px;
+  box-sizing: border-box;
 }
 
 .toggle-password {
-  margin-left: 8px;
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
   background: none;
   border: none;
   color: #ccc;


### PR DESCRIPTION
## Summary
- extend login overlay and update heading text
- fix password icon alignment and box sizing
- keep login layout left aligned

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685dbda7f3448322b1ca8e3c61226adb