### PR TITLE
Add relapse time input and persist relapse days

### DIFF
--- a/NofapCalendar.jsx
+++ b/NofapCalendar.jsx
@@ -58,6 +58,7 @@ export default function NofapCalendar({ onBack }) {
               end: r.end,
               relapsed: r.relapsed,
               reason: r.reason,
+              relapseTime: r.relapse_time,
             }))
           );
         }
@@ -94,16 +95,22 @@ export default function NofapCalendar({ onBack }) {
     const compute = () => {
       const updated = {};
       let longest = 0;
-      runs.forEach((r) => {
+      const ordered = [...runs].sort((a, b) => a.start - b.start);
+      ordered.forEach((r) => {
         const startDay = new Date(r.start);
         startDay.setHours(0, 0, 0, 0);
         const endDay = new Date(r.end);
         endDay.setHours(0, 0, 0, 0);
-        for (let d = new Date(startDay), idx = 0; d <= endDay; d.setDate(d.getDate() + 1), idx++) {
+        for (
+          let d = new Date(startDay), idx = 0;
+          d <= endDay;
+          d.setDate(d.getDate() + 1), idx++
+        ) {
           const key = d.toISOString().slice(0, 10);
-          if (r.relapsed && d.getTime() === endDay.getTime()) {
+          const isRelapseDay = r.relapsed && d.getTime() === endDay.getTime();
+          if (isRelapseDay) {
             updated[key] = 'relapse';
-          } else {
+          } else if (!updated[key]) {
             updated[key] = colorForIndex(idx);
           }
         }
@@ -144,16 +151,17 @@ export default function NofapCalendar({ onBack }) {
     return 'white';
   };
 
-  const finishRun = async (reason) => {
+  const finishRun = async (reason, relapseTime) => {
     if (!run) return;
     const relapsed = endType === 'relapse';
     const nowTime = Date.now();
     const entry = { ...run, end: nowTime, relapsed, reason };
+    if (relapsed) entry.relapseTime = relapseTime;
     if (userId && navigator.onLine) {
       if (run.id) {
         await supabaseClient
           .from('runs')
-          .update({ end: nowTime, relapsed, reason })
+          .update({ end: nowTime, relapsed, reason, relapse_time: relapseTime })
           .eq('id', run.id);
       } else {
         await supabaseClient.from('runs').insert({
@@ -162,6 +170,7 @@ export default function NofapCalendar({ onBack }) {
           end: nowTime,
           relapsed,
           reason,
+          relapse_time: relapseTime,
         });
       }
     }
@@ -293,11 +302,16 @@ export default function NofapCalendar({ onBack }) {
               {new Date(r.start).getDate()} {new Date(r.start).toLocaleString('default', { month: 'long' })} {new Date(r.start).getFullYear()} to {new Date(r.end).getDate()} {new Date(r.end).toLocaleString('default', { month: 'long' })} {new Date(r.end).getFullYear()}, {Math.ceil((r.end - r.start) / DAY_MS)} days
             </div>
             <div>Reason: {r.reason || 'N/A'}</div>
+            {r.relapseTime && <div>Relapse at: {r.relapseTime}</div>}
           </div>
         ))}
       </div>
       {showEndModal && (
-        <RunEndModal onSave={finishRun} onClose={() => setShowEndModal(false)} />
+        <RunEndModal
+          type={endType}
+          onSave={finishRun}
+          onClose={() => setShowEndModal(false)}
+        />
       )}
     </div>
   );

--- a/RunEndModal.jsx
+++ b/RunEndModal.jsx
@@ -1,11 +1,18 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
-export default function RunEndModal({ onSave, onClose }) {
+export default function RunEndModal({ onSave, onClose, type }) {
   const [reason, setReason] = useState('');
+  const [time, setTime] = useState(
+    () => new Date().toISOString().slice(11, 16)
+  );
 
   const handleSave = () => {
-    onSave(reason);
+    if (type === 'relapse') {
+      onSave(reason, time);
+    } else {
+      onSave(reason);
+    }
   };
 
   return (
@@ -18,6 +25,14 @@ export default function RunEndModal({ onSave, onClose }) {
           value={reason}
           onChange={(e) => setReason(e.target.value)}
         />
+        {type === 'relapse' && (
+          <input
+            type="time"
+            className="note-content"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        )}
         <div className="actions">
           <button className="save-button" onClick={handleSave}>Save</button>
         </div>

--- a/Timeline.test.js
+++ b/Timeline.test.js
@@ -6,7 +6,7 @@ import Timeline from './src/Timeline.jsx';
 test('renders timeline nodes', () => {
   render(<Timeline onBack={() => {}} />);
   // should contain stage and track labels
-  expect(screen.getByText('S1')).toBeInTheDocument();
-  expect(screen.getByText('D')).toBeInTheDocument();
-  expect(screen.getByText('B')).toBeInTheDocument();
+  expect(screen.getAllByText('S1')[0]).toBeInTheDocument();
+  expect(screen.getAllByText('D')[0]).toBeInTheDocument();
+  expect(screen.getAllByText('B')[0]).toBeInTheDocument();
 });

--- a/src/NofapCalendar.jsx
+++ b/src/NofapCalendar.jsx
@@ -58,6 +58,7 @@ export default function NofapCalendar({ onBack }) {
               end: r.end,
               relapsed: r.relapsed,
               reason: r.reason,
+              relapseTime: r.relapse_time,
             }))
           );
         }
@@ -94,16 +95,22 @@ export default function NofapCalendar({ onBack }) {
     const compute = () => {
       const updated = {};
       let longest = 0;
-      runs.forEach((r) => {
+      const ordered = [...runs].sort((a, b) => a.start - b.start);
+      ordered.forEach((r) => {
         const startDay = new Date(r.start);
         startDay.setHours(0, 0, 0, 0);
         const endDay = new Date(r.end);
         endDay.setHours(0, 0, 0, 0);
-        for (let d = new Date(startDay), idx = 0; d <= endDay; d.setDate(d.getDate() + 1), idx++) {
+        for (
+          let d = new Date(startDay), idx = 0;
+          d <= endDay;
+          d.setDate(d.getDate() + 1), idx++
+        ) {
           const key = d.toISOString().slice(0, 10);
-          if (r.relapsed && d.getTime() === endDay.getTime()) {
+          const isRelapseDay = r.relapsed && d.getTime() === endDay.getTime();
+          if (isRelapseDay) {
             updated[key] = 'relapse';
-          } else {
+          } else if (!updated[key]) {
             updated[key] = colorForIndex(idx);
           }
         }
@@ -144,16 +151,17 @@ export default function NofapCalendar({ onBack }) {
     return 'white';
   };
 
-  const finishRun = async (reason) => {
+  const finishRun = async (reason, relapseTime) => {
     if (!run) return;
     const relapsed = endType === 'relapse';
     const nowTime = Date.now();
     const entry = { ...run, end: nowTime, relapsed, reason };
+    if (relapsed) entry.relapseTime = relapseTime;
     if (userId && navigator.onLine) {
       if (run.id) {
         await supabaseClient
           .from('runs')
-          .update({ end: nowTime, relapsed, reason })
+          .update({ end: nowTime, relapsed, reason, relapse_time: relapseTime })
           .eq('id', run.id);
       } else {
         await supabaseClient.from('runs').insert({
@@ -162,6 +170,7 @@ export default function NofapCalendar({ onBack }) {
           end: nowTime,
           relapsed,
           reason,
+          relapse_time: relapseTime,
         });
       }
     }
@@ -293,11 +302,16 @@ export default function NofapCalendar({ onBack }) {
               {new Date(r.start).getDate()} {new Date(r.start).toLocaleString('default', { month: 'long' })} {new Date(r.start).getFullYear()} to {new Date(r.end).getDate()} {new Date(r.end).toLocaleString('default', { month: 'long' })} {new Date(r.end).getFullYear()}, {Math.ceil((r.end - r.start) / DAY_MS)} days
             </div>
             <div>Reason: {r.reason || 'N/A'}</div>
+            {r.relapseTime && <div>Relapse at: {r.relapseTime}</div>}
           </div>
         ))}
       </div>
       {showEndModal && (
-        <RunEndModal onSave={finishRun} onClose={() => setShowEndModal(false)} />
+        <RunEndModal
+          type={endType}
+          onSave={finishRun}
+          onClose={() => setShowEndModal(false)}
+        />
       )}
     </div>
   );

--- a/src/RunEndModal.jsx
+++ b/src/RunEndModal.jsx
@@ -1,11 +1,18 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
-export default function RunEndModal({ onSave, onClose }) {
+export default function RunEndModal({ onSave, onClose, type }) {
   const [reason, setReason] = useState('');
+  const [time, setTime] = useState(
+    () => new Date().toISOString().slice(11, 16)
+  );
 
   const handleSave = () => {
-    onSave(reason);
+    if (type === 'relapse') {
+      onSave(reason, time);
+    } else {
+      onSave(reason);
+    }
   };
 
   return (
@@ -18,6 +25,14 @@ export default function RunEndModal({ onSave, onClose }) {
           value={reason}
           onChange={(e) => setReason(e.target.value)}
         />
+        {type === 'relapse' && (
+          <input
+            type="time"
+            className="note-content"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        )}
         <div className="actions">
           <button className="save-button" onClick={handleSave}>Save</button>
         </div>

--- a/supabase-tables.sql
+++ b/supabase-tables.sql
@@ -20,5 +20,6 @@ create table if not exists runs (
   start bigint,
   "end" bigint,
   relapsed boolean,
-  reason text
+  reason text,
+  relapse_time text
 );


### PR DESCRIPTION
## Summary
- record relapse time via new time input in `RunEndModal`
- prevent relapse day color being overwritten in `NofapCalendar`
- store relapse times locally and in database
- display relapse time in run history
- adjust timeline test for multiple text matches
- update SQL schema for `relapse_time`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68639cc768d48322aec3ef4ab10271fe