### PR TITLE
Add delete icon overlay for calendar events

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -11,6 +11,23 @@ import BlockModal from "./BlockModal.jsx";
 const localizer = momentLocalizer(moment);
 const DnDCalendar = withDragAndDrop(RBCalendar);
 
+function CalendarEvent({ event, onDelete }) {
+  return (
+    <div className="calendar-event-content">
+      {event.title}
+      <span
+        className="event-delete-icon"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(event);
+        }}
+      >
+        ×
+      </span>
+    </div>
+  );
+}
+
 export default function Calendar({ onBack }) {
   const [events, setEvents] = useState(() => {
     const stored = localStorage.getItem("calendarEvents");
@@ -181,9 +198,10 @@ export default function Calendar({ onBack }) {
     return { style: base };
   };
 
-  const handleDelete = () => {
-    if (modalEvent && modalEvent.original) {
-      setEvents(events.filter((ev) => ev !== modalEvent.original));
+  const handleDelete = (target) => {
+    const toDelete = target || (modalEvent && modalEvent.original);
+    if (toDelete) {
+      setEvents(events.filter((ev) => ev !== toDelete));
     }
   };
 
@@ -222,6 +240,11 @@ export default function Calendar({ onBack }) {
           onEventDrop={moveEvent}
           onEventResize={resizeEvent}
           eventPropGetter={eventPropGetter}
+          components={{
+            event: (props) => (
+              <CalendarEvent {...props} onDelete={handleDelete} />
+            ),
+          }}
         />
       </div>
       {modalEvent && (

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -123,3 +123,15 @@
 .calendar-container .rbc-slot-selection {
   background-color: rgba(255, 255, 255, 0.1);
 }
+
+.calendar-event-content {
+  position: relative;
+}
+
+.calendar-event-content .event-delete-icon {
+  position: absolute;
+  top: 0;
+  right: 2px;
+  font-size: 12px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- create `CalendarEvent` component with delete overlay
- update calendar to use the component and allow deleting events directly
- style the delete overlay icon via `calendar-app.css`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd437fc08322a2bfdc68b6fe09a4