### PR TITLE
Fix login container placement

### DIFF
--- a/src/auth.css
+++ b/src/auth.css
@@ -18,7 +18,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  padding-left: 5%;
+  padding: 0 0 0 5%;
   font-family: 'Exodus', sans-serif;
   color: white;
   overflow: hidden;
@@ -35,10 +35,9 @@
 }
 
 .auth-box {
-  background: rgba(0, 0, 0, 0.48);
-  padding: 40px 5%;
-  width: calc(100% - 5%);
-  height: 100vh;
+  background: rgba(0, 0, 0, 0.7);
+  padding: 40px;
+  width: 360px;
   border-radius: 8px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
   display: flex;


### PR DESCRIPTION
## Summary
- align login container to left side with padding

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869088745508322a3b52a9094621160