### PR TITLE
Fix RunEndModal time input

### DIFF
--- a/RunEndModal.jsx
+++ b/RunEndModal.jsx
@@ -4,7 +4,7 @@ import './note-modal.css';
 export default function RunEndModal({ onSave, onClose, type }) {
   const [reason, setReason] = useState('');
   const [time, setTime] = useState(
-    () => new Date().toISOString().slice(11, 16)
+    () => new Date().toTimeString().slice(0, 5)
   );
 
   const handleSave = () => {

--- a/src/RunEndModal.jsx
+++ b/src/RunEndModal.jsx
@@ -4,7 +4,7 @@ import './note-modal.css';
 export default function RunEndModal({ onSave, onClose, type }) {
   const [reason, setReason] = useState('');
   const [time, setTime] = useState(
-    () => new Date().toISOString().slice(11, 16)
+    () => new Date().toTimeString().slice(0, 5)
   );
 
   const handleSave = () => {


### PR DESCRIPTION
## Summary
- ensure RunEndModal in `src` uses local time for default value

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863f6b143f083229b1ff8c50a08de17