### PR TITLE
Fix alignment for login screen

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -13,12 +13,12 @@
 }
 
 .auth-container {
-  position: relative;
-  height: 100vh;
+  position: fixed;
+  inset: 0;
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   align-items: center;
-  padding-left: 5%;
+  padding: 0 5% 0 0;
   font-family: 'Exodus', sans-serif;
   color: white;
   overflow: hidden;
@@ -43,10 +43,11 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  box-sizing: border-box;
 }
 
 .auth-box form {
-  width: 100%;
+  width: 360px;
   display: flex;
   flex-direction: column;
 }
@@ -65,6 +66,7 @@
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.1);
   color: white;
+  box-sizing: border-box;
 }
 
 .auth-box input::placeholder {
@@ -80,21 +82,21 @@
   font-weight: bold;
   cursor: pointer;
   color: white;
-@@ -87,47 +95,48 @@
-  background: #4752d3;
+  transition: background 0.2s;
+  box-sizing: border-box;
 }
 
- .primary-btn {
+.primary-btn {
   background: #5865f2;
   padding: 8px 20px;
   border-radius: 20px;
   font-weight: 600;
   font-size: 15px;
-  }
+}
 
-  .primary-btn:hover {
-      background: #4752d3;
-  }
+.primary-btn:hover {
+  background: #4752d3;
+}
 
 .secondary-btn {
   background: #4f545c;
@@ -127,12 +129,13 @@
 
 .password-wrapper input {
   width: 100%;
-  padding-right: 36px;
+  padding-right: 48px;
+  box-sizing: border-box;
 }
 
 .toggle-password {
   position: absolute;
-  left: 358px;
+  right: 12px;
   top: 50%;
   transform: translateY(-50%);
   background: none;

--- a/src/auth.css
+++ b/src/auth.css
@@ -18,7 +18,7 @@
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  padding: 0 0 0 5%;
+  padding: 0 5% 0 0;
   font-family: 'Exodus', sans-serif;
   color: white;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- adjust the auth container styling so the login form appears centered on the right side
- sync src/auth.css and auth.css

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686910d35e78832283f2a9a010644686