### PR TITLE
Remove duplicate styles in calendar CSS

### DIFF
--- a/calendar-app.css
+++ b/calendar-app.css
@@ -75,28 +75,3 @@
   background: #0d0e11;
 }
 
-.calendar-container .rbc-day-slot .rbc-time-slot {
-  position: relative;
-}
-.calendar-container .rbc-day-slot .rbc-time-slot::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  width: 1px;
-  background: rgba(255, 255, 255, 0.2);
-}
-.planned-event {
-  left: 0% !important;
-  width: 50% !important;
-}
-.done-event {
-  left: 50% !important;
-  width: 50% !important;
-}
-.fullpage-calendar {
-  position: fixed;
-  inset: 0;
-  background: #121212;
-}

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -79,32 +79,6 @@
   background: #0d0e11;
 }
 
-.calendar-container .rbc-day-slot .rbc-time-slot {
-  position: relative;
-}
-.calendar-container .rbc-day-slot .rbc-time-slot::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 50%;
-  width: 1px;
-  background: rgba(255, 255, 255, 0.2);
-
-}
-.planned-event {
-  left: 0% !important;
-  width: 50% !important;
-}
-.done-event {
-  left: 50% !important;
-  width: 50% !important;
-}
-.fullpage-calendar {
-  position: fixed;
-  inset: 0;
-  background: #121212;
-}
 
 /* Override default blue highlights */
 .calendar-container .rbc-event.rbc-selected,


### PR DESCRIPTION
## Summary
- clean up `calendar-app.css` and `src/calendar-app.css`
- drop repeated style blocks for `.planned-event`, `.done-event` and time slot rules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862dd441bdc8322adf8a0274e5a85f4