### PR TITLE
Adjust calendar slot height

### DIFF
--- a/calendar-app.css
+++ b/calendar-app.css
@@ -45,8 +45,13 @@
   background: #17181d;
   color: #e6e7eb;
 }
+.calendar-container .rbc-time-slot {
+  min-height: 3rem;
+}
 .calendar-container .rbc-day-slot .rbc-time-slot {
   position: relative;
+  /* Increase the height of each timeslot for better visibility */
+  min-height: 3rem;
 }
 .calendar-container .rbc-day-slot .rbc-time-slot::after {
   content: "";
@@ -77,6 +82,7 @@
 
 .calendar-container .rbc-day-slot .rbc-time-slot {
   position: relative;
+  min-height: 3rem;
 }
 .calendar-container .rbc-day-slot .rbc-time-slot::after {
   content: "";

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -45,8 +45,13 @@
   background: #17181d;
   color: #e6e7eb;
 }
+.calendar-container .rbc-time-slot {
+  min-height: 3rem;
+}
 .calendar-container .rbc-day-slot .rbc-time-slot {
   position: relative;
+  /* Increase the height of each timeslot for better visibility */
+  min-height: 3rem;
 }
 .calendar-container .rbc-day-slot .rbc-time-slot::after {
   content: "";
@@ -81,6 +86,7 @@
 
 .calendar-container .rbc-day-slot .rbc-time-slot {
   position: relative;
+  min-height: 3rem;
 }
 .calendar-container .rbc-day-slot .rbc-time-slot::after {
   content: "";


### PR DESCRIPTION
## Summary
- bump min-height for `.rbc-time-slot` and `.rbc-day-slot .rbc-time-slot` so each time block is taller

## Testing
- `npm test --silent` *(fails: Timeline.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd43204883228a00a633cb6ada8c