### PR TITLE
Refactor calendar event styles

### DIFF
--- a/Calendar.jsx
+++ b/Calendar.jsx
@@ -114,20 +114,11 @@ export default function Calendar({ onBack }) {
   };
 
   const eventPropGetter = (event) => {
-    const base = { backgroundColor: event.color || "#1a73e8" };
-    if (event.kind === "planned") {
-      return {
-        className: "planned-event",
-        style: { ...base, left: "0%", width: "50%" },
-      };
-    }
-    if (event.kind === "done") {
-      return {
-        className: "done-event",
-        style: { ...base, left: "50%", width: "50%" },
-      };
-    }
-    return { style: base };
+    const style = {
+      backgroundColor:
+        event.color || (event.kind === "done" ? "#34a853" : "#1a73e8"),
+    };
+    return { style };
   };
 
   const moveEvent = ({ event, start, end }) => {

--- a/calendar-app.css
+++ b/calendar-app.css
@@ -61,14 +61,6 @@
 .calendar-container .rbc-time-header .rbc-today {
   background: #17181d;
 }
-.planned-event {
-  left: 0% !important;
-  width: 50% !important;
-}
-.done-event {
-  left: 50% !important;
-  width: 50% !important;
-}
 .fullpage-calendar {
   position: fixed;
   inset: 0;
@@ -86,14 +78,6 @@
   left: 50%;
   width: 1px;
   background: rgba(255, 255, 255, 0.2);
-}
-.planned-event {
-  left: 0% !important;
-  width: 50% !important;
-}
-.done-event {
-  left: 50% !important;
-  width: 50% !important;
 }
 .fullpage-calendar {
   position: fixed;

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -159,26 +159,14 @@ export default function Calendar({ onBack }) {
   };
 
   const eventPropGetter = (event) => {
-    const base = { backgroundColor: event.color || "#888888" };
-    if (event.kind === "planned") {
-      return {
-        className: "planned-event",
-        style: { ...base, left: "0%", width: "50%" },
-      };
-    }
-    if (event.kind === "done") {
-      return {
-        className: "done-event",
-        style: { ...base, left: "50%", width: "50%" },
-      };
-    }
+    let style = {
+      backgroundColor:
+        event.color || (event.kind === "done" ? "#34a853" : "#888888"),
+    };
     if (event.kind === "block") {
-      return {
-        className: 'block-event',
-        style: { backgroundColor: '#000', color: '#fff', left: '50%', width: '50%' },
-      };
+      style = { backgroundColor: "#000", color: "#fff" };
     }
-    return { style: base };
+    return { style };
   };
 
   const handleDelete = () => {

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -61,14 +61,6 @@
 .calendar-container .rbc-time-header .rbc-today {
   background: #17181d;
 }
-.planned-event {
-  left: 0% !important;
-  width: 50% !important;
-}
-.done-event {
-  left: 50% !important;
-  width: 50% !important;
-}
 .block-event {
   background: #000 !important;
   color: #fff !important;
@@ -91,14 +83,6 @@
   width: 1px;
   background: rgba(255, 255, 255, 0.2);
 
-}
-.planned-event {
-  left: 0% !important;
-  width: 50% !important;
-}
-.done-event {
-  left: 50% !important;
-  width: 50% !important;
 }
 .fullpage-calendar {
   position: fixed;


### PR DESCRIPTION
## Summary
- simplify eventPropGetter logic for calendar events
- remove CSS classes that forced split widths
- keep calendar events stacked by default

## Testing
- `npm test` *(fails: renders timeline nodes)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd42d0308322afadd7d9885cbfa5