### PR TITLE
Update README for calendar theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,11 @@ the **Get username** button to choose one. After saving, the profile will show
 All password inputs include a small eye button on the right side to toggle
 visibility. Use it if you need to double‑check what you typed.
 
+## Calendar UI
+
+The calendar now uses a black background throughout for improved readability.
+Events are positioned in two columns: planned items occupy the left half of a
+slot while completed entries appear on the right. The accompanying styles
+(`.planned-event`, `.done-event` and `.block-event`) ensure consistent colors
+and widths for each type.
+


### PR DESCRIPTION
## Summary
- document calendar's black theme and split event layout

## Testing
- `npm test --silent` *(fails: Found multiple elements with the text: S1)*

------
https://chatgpt.com/codex/tasks/task_e_6862f3923f948322a50c55cecde896c0