### PR TITLE
Use dark theme for calendar

### DIFF
--- a/Calendar.jsx
+++ b/Calendar.jsx
@@ -116,11 +116,34 @@ export default function Calendar({ onBack }) {
   };
 
   const eventPropGetter = (event) => {
-    const style = {
+    const base = {
       backgroundColor:
         event.color || (event.kind === "done" ? "#34a853" : "#1a73e8"),
     };
-    return { style };
+    if (event.kind === "planned") {
+      return {
+        className: "planned-event",
+        style: { ...base, left: "0%", width: "50%" },
+      };
+    }
+    if (event.kind === "done") {
+      return {
+        className: "done-event",
+        style: { ...base, left: "50%", width: "50%" },
+      };
+    }
+    if (event.kind === "block") {
+      return {
+        className: "block-event",
+        style: {
+          backgroundColor: "#17181d",
+          color: "#fff",
+          left: "50%",
+          width: "50%",
+        },
+      };
+    }
+    return { style: base };
   };
 
   const moveEvent = ({ event, start, end }) => {

--- a/calendar-app.css
+++ b/calendar-app.css
@@ -9,7 +9,7 @@
 
 .calendar-container {
   flex: 1;
-  background: #17181d;
+  background: #000;
   color: #e6e7eb;
   padding: 10px;
   border-radius: 8px;
@@ -20,7 +20,7 @@
 .calendar-container .rbc-month-view,
 .calendar-container .rbc-time-view,
 .calendar-container .rbc-agenda-view {
-  background: #17181d;
+  background: #000;
   color: #e6e7eb;
 }
 
@@ -29,14 +29,14 @@
 }
 
 .calendar-container .rbc-off-range-bg {
-  background: #0d0e11;
+  background: #000;
 }
 
 /* Neutral style for calendar events */
 .calendar-container .rbc-event,
 .calendar-container .rbc-addons-dnd .rbc-event {
-  background-color: #333;
-  color: #e6e7eb;
+  background-color: #17181d;
+  color: #fff;
 }
 
 .calendar-container .rbc-toolbar button {
@@ -71,10 +71,22 @@
 }
 .calendar-container .rbc-day-bg.rbc-today,
 .calendar-container .rbc-time-header .rbc-today {
-  background: #17181d;
+  background: #000;
+}
+.planned-event {
+  left: 0% !important;
+  width: 50% !important;
+}
+.done-event {
+  left: 50% !important;
+  width: 50% !important;
+}
+.block-event {
+  background: #17181d !important;
+  color: #fff !important;
 }
 .fullpage-calendar {
   position: fixed;
   inset: 0;
-  background: #0d0e11;
+  background: #000;
 }

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -176,14 +176,34 @@ export default function Calendar({ onBack }) {
   };
 
   const eventPropGetter = (event) => {
-    let style = {
+    const base = {
       backgroundColor:
         event.color || (event.kind === "done" ? "#34a853" : "#888888"),
     };
-    if (event.kind === "block") {
-      style = { backgroundColor: "#000", color: "#fff" };
+    if (event.kind === "planned") {
+      return {
+        className: "planned-event",
+        style: { ...base, left: "0%", width: "50%" },
+      };
     }
-    return { style };
+    if (event.kind === "done") {
+      return {
+        className: "done-event",
+        style: { ...base, left: "50%", width: "50%" },
+      };
+    }
+    if (event.kind === "block") {
+      return {
+        className: "block-event",
+        style: {
+          backgroundColor: "#17181d",
+          color: "#fff",
+          left: "50%",
+          width: "50%",
+        },
+      };
+    }
+    return { style: base };
   };
 
   const handleDelete = (target) => {

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -9,7 +9,7 @@
 
 .calendar-container {
   flex: 1;
-  background: #17181d;
+  background: #000;
   color: #e6e7eb;
   padding: 10px;
   border-radius: 8px;
@@ -20,7 +20,7 @@
 .calendar-container .rbc-month-view,
 .calendar-container .rbc-time-view,
 .calendar-container .rbc-agenda-view {
-  background: #17181d;
+  background: #000;
   color: #e6e7eb;
 }
 
@@ -29,14 +29,14 @@
 }
 
 .calendar-container .rbc-off-range-bg {
-  background: #0d0e11;
+  background: #000;
 }
 
 /* Neutral style for calendar events */
 .calendar-container .rbc-event,
 .calendar-container .rbc-addons-dnd .rbc-event {
-  background-color: #333;
-  color: #e6e7eb;
+  background-color: #17181d;
+  color: #fff;
 }
 
 .calendar-container .rbc-toolbar button {
@@ -71,16 +71,24 @@
 }
 .calendar-container .rbc-day-bg.rbc-today,
 .calendar-container .rbc-time-header .rbc-today {
-  background: #17181d;
+  background: #000;
+}
+.planned-event {
+  left: 0% !important;
+  width: 50% !important;
+}
+.done-event {
+  left: 50% !important;
+  width: 50% !important;
 }
 .block-event {
-  background: #000 !important;
+  background: #17181d !important;
   color: #fff !important;
 }
 .fullpage-calendar {
   position: fixed;
   inset: 0;
-  background: #0d0e11;
+  background: #000;
 }
 
 


### PR DESCRIPTION
## Summary
- set calendar background to black
- style events with lighter-black background and white text
- keep block events dark gray with white text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cc300e08832288eb1d6f8ac5cacf