### PR TITLE
Add calendar block aggregation

### DIFF
--- a/src/ActivityLogger.jsx
+++ b/src/ActivityLogger.jsx
@@ -7,6 +7,12 @@ export default function ActivityLogger({ enabled }) {
     enabledRef.current = enabled;
   }, [enabled]);
 
+  const roundSlot = (date) => {
+    const d = new Date(date);
+    d.setMinutes(Math.floor(d.getMinutes() / 30) * 30, 0, 0);
+    return d;
+  };
+
   useEffect(() => {
     if (window.electronAPI && window.electronAPI.onActivity) {
       const handler = (_event, data) => {
@@ -24,6 +30,34 @@ export default function ActivityLogger({ enabled }) {
         localStorage.setItem('calendarEvents', JSON.stringify(events));
         window.dispatchEvent(
           new CustomEvent('calendar-add-event', { detail: newEvent })
+        );
+
+        const blockStart = roundSlot(data.start);
+        const blockEnd = new Date(blockStart.getTime() + 30 * 60000);
+        const blocks = JSON.parse(localStorage.getItem('calendarBlocks') || '[]');
+        let block = blocks.find((b) => b.start === blockStart.toISOString());
+        if (!block) {
+          block = {
+            start: blockStart.toISOString(),
+            end: blockEnd.toISOString(),
+            items: [],
+            kind: 'block',
+            color: '#000000',
+          };
+          blocks.push(block);
+        }
+        block.items.push({
+          label: `${data.app}: ${data.title}`,
+          duration: new Date(data.end).getTime() - new Date(data.start).getTime(),
+        });
+        block.title = block.items
+          .map((i) => i.label.split(':')[0])
+          .slice(0, 2)
+          .join(', ');
+        if (block.items.length > 2) block.title += ' & more';
+        localStorage.setItem('calendarBlocks', JSON.stringify(blocks));
+        window.dispatchEvent(
+          new CustomEvent('calendar-add-block', { detail: block })
         );
       };
       window.electronAPI.onActivity(handler);

--- a/src/BlockModal.jsx
+++ b/src/BlockModal.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import './note-modal.css';
+import './block-modal.css';
+
+export default function BlockModal({ start, end, items, onClose }) {
+  const format = (d) => new Date(d).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h3>{`${format(start)} - ${format(end)}`}</h3>
+        <ul className="block-items">
+          {items.map((it, idx) => (
+            <li key={idx} className="block-item">
+              <span className="block-icon" />
+              <span className="block-label">{it.label}</span>
+              {it.duration != null && (
+                <span className="block-duration">{Math.round(it.duration / 60000)}m</span>
+              )}
+            </li>
+          ))}
+        </ul>
+        <div className="actions">
+          <button className="save-button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -6,6 +6,7 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
 import "./calendar-app.css";
 import EventModal from "../EventModal.jsx";
+import BlockModal from "./BlockModal.jsx";
 
 const localizer = momentLocalizer(moment);
 const DnDCalendar = withDragAndDrop(RBCalendar);
@@ -34,13 +35,31 @@ export default function Calendar({ onBack }) {
       return [];
     }
   });
+  const [blocks, setBlocks] = useState(() => {
+    const stored = localStorage.getItem('calendarBlocks');
+    if (!stored) return [];
+    try {
+      return JSON.parse(stored).map((b) => ({
+        ...b,
+        start: new Date(b.start),
+        end: new Date(b.end),
+      }));
+    } catch {
+      return [];
+    }
+  });
   const [modalEvent, setModalEvent] = useState(null);
+  const [selectedBlock, setSelectedBlock] = useState(null);
   const containerRef = useRef(null);
   const lastClickX = useRef(null);
 
   useEffect(() => {
     localStorage.setItem("calendarEvents", JSON.stringify(events));
   }, [events]);
+
+  useEffect(() => {
+    localStorage.setItem('calendarBlocks', JSON.stringify(blocks));
+  }, [blocks]);
 
   useEffect(() => {
     const handleAdd = (e) => {
@@ -57,6 +76,30 @@ export default function Calendar({ onBack }) {
     };
     window.addEventListener("calendar-add-event", handleAdd);
     return () => window.removeEventListener("calendar-add-event", handleAdd);
+  }, []);
+
+  useEffect(() => {
+    const handleBlockAdd = (e) => {
+      const b = e.detail;
+      setBlocks((prev) => {
+        const idx = prev.findIndex(
+          (p) => new Date(p.start).getTime() === new Date(b.start).getTime()
+        );
+        const block = {
+          ...b,
+          start: new Date(b.start),
+          end: new Date(b.end),
+        };
+        if (idx !== -1) {
+          const updated = [...prev];
+          updated[idx] = block;
+          return updated;
+        }
+        return [...prev, block];
+      });
+    };
+    window.addEventListener('calendar-add-block', handleBlockAdd);
+    return () => window.removeEventListener('calendar-add-block', handleBlockAdd);
   }, []);
 
   useEffect(() => {
@@ -104,7 +147,11 @@ export default function Calendar({ onBack }) {
   };
 
   const handleSelectEvent = (event) => {
-    setModalEvent({ ...event, index: events.indexOf(event) });
+    if (event.kind === 'block') {
+      setSelectedBlock(event);
+    } else {
+      setModalEvent({ ...event, index: events.indexOf(event) });
+    }
   };
 
   const eventPropGetter = (event) => {
@@ -121,6 +168,12 @@ export default function Calendar({ onBack }) {
         style: { ...base, left: "50%", width: "50%" },
       };
     }
+    if (event.kind === "block") {
+      return {
+        className: 'block-event',
+        style: { backgroundColor: '#000', color: '#fff', left: '0%', width: '100%' },
+      };
+    }
     return { style: base };
   };
 
@@ -131,6 +184,7 @@ export default function Calendar({ onBack }) {
   };
 
   const moveEvent = ({ event, start, end }) => {
+    if (event.kind === 'block') return;
     const idx = events.indexOf(event);
     if (idx !== -1) {
       const updated = [...events];
@@ -153,7 +207,7 @@ export default function Calendar({ onBack }) {
           selectable
           resizable
           localizer={localizer}
-          events={events}
+          events={[...events, ...blocks]}
           startAccessor="start"
           endAccessor="end"
           defaultView="month"
@@ -176,6 +230,14 @@ export default function Calendar({ onBack }) {
           onSave={handleSaveEvent}
           onDelete={modalEvent.index != null ? handleDelete : undefined}
           onClose={() => setModalEvent(null)}
+        />
+      )}
+      {selectedBlock && (
+        <BlockModal
+          start={selectedBlock.start}
+          end={selectedBlock.end}
+          items={selectedBlock.items}
+          onClose={() => setSelectedBlock(null)}
         />
       )}
     </div>

--- a/src/block-modal.css
+++ b/src/block-modal.css
@@ -1,0 +1,27 @@
+.block-items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.block-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.block-icon {
+  width: 12px;
+  height: 12px;
+  background: #888;
+  display: inline-block;
+}
+
+.block-duration {
+  margin-left: auto;
+  font-size: 0.8em;
+  color: #666;
+}

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -69,6 +69,10 @@
   left: 50% !important;
   width: 50% !important;
 }
+.block-event {
+  background: #000 !important;
+  color: #fff !important;
+}
 .fullpage-calendar {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- aggregate activity logs into 30‑minute blocks
- display block summaries on the calendar
- show block details in a new modal

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861908a977883228a0b4297709b38a3