### PR TITLE
Add Moodtracker feature

### DIFF
--- a/Moodtracker.jsx
+++ b/Moodtracker.jsx
@@ -1,11 +1,88 @@
-import React from 'react';
-import './placeholder-app.css';
+import React, { useState } from 'react';
+import './moodtracker.css';
+
+const TAGS = [
+  'Happy',
+  'Sad',
+  'Angry',
+  'Excited',
+  'Tired',
+  'Calm',
+  'Anxious',
+];
 
 export default function Moodtracker({ onBack }) {
+  const [score, setScore] = useState(5);
+  const [tags, setTags] = useState([]);
+  const [log, setLog] = useState(() => {
+    const stored = localStorage.getItem('moodLog');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  const toggleTag = (tag) => {
+    setTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const addEntry = () => {
+    const entry = { time: Date.now(), score, tags };
+    const updated = [...log, entry];
+    setLog(updated);
+    localStorage.setItem('moodLog', JSON.stringify(updated));
+    setTags([]);
+    setScore(5);
+  };
+
+  const stars = (s) => '⭐'.repeat(Math.floor(s / 2));
+
   return (
-    <div className="placeholder-app">
-      <button className="back-button" onClick={onBack}>Back</button>
-      <p>Moodtracker coming soon...</p>
+    <div className="moodtracker">
+      <div className="left-panel">
+        <button className="back-button" onClick={onBack}>Back</button>
+        <div className="input-section">
+          <label>
+            Mood score: {score}/10
+            <input
+              type="range"
+              min="0"
+              max="10"
+              value={score}
+              onChange={(e) => setScore(parseInt(e.target.value, 10))}
+            />
+          </label>
+          <div className="tag-options">
+            {TAGS.map((tag) => (
+              <label key={tag} className="tag-option">
+                <input
+                  type="checkbox"
+                  checked={tags.includes(tag)}
+                  onChange={() => toggleTag(tag)}
+                />
+                {tag}
+              </label>
+            ))}
+          </div>
+          <button className="action-button" onClick={addEntry}>
+            Add Entry
+          </button>
+        </div>
+      </div>
+      <div className="right-panel">
+        <div className="mood-log">
+          {log.map((entry, idx) => {
+            const d = new Date(entry.time);
+            const date = d.toLocaleDateString();
+            const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+            return (
+              <div key={idx} className="mood-banner">
+                {date} {time} mood: {entry.tags.join(', ') || 'none'} {stars(entry.score)}{' '}
+                {entry.score}/10
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }

--- a/Moodtracker.test.js
+++ b/Moodtracker.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Moodtracker from './src/Moodtracker.jsx';
+
+test('adds mood entry to log', () => {
+  render(<Moodtracker onBack={() => {}} />);
+  const slider = screen.getByRole('slider');
+  fireEvent.change(slider, { target: { value: '6' } });
+  fireEvent.click(screen.getByLabelText('Sad'));
+  fireEvent.click(screen.getByText(/add entry/i));
+  expect(screen.getByText(/6\/10/)).toBeInTheDocument();
+});

--- a/moodtracker.css
+++ b/moodtracker.css
@@ -1,0 +1,49 @@
+.moodtracker {
+  display: flex;
+  height: 100%;
+}
+
+.left-panel {
+  flex-basis: 70%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.right-panel {
+  flex-basis: 30%;
+  padding-left: 10px;
+  overflow-y: auto;
+}
+
+.input-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tag-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-option {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.mood-log {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mood-banner {
+  background: #333;
+  padding: 6px 10px;
+  border-radius: 6px;
+  color: white;
+  font-size: 0.9em;
+}

--- a/src/Moodtracker.jsx
+++ b/src/Moodtracker.jsx
@@ -1,11 +1,88 @@
-import React from 'react';
-import './placeholder-app.css';
+import React, { useState } from 'react';
+import './moodtracker.css';
+
+const TAGS = [
+  'Happy',
+  'Sad',
+  'Angry',
+  'Excited',
+  'Tired',
+  'Calm',
+  'Anxious',
+];
 
 export default function Moodtracker({ onBack }) {
+  const [score, setScore] = useState(5);
+  const [tags, setTags] = useState([]);
+  const [log, setLog] = useState(() => {
+    const stored = localStorage.getItem('moodLog');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  const toggleTag = (tag) => {
+    setTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const addEntry = () => {
+    const entry = { time: Date.now(), score, tags };
+    const updated = [...log, entry];
+    setLog(updated);
+    localStorage.setItem('moodLog', JSON.stringify(updated));
+    setTags([]);
+    setScore(5);
+  };
+
+  const stars = (s) => '⭐'.repeat(Math.floor(s / 2));
+
   return (
-    <div className="placeholder-app">
-      <button className="back-button" onClick={onBack}>Back</button>
-      <p>Moodtracker coming soon...</p>
+    <div className="moodtracker">
+      <div className="left-panel">
+        <button className="back-button" onClick={onBack}>Back</button>
+        <div className="input-section">
+          <label>
+            Mood score: {score}/10
+            <input
+              type="range"
+              min="0"
+              max="10"
+              value={score}
+              onChange={(e) => setScore(parseInt(e.target.value, 10))}
+            />
+          </label>
+          <div className="tag-options">
+            {TAGS.map((tag) => (
+              <label key={tag} className="tag-option">
+                <input
+                  type="checkbox"
+                  checked={tags.includes(tag)}
+                  onChange={() => toggleTag(tag)}
+                />
+                {tag}
+              </label>
+            ))}
+          </div>
+          <button className="action-button" onClick={addEntry}>
+            Add Entry
+          </button>
+        </div>
+      </div>
+      <div className="right-panel">
+        <div className="mood-log">
+          {log.map((entry, idx) => {
+            const d = new Date(entry.time);
+            const date = d.toLocaleDateString();
+            const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+            return (
+              <div key={idx} className="mood-banner">
+                {date} {time} mood: {entry.tags.join(', ') || 'none'} {stars(entry.score)}{' '}
+                {entry.score}/10
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/moodtracker.css
+++ b/src/moodtracker.css
@@ -1,0 +1,49 @@
+.moodtracker {
+  display: flex;
+  height: 100%;
+}
+
+.left-panel {
+  flex-basis: 70%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.right-panel {
+  flex-basis: 30%;
+  padding-left: 10px;
+  overflow-y: auto;
+}
+
+.input-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tag-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-option {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.mood-log {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mood-banner {
+  background: #333;
+  padding: 6px 10px;
+  border-radius: 6px;
+  color: white;
+  font-size: 0.9em;
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.4.11';
+export const APP_VERSION = '0.4.12';


### PR DESCRIPTION
## Summary
- implement a basic mood tracker app
- style layout in new CSS
- keep duplicate files for Electron build
- test mood entries
- bump version to 0.4.12

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864200b2dd083229dbd658ba9319c24