### PR TITLE
Fix calendar event styling and deletion

### DIFF
--- a/EventModal.jsx
+++ b/EventModal.jsx
@@ -6,7 +6,7 @@ export default function EventModal({
   end,
   title: initialTitle = '',
   kind: initialKind = 'planned',
-  color: initialColor = '#1a73e8',
+  color: initialColor = '#888888',
   onSave,
   onDelete,
   onClose,

--- a/src/ActivityLogger.jsx
+++ b/src/ActivityLogger.jsx
@@ -23,7 +23,7 @@ export default function ActivityLogger({ enabled }) {
           title: `${data.app}: ${data.title}`,
           start: data.start,
           end: data.end,
-          color: '#1a73e8',
+          color: '#888888',
           kind: 'done',
         };
         events.push(newEvent);

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -150,12 +150,16 @@ export default function Calendar({ onBack }) {
     if (event.kind === 'block') {
       setSelectedBlock(event);
     } else {
-      setModalEvent({ ...event, index: events.indexOf(event) });
+      setModalEvent({
+        ...event,
+        index: events.indexOf(event),
+        original: event,
+      });
     }
   };
 
   const eventPropGetter = (event) => {
-    const base = { backgroundColor: event.color || "#1a73e8" };
+    const base = { backgroundColor: event.color || "#888888" };
     if (event.kind === "planned") {
       return {
         className: "planned-event",
@@ -171,15 +175,15 @@ export default function Calendar({ onBack }) {
     if (event.kind === "block") {
       return {
         className: 'block-event',
-        style: { backgroundColor: '#000', color: '#fff', left: '0%', width: '100%' },
+        style: { backgroundColor: '#000', color: '#fff', left: '50%', width: '50%' },
       };
     }
     return { style: base };
   };
 
   const handleDelete = () => {
-    if (modalEvent && modalEvent.index != null) {
-      setEvents(events.filter((_, i) => i !== modalEvent.index));
+    if (modalEvent && modalEvent.original) {
+      setEvents(events.filter((ev) => ev !== modalEvent.original));
     }
   };
 

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -105,3 +105,21 @@
   inset: 0;
   background: #121212;
 }
+
+/* Override default blue highlights */
+.calendar-container .rbc-event.rbc-selected,
+.calendar-container .rbc-day-slot .rbc-selected.rbc-background-event {
+  background-color: #444;
+}
+
+.calendar-container .rbc-selected-cell {
+  background-color: #222;
+}
+
+.calendar-container .rbc-show-more {
+  color: #ccc;
+}
+
+.calendar-container .rbc-slot-selection {
+  background-color: rgba(255, 255, 255, 0.1);
+}

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -62,7 +62,7 @@
 
 .save-button {
   padding: 6px 16px;
-  background: #007bff;
+  background: #555;
   color: white;
   border: none;
   border-radius: 6px;
@@ -70,7 +70,7 @@
 }
 
 .save-button:hover {
-  background: #0056b3;
+  background: #444;
 }
 
 .notes-list {


### PR DESCRIPTION
## Summary
- adjust event selection handler to track original event
- color events gray instead of blue and move block events to the right side
- update ActivityLogger default color
- remove blue palette from EventModal and save button
- override big calendar highlight colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628944a5648322a81c671d42d484e9