### PR TITLE
Add event delete icon

### DIFF
--- a/Calendar.jsx
+++ b/Calendar.jsx
@@ -10,6 +10,23 @@ import EventModal from "./EventModal.jsx";
 const localizer = momentLocalizer(moment);
 const DnDCalendar = withDragAndDrop(RBCalendar);
 
+function CalendarEvent({ event, onDelete }) {
+  return (
+    <div className="calendar-event-content">
+      {event.title}
+      <span
+        className="event-delete-icon"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(event);
+        }}
+      >
+        ×
+      </span>
+    </div>
+  );
+}
+
 export default function Calendar({ onBack }) {
   const [events, setEvents] = useState(() => {
     const stored = localStorage.getItem("calendarEvents");
@@ -200,6 +217,11 @@ export default function Calendar({ onBack }) {
           onEventDrop={moveEvent}
           onEventResize={resizeEvent}
           eventPropGetter={eventPropGetter}
+          components={{
+            event: (props) => (
+              <CalendarEvent {...props} onDelete={handleDelete} />
+            ),
+          }}
         />
       </div>
       {modalEvent && (

--- a/calendar-app.css
+++ b/calendar-app.css
@@ -92,3 +92,15 @@
   inset: 0;
   background: #000;
 }
+
+.calendar-event-content {
+  position: relative;
+}
+
+.calendar-event-content .event-delete-icon {
+  position: absolute;
+  top: 0;
+  right: 2px;
+  font-size: 12px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- port `.calendar-event-content` and `.event-delete-icon` rules from `src` CSS
- render calendar events with delete icons in `Calendar.jsx`

## Testing
- `npm test --silent` *(fails: Timeline.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6862f390de0c8322bed0bb32aa110652