### PR TITLE
Add settings modal with auto log toggle

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -16,6 +16,8 @@ import Anima from './Anima.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
+import SettingsModal from './SettingsModal.jsx';
+import ActivityLogger from './ActivityLogger.jsx';
 import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
@@ -46,6 +48,14 @@ export default function QuadrantPage({ initialTab }) {
   const [showAnima, setShowAnima] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
+  const [showSettings, setShowSettings] = useState(false);
+  const [autoLog, setAutoLog] = useState(
+    () => localStorage.getItem('autoLog') === 'true'
+  );
+
+  useEffect(() => {
+    localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
+  }, [autoLog]);
 
   useEffect(() => {
     const loadAvatar = async () => {
@@ -83,6 +93,7 @@ export default function QuadrantPage({ initialTab }) {
 
   return (
     <QuestProvider>
+      <ActivityLogger enabled={autoLog} />
       <div className="app-container">
       <aside className="sidebar">
         {tabs.map((tab) => (
@@ -95,6 +106,12 @@ export default function QuadrantPage({ initialTab }) {
           </div>
         ))}
         <div className="bottom-buttons">
+          <div className="settings-button" onClick={() => setShowSettings(true)}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M13.6006 21.0761L19.0608 17.9236C19.6437 17.5871 19.9346 17.4188 20.1465 17.1834C20.3341 16.9751 20.4759 16.7297 20.5625 16.4632C20.6602 16.1626 20.6602 15.8267 20.6602 15.1568V8.84268C20.6602 8.17277 20.6602 7.83694 20.5625 7.53638C20.4759 7.26982 20.3341 7.02428 20.1465 6.816C19.9355 6.58161 19.6453 6.41405 19.0674 6.08043L13.5996 2.92359C13.0167 2.58706 12.7259 2.41913 12.416 2.35328C12.1419 2.295 11.8584 2.295 11.5843 2.35328C11.2744 2.41914 10.9826 2.58706 10.3997 2.92359L4.93843 6.07666C4.35623 6.41279 4.06535 6.58073 3.85352 6.816C3.66597 7.02428 3.52434 7.26982 3.43773 7.53638C3.33984 7.83765 3.33984 8.17436 3.33984 8.84742V15.1524C3.33984 15.8254 3.33984 16.1619 3.43773 16.4632C3.52434 16.7297 3.66597 16.9751 3.85352 17.1834C4.06548 17.4188 4.35657 17.5871 4.93945 17.9236L10.3997 21.0761C10.9826 21.4126 11.2744 21.5806 11.5843 21.6465C11.8584 21.7047 12.1419 21.7047 12.416 21.6465C12.7259 21.5806 13.0177 21.4126 13.6006 21.0761Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M9 11.9998C9 13.6566 10.3431 14.9998 12 14.9998C13.6569 14.9998 15 13.6566 15 11.9998C15 10.3429 13.6569 8.99976 12 8.99976C10.3431 8.99976 9 10.3429 9 11.9998Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
           <div className="profile-button" onClick={() => setShowProfile(true)}>
             <img className="sidebar-avatar" src={avatarUrl} alt="Profile" />
           </div>
@@ -195,7 +212,14 @@ export default function QuadrantPage({ initialTab }) {
           onAvatarUpdated={handleAvatarUpdated}
         />
       )}
-        <VersionLabel />
+      {showSettings && (
+        <SettingsModal
+          onClose={() => setShowSettings(false)}
+          autoLog={autoLog}
+          onToggleAutoLog={setAutoLog}
+        />
+      )}
+      <VersionLabel />
       </div>
     </QuestProvider>
   );

--- a/SettingsModal.jsx
+++ b/SettingsModal.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import './note-modal.css';
+
+export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <input
+            type="checkbox"
+            checked={autoLog}
+            onChange={e => onToggleAutoLog(e.target.checked)}
+          />
+          Auto log calendar
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,7 +61,8 @@ body {
 }
 
 .home-button,
-.profile-button {
+.profile-button,
+.settings-button {
   width: 50px;
   height: 50px;
   background: white;
@@ -73,6 +74,12 @@ body {
   cursor: pointer;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+.settings-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
 }
 
 body.character-page .content {

--- a/styles.css
+++ b/styles.css
@@ -61,7 +61,8 @@ body {
 }
 
 .home-button,
-.profile-button {
+.profile-button,
+.settings-button {
   width: 50px;
   height: 50px;
   background: white;
@@ -73,6 +74,12 @@ body {
   cursor: pointer;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+.settings-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
 }
 
 body.character-page .content {


### PR DESCRIPTION
## Summary
- add a new `SettingsModal` component for app preferences
- show a new settings button above the profile picture
- persist the auto log preference and connect it to `ActivityLogger`
- style the settings button in both style sheets

## Testing
- `npx -y jest` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff4fab588322a76b3465af4d103f