### PR TITLE
Add neutral event styling in calendar

### DIFF
--- a/calendar-app.css
+++ b/calendar-app.css
@@ -32,6 +32,13 @@
   background: #0d0e11;
 }
 
+/* Neutral style for calendar events */
+.calendar-container .rbc-event,
+.calendar-container .rbc-addons-dnd .rbc-event {
+  background-color: #333;
+  color: #e6e7eb;
+}
+
 .calendar-container .rbc-toolbar button {
   background: none;
   border: none;

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -32,6 +32,13 @@
   background: #0d0e11;
 }
 
+/* Neutral style for calendar events */
+.calendar-container .rbc-event,
+.calendar-container .rbc-addons-dnd .rbc-event {
+  background-color: #333;
+  color: #e6e7eb;
+}
+
 .calendar-container .rbc-toolbar button {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- style `.rbc-event` elements with a neutral look
- keep consistent color during drag-and-drop

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd432ce88322bf128dd99dd46884