### PR TITLE
Fix login wrapper alignment

### DIFF
--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -151,7 +151,7 @@ export default function Auth() {
         <source src={loginVideo} type="video/mp4" />
       </video>
       <div className="auth-box">
-        <h2>Welcome</h2>
+        <h2>Mazed</h2>
         {mode === 'signin' ? (
           <form onSubmit={handleSignIn}>
             <input

--- a/src/auth.css
+++ b/src/auth.css
@@ -5,9 +5,16 @@
   font-style: normal;
 }
 
+@font-face {
+  font-family: 'ExodiusD-regular';
+  src: url('./assets/fonts/ExodusD-Regular.otf') format('opentype');
+  font-weight: normal;
+  font-style: normal;
+}
+
 .auth-container {
-  position: relative;
-  height: 100vh;
+  position: fixed;
+  inset: 0;
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -47,6 +54,7 @@
 .auth-box h2 {
   margin: 0 0 20px;
   font-size: 28px;
+  font-family: 'ExodiusD-regular', sans-serif;
 }
 
 .auth-box input {
@@ -109,6 +117,7 @@
 }
 
 .password-wrapper {
+  position: relative;
   display: flex;
   align-items: center;
   width: 100%;
@@ -116,13 +125,16 @@
 }
 
 .password-wrapper input {
-  flex: 1;
   width: 100%;
-  min-width: 0;
+  padding-right: 48px;
+  box-sizing: border-box;
 }
 
 .toggle-password {
-  margin-left: 8px;
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
   background: none;
   border: none;
   color: #ccc;


### PR DESCRIPTION
## Summary
- adjust login container positioning so form sits on the left center of the screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbda7f3448322b1ca8e3c61226adb