### PR TITLE
Add Activity application

### DIFF
--- a/src/ActivityApp.jsx
+++ b/src/ActivityApp.jsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react';
+import './placeholder-app.css';
+import './activity-app.css';
+
+const SUGGESTIONS = [
+  { title: 'Meditation', duration: 30, reward: 5, cost: 0 },
+  { title: 'Workout', duration: 45, reward: 8, cost: 0 },
+  { title: 'Reading', duration: 20, reward: 3, cost: 0 },
+];
+
+export default function ActivityApp({ onBack }) {
+  const [title, setTitle] = useState('');
+  const [duration, setDuration] = useState(30);
+  const [reward, setReward] = useState(0);
+  const [cost, setCost] = useState(0);
+
+  const addEvent = (kind, startTime) => {
+    const start = startTime ? new Date(startTime) : new Date();
+    const end = new Date(start.getTime() + duration * 60000);
+    const ev = {
+      title: title || 'Activity',
+      start: start.toISOString(),
+      end: end.toISOString(),
+      kind,
+      color: '#34a853',
+      reward,
+      cost,
+    };
+    const events = JSON.parse(localStorage.getItem('calendarEvents') || '[]');
+    events.push(ev);
+    localStorage.setItem('calendarEvents', JSON.stringify(events));
+    window.dispatchEvent(new CustomEvent('calendar-add-event', { detail: ev }));
+  };
+
+  const handleStart = () => {
+    if (!title.trim()) return;
+    addEvent('done');
+    setTitle('');
+  };
+
+  const handleSchedule = () => {
+    if (!title.trim()) return;
+    const input = prompt('Start time (YYYY-MM-DDTHH:MM)', new Date().toISOString().slice(0,16));
+    if (!input) return;
+    addEvent('planned', input);
+    setTitle('');
+  };
+
+  const applySuggestion = (s) => {
+    setTitle(s.title);
+    setDuration(s.duration);
+    setReward(s.reward);
+    setCost(s.cost);
+  };
+
+  return (
+    <div className="placeholder-app activity-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <h2>Activity</h2>
+      <div className="activity-form">
+        <input
+          className="activity-input"
+          placeholder="Activity"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <input
+          type="number"
+          min="1"
+          className="activity-input short"
+          value={duration}
+          onChange={(e) => setDuration(Number(e.target.value))}
+        />
+        <input
+          type="number"
+          className="activity-input short"
+          value={reward}
+          onChange={(e) => setReward(Number(e.target.value))}
+        />
+        <input
+          type="number"
+          className="activity-input short"
+          value={cost}
+          onChange={(e) => setCost(Number(e.target.value))}
+        />
+        <button className="save-button" onClick={handleStart}>Start Now</button>
+        <button className="save-button" onClick={handleSchedule}>Schedule</button>
+      </div>
+      <h3>Suggestions</h3>
+      <ul className="activity-suggestions">
+        {SUGGESTIONS.map((s) => (
+          <li key={s.title}>
+            <button className="save-button" onClick={() => applySuggestion(s)}>
+              {s.title} ({s.duration}m, +{s.reward}xp)
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
 import TodoGoals from './TodoGoals.jsx';
+import ActivityApp from './ActivityApp.jsx';
 import SettingsModal from './SettingsModal.jsx';
 import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
@@ -50,6 +51,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showAnima, setShowAnima] = useState(false);
   const [showQuadrantComb, setShowQuadrantComb] = useState(false);
   const [showTodoGoals, setShowTodoGoals] = useState(false);
+  const [showActivity, setShowActivity] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
@@ -166,6 +168,8 @@ export default function QuadrantPage({ initialTab }) {
               <Anima onBack={() => setShowAnima(false)} />
               ) : showTodoGoals ? (
               <TodoGoals onBack={() => setShowTodoGoals(false)} />
+            ) : showActivity ? (
+              <ActivityApp onBack={() => setShowActivity(false)} />
             ) : (
               <div className="feature-cards">
                 <div className="app-card" onClick={() => setShowJournal(true)}>
@@ -223,6 +227,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowTodoGoals(true)}>
                   <div className="star-icon">✅</div>
                   <span>Todo & Goals</span>
+                </div>
+                <div className="app-card" onClick={() => setShowActivity(true)}>
+                  <div className="star-icon">🏃</div>
+                  <span>Activity</span>
                 </div>
               </div>
             )}

--- a/src/activity-app.css
+++ b/src/activity-app.css
@@ -1,0 +1,31 @@
+.activity-app {
+  width: 100%;
+  padding: 20px;
+}
+
+.activity-form {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.activity-input {
+  background: #17181d;
+  color: #e6e7eb;
+  border: none;
+  padding: 6px;
+  border-radius: 4px;
+}
+
+.activity-input.short {
+  width: 80px;
+}
+
+.activity-suggestions {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.5.0';
+export const APP_VERSION = '0.5.1';


### PR DESCRIPTION
## Summary
- add simple Activity app for starting or scheduling an activity
- register Activity app in dashboard
- bump version to 0.5.1

## Testing
- `npm test`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68693367b220832291bfec66f9af7144