### PR TITLE
Add divider line for calendar halves

### DIFF
--- a/Calendar.jsx
+++ b/Calendar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Calendar as RBCalendar,
   momentLocalizer,
@@ -14,11 +14,24 @@ const localizer = momentLocalizer(moment);
 const DnDCalendar = withDragAndDrop(RBCalendar);
 
 export default function Calendar({ onBack }) {
-  const [events, setEvents] = useState(() => {
-    const stored = localStorage.getItem('calendarEvents');
+  const [plans, setPlans] = useState(() => {
+    const stored = localStorage.getItem('calendarPlans');
     if (!stored) return [];
     try {
-      return JSON.parse(stored).map(e => ({
+      return JSON.parse(stored).map((e) => ({
+        ...e,
+        start: new Date(e.start),
+        end: new Date(e.end),
+      }));
+    } catch {
+      return [];
+    }
+  });
+  const [logs, setLogs] = useState(() => {
+    const stored = localStorage.getItem('calendarLogs');
+    if (!stored) return [];
+    try {
+      return JSON.parse(stored).map((e) => ({
         ...e,
         start: new Date(e.start),
         end: new Date(e.end),
@@ -28,15 +41,26 @@ export default function Calendar({ onBack }) {
     }
   });
   const [modalEvent, setModalEvent] = useState(null);
+  const events = useMemo(
+    () => [
+      ...plans.map((e) => ({ ...e, type: 'plan' })),
+      ...logs.map((e) => ({ ...e, type: 'log' })),
+    ],
+    [plans, logs]
+  );
 
   useEffect(() => {
-    localStorage.setItem('calendarEvents', JSON.stringify(events));
-  }, [events]);
+    localStorage.setItem('calendarPlans', JSON.stringify(plans));
+  }, [plans]);
+
+  useEffect(() => {
+    localStorage.setItem('calendarLogs', JSON.stringify(logs));
+  }, [logs]);
 
   useEffect(() => {
     const handleAdd = (e) => {
       const ev = e.detail;
-      setEvents((prev) => [
+      setLogs((prev) => [
         ...prev,
         {
           ...ev,
@@ -45,8 +69,8 @@ export default function Calendar({ onBack }) {
         },
       ]);
     };
-    window.addEventListener('calendar-add-event', handleAdd);
-    return () => window.removeEventListener('calendar-add-event', handleAdd);
+    window.addEventListener('calendar-add-log', handleAdd);
+    return () => window.removeEventListener('calendar-add-log', handleAdd);
   }, []);
 
   const handleSelectSlot = ({ start, end }) => {
@@ -54,33 +78,56 @@ export default function Calendar({ onBack }) {
     const s = new Date(start);
     const e = new Date(end);
     if (isNaN(s) || isNaN(e)) return;
-    setModalEvent({ start: s, end: e });
+    setModalEvent({ start: s, end: e, type: 'plan' });
   };
 
   const handleSaveEvent = (event) => {
     if (modalEvent && modalEvent.index != null) {
-      const updated = [...events];
-      updated[modalEvent.index] = event;
-      setEvents(updated);
+      if (modalEvent.type === 'log') {
+        const updated = [...logs];
+        updated[modalEvent.index] = event;
+        setLogs(updated);
+      } else {
+        const updated = [...plans];
+        updated[modalEvent.index] = event;
+        setPlans(updated);
+      }
     } else {
-      setEvents([...events, event]);
+      if (modalEvent && modalEvent.type === 'log') {
+        setLogs([...logs, event]);
+      } else {
+        setPlans([...plans, event]);
+      }
     }
   };
 
   const handleSelectEvent = (event) => {
-    setModalEvent({ ...event, index: events.indexOf(event) });
+    const idx = event.type === 'log'
+      ? logs.indexOf(event)
+      : plans.indexOf(event);
+    setModalEvent({ ...event, index: idx, type: event.type });
   };
 
   const eventPropGetter = (event) => ({
+    className: event.type === 'log' ? 'log-event' : 'plan-event',
     style: { backgroundColor: event.color || '#1a73e8' },
   });
 
   const moveEvent = ({ event, start, end }) => {
-    const idx = events.indexOf(event);
-    if (idx !== -1) {
-      const updated = [...events];
-      updated[idx] = { ...event, start, end };
-      setEvents(updated);
+    if (event.type === 'log') {
+      const idx = logs.indexOf(event);
+      if (idx !== -1) {
+        const updated = [...logs];
+        updated[idx] = { ...event, start, end };
+        setLogs(updated);
+      }
+    } else {
+      const idx = plans.indexOf(event);
+      if (idx !== -1) {
+        const updated = [...plans];
+        updated[idx] = { ...event, start, end };
+        setPlans(updated);
+      }
     }
   };
 
@@ -90,7 +137,11 @@ export default function Calendar({ onBack }) {
 
   const handleDelete = () => {
     if (modalEvent && modalEvent.index != null) {
-      setEvents(events.filter((_, i) => i !== modalEvent.index));
+      if (modalEvent.type === 'log') {
+        setLogs(logs.filter((_, i) => i !== modalEvent.index));
+      } else {
+        setPlans(plans.filter((_, i) => i !== modalEvent.index));
+      }
     }
   };
 

--- a/calendar-app.css
+++ b/calendar-app.css
@@ -34,3 +34,33 @@
   inset: 0;
   background: #121212;
 }
+
+.rbc-event.plan-event {
+  left: 0 !important;
+  width: 50% !important;
+}
+
+.rbc-event.log-event {
+  left: 50% !important;
+  width: 50% !important;
+}
+
+/* visual divider between planned and logged halves */
+.rbc-day-bg,
+.rbc-day-slot,
+.rbc-allday-cell {
+  position: relative;
+}
+
+.rbc-day-bg::after,
+.rbc-day-slot::after,
+.rbc-allday-cell::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.2);
+}

--- a/src/ActivityLogger.jsx
+++ b/src/ActivityLogger.jsx
@@ -11,7 +11,7 @@ export default function ActivityLogger({ enabled }) {
     if (window.electronAPI && window.electronAPI.onActivity) {
       const handler = (_event, data) => {
         if (!enabledRef.current) return;
-        const stored = localStorage.getItem('calendarEvents');
+        const stored = localStorage.getItem('calendarLogs');
         const events = stored ? JSON.parse(stored) : [];
         const newEvent = {
           title: `${data.app}: ${data.title}`,
@@ -20,9 +20,9 @@ export default function ActivityLogger({ enabled }) {
           color: '#1a73e8',
         };
         events.push(newEvent);
-        localStorage.setItem('calendarEvents', JSON.stringify(events));
+        localStorage.setItem('calendarLogs', JSON.stringify(events));
         window.dispatchEvent(
-          new CustomEvent('calendar-add-event', { detail: newEvent })
+          new CustomEvent('calendar-add-log', { detail: newEvent })
         );
       };
       window.electronAPI.onActivity(handler);


### PR DESCRIPTION
## Summary
- keep planned events left and logs right
- draw a vertical divider in each calendar cell

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686153cb5c7c83229f5a651f1c2012ab