### PR TITLE
Add Quadrant combinaisons app

### DIFF
--- a/QuadrantCombinaisons.test.js
+++ b/QuadrantCombinaisons.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuadrantCombinaisons from './src/QuadrantCombinaisons.jsx';
+
+test('shows add combinaison button', () => {
+  render(<QuadrantCombinaisons onBack={() => {}} />);
+  expect(screen.getByText(/add combinaison/i)).toBeInTheDocument();
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import Timeline from './Timeline.jsx';
 import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
+import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -44,6 +45,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showTypomancy, setShowTypomancy] = useState(false);
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
+  const [showQuadrantComb, setShowQuadrantComb] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
 
@@ -130,6 +132,8 @@ export default function QuadrantPage({ initialTab }) {
               <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : showMoodtracker ? (
               <Moodtracker onBack={() => setShowMoodtracker(false)} />
+            ) : showQuadrantComb ? (
+              <QuadrantCombinaisons onBack={() => setShowQuadrantComb(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : (
@@ -177,6 +181,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowMoodtracker(true)}>
                   <div className="star-icon">😊</div>
                   <span>Moodtracker</span>
+                </div>
+                <div className="app-card" onClick={() => setShowQuadrantComb(true)}>
+                  <div className="star-icon">🔀</div>
+                  <span>Quadrant combinaisons</span>
                 </div>
                 <div className="app-card" onClick={() => setShowAnima(true)}>
                   <div className="star-icon">💃</div>

--- a/src/QuadrantCombModal.jsx
+++ b/src/QuadrantCombModal.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import './note-modal.css';
+
+export default function QuadrantCombModal({ onAdd, onClose }) {
+  const [name, setName] = useState('');
+  const [notes, setNotes] = useState('');
+  const [ii, setII] = useState('');
+  const [ie, setIE] = useState('');
+  const [ei, setEI] = useState('');
+  const [ee, setEE] = useState('');
+
+  const handleSave = () => {
+    onAdd({
+      id: Date.now(),
+      name: name || 'Unnamed',
+      notes,
+      quadrants: { II: ii, IE: ie, EI: ei, EE: ee },
+    });
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <input
+          className="note-title"
+          placeholder="Combinaison name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Quadrant II"
+          value={ii}
+          onChange={(e) => setII(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Quadrant IE"
+          value={ie}
+          onChange={(e) => setIE(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Quadrant EI"
+          value={ei}
+          onChange={(e) => setEI(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Quadrant EE"
+          value={ee}
+          onChange={(e) => setEE(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+        />
+        <div className="actions">
+          <button className="save-button" onClick={handleSave}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/QuadrantCombinaisons.jsx
+++ b/src/QuadrantCombinaisons.jsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import QuadrantCombModal from './QuadrantCombModal.jsx';
+import './version-rating.css';
+
+export default function QuadrantCombinaisons({ onBack }) {
+  const [combos, setCombos] = useState(() => {
+    const stored = localStorage.getItem('quadrantCombinaisons');
+    return stored ? JSON.parse(stored) : [];
+  });
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem('quadrantCombinaisons', JSON.stringify(combos));
+  }, [combos]);
+
+  const addCombo = (c) => setCombos([...combos, c]);
+  const removeCombo = (id) => setCombos(combos.filter((c) => c.id !== id));
+
+  return (
+    <div className="version-rating">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <div className="rating-list">
+        {combos.map((c) => (
+          <div key={c.id} className="version-card">
+            <div className="version-header">
+              <div className="version-name">{c.name}</div>
+              <button className="delete-button" onClick={() => removeCombo(c.id)}>
+                ✖
+              </button>
+            </div>
+            <div className="quadrant-notes">
+              <div><strong>II:</strong> {c.quadrants?.II}</div>
+              <div><strong>IE:</strong> {c.quadrants?.IE}</div>
+              <div><strong>EI:</strong> {c.quadrants?.EI}</div>
+              <div><strong>EE:</strong> {c.quadrants?.EE}</div>
+            </div>
+            {c.notes && <div className="extra-notes">{c.notes}</div>}
+          </div>
+        ))}
+      </div>
+      <button className="action-button" onClick={() => setShowModal(true)}>
+        Add Combinaison
+      </button>
+      {showModal && (
+        <QuadrantCombModal
+          onAdd={addCombo}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new app `Quadrant combinaisons`
- support storing combinations in localStorage
- implement modal to create new combinations
- expose the new feature in the Training tab
- test that the new app renders

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f0be8ccf88322a63bd77ab3d11fe8