### PR TITLE
Add description support to calendar events

### DIFF
--- a/Calendar.jsx
+++ b/Calendar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Calendar as RBCalendar, momentLocalizer } from "react-big-calendar";
 import withDragAndDrop from "react-big-calendar/lib/addons/dragAndDrop";
 import moment from "moment";
@@ -29,6 +29,7 @@ export default function Calendar({ onBack }) {
           start: new Date(e.start),
           end: new Date(e.end),
           kind: e.kind || (e.title.includes(":") ? "done" : "planned"),
+          description: e.description || "",
         }));
     } catch {
       return [];
@@ -54,15 +55,16 @@ export default function Calendar({ onBack }) {
   useEffect(() => {
     const handleAdd = (e) => {
       const ev = e.detail;
-      setEvents((prev) => [
-        ...prev,
-        {
-          ...ev,
-          start: new Date(ev.start),
-          end: new Date(ev.end),
-          kind: ev.kind || "planned",
-        },
-      ]);
+        setEvents((prev) => [
+          ...prev,
+          {
+            ...ev,
+            start: new Date(ev.start),
+            end: new Date(ev.end),
+            kind: ev.kind || "planned",
+            description: ev.description || "",
+          },
+        ]);
     };
     window.addEventListener("calendar-add-event", handleAdd);
     return () => window.removeEventListener("calendar-add-event", handleAdd);
@@ -83,7 +85,7 @@ export default function Calendar({ onBack }) {
     const s = new Date(start);
     const e = new Date(end);
     if (isNaN(s) || isNaN(e)) return;
-    setModalEvent({ start: s, end: e, kind: "planned" });
+    setModalEvent({ start: s, end: e, kind: "planned", description: "" });
   };
 
   const handleSaveEvent = (event) => {
@@ -175,6 +177,7 @@ export default function Calendar({ onBack }) {
           events={events}
           startAccessor="start"
           endAccessor="end"
+          tooltipAccessor="description"
           defaultView="month"
           views={["month", "week", "day"]}
           style={{ height: "100%" }}
@@ -186,16 +189,17 @@ export default function Calendar({ onBack }) {
         />
       </div>
       {modalEvent && (
-        <EventModal
-          start={modalEvent.start}
-          end={modalEvent.end}
-          title={modalEvent.title}
-          color={modalEvent.color}
-          kind={modalEvent.kind || "planned"}
-          onSave={handleSaveEvent}
-          onDelete={modalEvent.index != null ? handleDelete : undefined}
-          onClose={() => setModalEvent(null)}
-        />
+          <EventModal
+            start={modalEvent.start}
+            end={modalEvent.end}
+            title={modalEvent.title}
+            color={modalEvent.color}
+            kind={modalEvent.kind || "planned"}
+            description={modalEvent.description}
+            onSave={handleSaveEvent}
+            onDelete={modalEvent.index != null ? handleDelete : undefined}
+            onClose={() => setModalEvent(null)}
+          />
       )}
     </div>
   );

--- a/EventModal.jsx
+++ b/EventModal.jsx
@@ -7,6 +7,7 @@ export default function EventModal({
   title: initialTitle = '',
   kind: initialKind = 'planned',
   color: initialColor = '#888888',
+  description: initialDescription = '',
   onSave,
   onDelete,
   onClose,
@@ -20,6 +21,7 @@ export default function EventModal({
   );
   const [color, setColor] = useState(initialColor);
   const [kind, setKind] = useState(initialKind);
+  const [description, setDescription] = useState(initialDescription);
 
   const handleSave = () => {
     onSave({
@@ -28,6 +30,7 @@ export default function EventModal({
       end: new Date(endTime),
       color,
       kind,
+      description,
     });
   };
 
@@ -72,6 +75,14 @@ export default function EventModal({
             <option value="planned">Planned</option>
             <option value="done">Done</option>
           </select>
+        </label>
+        <label className="note-label">
+          Description
+          <textarea
+            className="note-title"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+          />
         </label>
         <div className="actions">
           {onDelete && (


### PR DESCRIPTION
## Summary
- add `description` state to `EventModal`
- persist event `description` in `Calendar`
- display description in event tooltip

## Testing
- `npm test` *(fails: renders timeline nodes)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd4336e4832292afdef7d70b8b01