### PR TITLE
Add category support to ShadowWork

### DIFF
--- a/ShadowModal.jsx
+++ b/ShadowModal.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import './shadow-modal.css';
 
-export default function ShadowModal({ onAdd, onClose }) {
+export default function ShadowModal({ categories, onAdd, onClose }) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [notes, setNotes] = useState('');
+  const [category, setCategory] = useState(categories[0]);
 
   const handleSave = () => {
-    onAdd({
+    onAdd(category, {
       id: Date.now(),
       name: name || 'Unnamed',
       description,
@@ -37,6 +38,13 @@ export default function ShadowModal({ onAdd, onClose }) {
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
         />
+        <select value={category} onChange={(e) => setCategory(e.target.value)}>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c.charAt(0).toUpperCase() + c.slice(1)}
+            </option>
+          ))}
+        </select>
         <div className="actions">
           <button className="save-button" onClick={handleSave}>Save</button>
         </div>

--- a/ShadowWork.jsx
+++ b/ShadowWork.jsx
@@ -1,39 +1,55 @@
 import React, { useState, useEffect } from 'react';
 import ShadowModal from './ShadowModal.jsx';
 import './placeholder-app.css';
+import './shadow-work.css';
 
 export default function ShadowWork({ onBack }) {
+  const categories = ['desires', 'aversion', 'ideas'];
   const [shadows, setShadows] = useState(() => {
     const stored = localStorage.getItem('shadows');
-    return stored ? JSON.parse(stored) : [];
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        return { desires: parsed, aversion: [], ideas: [] };
+      }
+      return { desires: [], aversion: [], ideas: [], ...parsed };
+    }
+    return { desires: [], aversion: [], ideas: [] };
   });
   const [showModal, setShowModal] = useState(false);
-
+  
   useEffect(() => {
     localStorage.setItem('shadows', JSON.stringify(shadows));
   }, [shadows]);
 
-  const addShadow = (s) => {
-    setShadows([...shadows, s]);
+  const addShadow = (cat, s) => {
+    setShadows({ ...shadows, [cat]: [...shadows[cat], s] });
   };
 
   return (
     <div className="placeholder-app">
       <button className="back-button" onClick={onBack}>Back</button>
-      <ul style={{ listStyle: 'none', padding: 0, width: '100%', maxWidth: '400px' }}>
-        {shadows.map(s => (
-          <li key={s.id} style={{ background: '#333', color: 'white', padding: '8px 12px', borderRadius: '8px', marginBottom: '8px' }}>
-            <div style={{ fontWeight: 'bold' }}>{s.name}</div>
-            {s.description && <div style={{ marginTop: '4px' }}>{s.description}</div>}
-            {s.notes && <div style={{ marginTop: '4px', fontSize: '0.9em' }}>{s.notes}</div>}
-          </li>
+      <div className="shadow-categories">
+        {categories.map(cat => (
+          <div key={cat} className="shadow-category">
+            <h3>{cat.charAt(0).toUpperCase() + cat.slice(1)}</h3>
+            <ul>
+              {shadows[cat].map(s => (
+                <li key={s.id}>
+                  <div style={{ fontWeight: 'bold' }}>{s.name}</div>
+                  {s.description && <div style={{ marginTop: '4px' }}>{s.description}</div>}
+                  {s.notes && <div style={{ marginTop: '4px', fontSize: '0.9em' }}>{s.notes}</div>}
+                </li>
+              ))}
+            </ul>
+          </div>
         ))}
-      </ul>
+      </div>
       <button className="action-button" onClick={() => setShowModal(true)} style={{ borderRadius: '50%', width: '40px', height: '40px', fontSize: '24px', padding: 0 }}>
         +
       </button>
       {showModal && (
-        <ShadowModal onAdd={addShadow} onClose={() => setShowModal(false)} />
+        <ShadowModal categories={categories} onAdd={addShadow} onClose={() => setShowModal(false)} />
       )}
     </div>
   );

--- a/shadow-modal.css
+++ b/shadow-modal.css
@@ -45,6 +45,14 @@
   resize: vertical;
 }
 
+select {
+  padding: 6px 10px;
+  border: 1px solid #555;
+  border-radius: 6px;
+  background: #333;
+  color: #eee;
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/shadow-work.css
+++ b/shadow-work.css
@@ -1,0 +1,32 @@
+.shadow-categories {
+  display: flex;
+  gap: 20px;
+  width: 100%;
+  max-width: 900px;
+}
+
+.shadow-category {
+  flex: 1;
+  background: #222;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.shadow-category h3 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.shadow-category ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.shadow-category li {
+  background: #333;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 8px;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Summary
- organize shadow items into Desires, Aversion and Ideas categories
- allow selecting a category when adding a new entry
- style modal select and add new shadow-work layout

## Testing
- `npm test` *(fails: Timeline.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68638f0539a0832296836ee903eff318