### PR TITLE
Add Todo & Goals app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
+import TodoGoals from './TodoGoals.jsx';
 import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
@@ -47,6 +48,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
   const [showQuadrantComb, setShowQuadrantComb] = useState(false);
+  const [showTodoGoals, setShowTodoGoals] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
   const [autoLog, setAutoLog] = useState(
@@ -95,9 +97,7 @@ export default function QuadrantPage({ initialTab }) {
     return (
       <QuestProvider>
         <ActivityLogger enabled={autoLog} />
-        <div className="fullpage-calendar">
-          <Calendar onBack={() => setShowCalendarApp(false)} />
-        </div>
+        <Calendar onBack={() => setShowCalendarApp(false)} />
       </QuestProvider>
     );
   }
@@ -156,6 +156,8 @@ export default function QuadrantPage({ initialTab }) {
               <QuadrantCombinaisons onBack={() => setShowQuadrantComb(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
+              ) : showTodoGoals ? (
+              <TodoGoals onBack={() => setShowTodoGoals(false)} />
             ) : (
               <div className="feature-cards">
                 <div className="app-card" onClick={() => setShowJournal(true)}>
@@ -209,6 +211,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowAnima(true)}>
                   <div className="star-icon">💃</div>
                   <span>Anima</span>
+                </div>
+                <div className="app-card" onClick={() => setShowTodoGoals(true)}>
+                  <div className="star-icon">✅</div>
+                  <span>Todo & Goals</span>
                 </div>
               </div>
             )}

--- a/src/TodoGoals.jsx
+++ b/src/TodoGoals.jsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect } from 'react';
+import './todo-goals.css';
+
+const TIMEFRAMES = ['All Goals', 'Daily', 'Weekly', 'Monthly', 'Yearly'];
+const QUADRANTS = [
+  { key: 'UI', label: 'Urgent & Important' },
+  { key: 'NI', label: 'Not Urgent & Important' },
+  { key: 'UN', label: 'Urgent & Not Important' },
+  { key: 'NN', label: 'Not Urgent & Not Important' },
+];
+
+export default function TodoGoals({ onBack }) {
+  const [activeTab, setActiveTab] = useState(TIMEFRAMES[0]);
+  const [tasks, setTasks] = useState(() => {
+    const stored = localStorage.getItem('todoGoals');
+    return stored ? JSON.parse(stored) : {};
+  });
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    localStorage.setItem('todoGoals', JSON.stringify(tasks));
+  }, [tasks]);
+
+  const handleAdd = () => {
+    if (!input.trim()) return;
+    const id = Date.now().toString();
+    setTasks((prev) => {
+      const next = { ...prev };
+      const list = next[activeTab] || [];
+      list.push({ id, text: input.trim(), quadrant: 'NI' });
+      next[activeTab] = list;
+      return next;
+    });
+    setInput('');
+  };
+
+  const handleDragStart = (e, task, timeframe) => {
+    e.dataTransfer.setData('task-id', task.id);
+    e.dataTransfer.setData('from-timeframe', timeframe);
+    e.dataTransfer.setData('quadrant', task.quadrant);
+  };
+
+  const handleDrop = (e, quadrant, timeframe) => {
+    e.preventDefault();
+    const id = e.dataTransfer.getData('task-id');
+    const from = e.dataTransfer.getData('from-timeframe');
+    const fromQuadrant = e.dataTransfer.getData('quadrant');
+    if (!id) return;
+    setTasks((prev) => {
+      const next = { ...prev };
+      let moved;
+      next[from] = (next[from] || []).filter((t) => {
+        if (t.id === id) {
+          moved = t;
+          return false;
+        }
+        return true;
+      });
+      if (!moved) return prev;
+      const targetQuadrant = quadrant || moved.quadrant || fromQuadrant;
+      moved = { ...moved, quadrant: targetQuadrant };
+      const dest = next[timeframe] || [];
+      dest.push(moved);
+      next[timeframe] = dest;
+      return next;
+    });
+  };
+
+  const allowDrop = (e) => e.preventDefault();
+
+  const renderQuadrant = (qKey) => {
+    const items = (tasks[activeTab] || []).filter((t) => t.quadrant === qKey);
+    return (
+      <div
+        className="quadrant"
+        onDragOver={allowDrop}
+        onDrop={(e) => handleDrop(e, qKey, activeTab)}
+      >
+        {items.map((task) => (
+          <div
+            key={task.id}
+            className="task"
+            draggable
+            onDragStart={(e) => handleDragStart(e, task, activeTab)}
+          >
+            {task.text}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="todo-goals">
+      {onBack && (
+        <button className="back-button" onClick={onBack}>Back</button>
+      )}
+      <div className="tabs">
+        {TIMEFRAMES.map((t) => (
+          <button
+            key={t}
+            className={activeTab === t ? 'active' : ''}
+            onClick={() => setActiveTab(t)}
+            onDragOver={allowDrop}
+            onDrop={(e) => handleDrop(e, null, t)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="eisenhower">
+        {QUADRANTS.map((q) => (
+          <div key={q.key} className="quadrant-wrapper">
+            <h3>{q.label}</h3>
+            {renderQuadrant(q.key)}
+          </div>
+        ))}
+      </div>
+      <div className="add">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Add goal"
+        />
+        <button onClick={handleAdd}>Add</button>
+      </div>
+    </div>
+  );
+}

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -88,11 +88,6 @@
   left: 50% !important;
   width: 50% !important;
 }
-.fullpage-calendar {
-  position: fixed;
-  inset: 0;
-  background: #000;
-}
 
 
 /* Override default blue highlights */

--- a/src/todo-goals.css
+++ b/src/todo-goals.css
@@ -1,0 +1,84 @@
+.todo-goals {
+  padding: 20px;
+  color: #e6e7eb;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.tabs button {
+  background: #17181d;
+  color: #e6e7eb;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.tabs button.active {
+  background: #0d0e11;
+}
+
+.eisenhower {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+  gap: 10px;
+}
+
+.quadrant-wrapper {
+  background: #2c2d33;
+  padding: 8px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.quadrant-wrapper h3 {
+  margin: 0 0 6px 0;
+  font-size: 14px;
+}
+
+.quadrant {
+  flex: 1;
+  min-height: 80px;
+  background: #17181d;
+  border-radius: 4px;
+  padding: 4px;
+  overflow-y: auto;
+}
+
+.task {
+  background: #0d0e11;
+  padding: 4px 6px;
+  border-radius: 4px;
+  margin-bottom: 4px;
+  cursor: grab;
+}
+
+.add {
+  margin-top: 10px;
+  display: flex;
+  gap: 6px;
+}
+
+.add input {
+  flex: 1;
+  background: #17181d;
+  color: #e6e7eb;
+  border: none;
+  padding: 6px;
+  border-radius: 4px;
+}
+
+.add button {
+  background: #17181d;
+  color: #e6e7eb;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- implement Todo & Goals component with tabs and an Eisenhower matrix
- style the new component
- integrate Todo & Goals feature into main app
- fix stray full-screen calendar container covering the interface

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68644cfd8a94832296aeaa0addb118ef