### PR TITLE
Restore left/right calendar layout

### DIFF
--- a/Calendar.jsx
+++ b/Calendar.jsx
@@ -116,11 +116,34 @@ export default function Calendar({ onBack }) {
   };
 
   const eventPropGetter = (event) => {
-    const style = {
+    const base = {
       backgroundColor:
         event.color || (event.kind === "done" ? "#34a853" : "#1a73e8"),
     };
-    return { style };
+    if (event.kind === "planned") {
+      return {
+        className: "planned-event",
+        style: { ...base, left: "0%", width: "50%" },
+      };
+    }
+    if (event.kind === "done") {
+      return {
+        className: "done-event",
+        style: { ...base, left: "50%", width: "50%" },
+      };
+    }
+    if (event.kind === "block") {
+      return {
+        className: "block-event",
+        style: {
+          backgroundColor: "#000",
+          color: "#fff",
+          left: "50%",
+          width: "50%",
+        },
+      };
+    }
+    return { style: base };
   };
 
   const moveEvent = ({ event, start, end }) => {

--- a/calendar-app.css
+++ b/calendar-app.css
@@ -73,6 +73,18 @@
 .calendar-container .rbc-time-header .rbc-today {
   background: #17181d;
 }
+.planned-event {
+  left: 0% !important;
+  width: 50% !important;
+}
+.done-event {
+  left: 50% !important;
+  width: 50% !important;
+}
+.block-event {
+  background: #000 !important;
+  color: #fff !important;
+}
 .fullpage-calendar {
   position: fixed;
   inset: 0;

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -176,14 +176,34 @@ export default function Calendar({ onBack }) {
   };
 
   const eventPropGetter = (event) => {
-    let style = {
+    const base = {
       backgroundColor:
         event.color || (event.kind === "done" ? "#34a853" : "#888888"),
     };
-    if (event.kind === "block") {
-      style = { backgroundColor: "#000", color: "#fff" };
+    if (event.kind === "planned") {
+      return {
+        className: "planned-event",
+        style: { ...base, left: "0%", width: "50%" },
+      };
     }
-    return { style };
+    if (event.kind === "done") {
+      return {
+        className: "done-event",
+        style: { ...base, left: "50%", width: "50%" },
+      };
+    }
+    if (event.kind === "block") {
+      return {
+        className: "block-event",
+        style: {
+          backgroundColor: "#000",
+          color: "#fff",
+          left: "50%",
+          width: "50%",
+        },
+      };
+    }
+    return { style: base };
   };
 
   const handleDelete = (target) => {

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -73,6 +73,14 @@
 .calendar-container .rbc-time-header .rbc-today {
   background: #17181d;
 }
+.planned-event {
+  left: 0% !important;
+  width: 50% !important;
+}
+.done-event {
+  left: 50% !important;
+  width: 50% !important;
+}
 .block-event {
   background: #000 !important;
   color: #fff !important;


### PR DESCRIPTION
## Summary
- restore split layout for planned and done events in calendar
- add CSS rules for planned/done/block events

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cc300e08832288eb1d6f8ac5cacf