### PR TITLE
Switch calendar to block-only logs

### DIFF
--- a/src/ActivityLogger.jsx
+++ b/src/ActivityLogger.jsx
@@ -17,19 +17,15 @@ export default function ActivityLogger({ enabled }) {
     if (window.electronAPI && window.electronAPI.onActivity) {
       const handler = (_event, data) => {
         if (!enabledRef.current) return;
-        const stored = localStorage.getItem('calendarEvents');
-        const events = stored ? JSON.parse(stored) : [];
-        const newEvent = {
-          title: `${data.app}: ${data.title}`,
-          start: data.start,
-          end: data.end,
-          color: '#888888',
-          kind: 'done',
-        };
-        events.push(newEvent);
-        localStorage.setItem('calendarEvents', JSON.stringify(events));
-        window.dispatchEvent(
-          new CustomEvent('calendar-add-event', { detail: newEvent })
+        // Only create aggregated blocks rather than individual done events
+        // Remove old event log storage to keep the interface clean
+        localStorage.setItem(
+          'calendarEvents',
+          JSON.stringify(
+            (JSON.parse(localStorage.getItem('calendarEvents') || '[]') || []).filter(
+              (e) => e && (e.kind === 'planned')
+            )
+          )
         );
 
         const blockStart = roundSlot(data.start);

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -29,25 +29,72 @@ function CalendarEvent({ event, onDelete }) {
 }
 
 export default function Calendar({ onBack }) {
+  const roundSlot = (date) => {
+    const d = new Date(date);
+    d.setMinutes(Math.floor(d.getMinutes() / 30) * 30, 0, 0);
+    return d;
+  };
+
   const [events, setEvents] = useState(() => {
     const stored = localStorage.getItem("calendarEvents");
     if (!stored) return [];
     try {
-      return JSON.parse(stored)
-        .filter(
-          (e) =>
-            e &&
-            e.start &&
-            e.end &&
-            typeof e.title === "string" &&
-            e.title.trim() !== ""
-        )
-        .map((e) => ({
-          ...e,
-          start: new Date(e.start),
-          end: new Date(e.end),
-          kind: e.kind || (e.title.includes(":") ? "done" : "planned"),
-        }));
+      const parsed = JSON.parse(stored).filter(
+        (e) =>
+          e &&
+          e.start &&
+          e.end &&
+          typeof e.title === "string" &&
+          e.title.trim() !== ""
+      );
+
+      const planned = [];
+      const done = [];
+      parsed.forEach((e) => {
+        const kind = e.kind || (e.title.includes(":") ? "done" : "planned");
+        const ev = { ...e, start: new Date(e.start), end: new Date(e.end), kind };
+        if (kind === "planned") planned.push(ev);
+        else if (kind === "done") done.push(ev);
+      });
+
+      if (done.length) {
+        let blocks = [];
+        try {
+          blocks = JSON.parse(localStorage.getItem("calendarBlocks") || "[]");
+        } catch {
+          blocks = [];
+        }
+        done.forEach((ev) => {
+          const slot = roundSlot(ev.start);
+          const blockEnd = new Date(slot.getTime() + 30 * 60000);
+          let block = blocks.find(
+            (b) => new Date(b.start).getTime() === slot.getTime()
+          );
+          if (!block) {
+            block = {
+              start: slot.toISOString(),
+              end: blockEnd.toISOString(),
+              items: [],
+              kind: "block",
+              color: "#000000",
+            };
+            blocks.push(block);
+          }
+          block.items.push({
+            label: ev.title,
+            duration: new Date(ev.end).getTime() - new Date(ev.start).getTime(),
+          });
+          block.title = block.items
+            .map((i) => i.label.split(":")[0])
+            .slice(0, 2)
+            .join(", ");
+          if (block.items.length > 2) block.title += " & more";
+        });
+        localStorage.setItem("calendarBlocks", JSON.stringify(blocks));
+        localStorage.setItem("calendarEvents", JSON.stringify(planned));
+      }
+
+      return planned;
     } catch {
       return [];
     }

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -85,6 +85,8 @@
 .block-event {
   background: #17181d !important;
   color: #fff !important;
+  left: 50% !important;
+  width: 50% !important;
 }
 .fullpage-calendar {
   position: fixed;


### PR DESCRIPTION
## Summary
- drop creation of individual `done` events in `ActivityLogger`
- convert any legacy `done` events to blocks when the calendar loads
- force blocks to render on the right side of the calendar

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ffeb79cc8322831aec129bf58cea