### PR TITLE
Add premium X resource placeholder

### DIFF
--- a/ResourceContext.jsx
+++ b/ResourceContext.jsx
@@ -8,6 +8,11 @@ export function ResourceProvider({ children }) {
     return stored ? parseInt(stored, 10) : 0;
   });
 
+  const [xResource, setXResource] = useState(() => {
+    const stored = localStorage.getItem('worldXResource');
+    return stored ? parseInt(stored, 10) : 0;
+  });
+
   useEffect(() => {
     const interval = setInterval(() => {
       setResource((r) => r + 1);
@@ -19,11 +24,18 @@ export function ResourceProvider({ children }) {
     localStorage.setItem('worldResource', resource);
   }, [resource]);
 
+  useEffect(() => {
+    localStorage.setItem('worldXResource', xResource);
+  }, [xResource]);
+
   const add = (amount) => setResource((r) => r + amount);
   const spend = (amount) => setResource((r) => Math.max(0, r - amount));
 
+  const addX = (amount) => setXResource((r) => r + amount);
+  const spendX = (amount) => setXResource((r) => Math.max(0, r - amount));
+
   return (
-    <ResourceContext.Provider value={{ resource, add, spend }}>
+    <ResourceContext.Provider value={{ resource, xResource, add, spend, addX, spendX }}>
       {children}
     </ResourceContext.Provider>
   );

--- a/ResourceIndicator.jsx
+++ b/ResourceIndicator.jsx
@@ -3,11 +3,12 @@ import { useResource } from './ResourceContext.jsx';
 import './resource-indicator.css';
 
 export default function ResourceIndicator() {
-  const { resource } = useResource();
+  const { resource, xResource } = useResource();
 
   return (
     <div className="resource-box">
-      <div className="resource-circle">{resource}</div>
+      <div className="resource-circle">{resource} R</div>
+      <div className="resource-circle">{xResource} X</div>
     </div>
   );
 }

--- a/resource-indicator.css
+++ b/resource-indicator.css
@@ -4,6 +4,8 @@
   left: 50%;
   transform: translateX(-50%);
   pointer-events: none;
+  display: flex;
+  gap: 10px;
 }
 
 .resource-circle {

--- a/src/ResourceContext.jsx
+++ b/src/ResourceContext.jsx
@@ -8,6 +8,11 @@ export function ResourceProvider({ children }) {
     return stored ? parseInt(stored, 10) : 0;
   });
 
+  const [xResource, setXResource] = useState(() => {
+    const stored = localStorage.getItem('worldXResource');
+    return stored ? parseInt(stored, 10) : 0;
+  });
+
   useEffect(() => {
     const interval = setInterval(() => {
       setResource((r) => r + 1);
@@ -19,11 +24,18 @@ export function ResourceProvider({ children }) {
     localStorage.setItem('worldResource', resource);
   }, [resource]);
 
+  useEffect(() => {
+    localStorage.setItem('worldXResource', xResource);
+  }, [xResource]);
+
   const add = (amount) => setResource((r) => r + amount);
   const spend = (amount) => setResource((r) => Math.max(0, r - amount));
 
+  const addX = (amount) => setXResource((r) => r + amount);
+  const spendX = (amount) => setXResource((r) => Math.max(0, r - amount));
+
   return (
-    <ResourceContext.Provider value={{ resource, add, spend }}>
+    <ResourceContext.Provider value={{ resource, xResource, add, spend, addX, spendX }}>
       {children}
     </ResourceContext.Provider>
   );

--- a/src/ResourceIndicator.jsx
+++ b/src/ResourceIndicator.jsx
@@ -3,11 +3,12 @@ import { useResource } from './ResourceContext.jsx';
 import './resource-indicator.css';
 
 export default function ResourceIndicator() {
-  const { resource } = useResource();
+  const { resource, xResource } = useResource();
 
   return (
     <div className="resource-box">
-      <div className="resource-circle">{resource}</div>
+      <div className="resource-circle">{resource} R</div>
+      <div className="resource-circle">{xResource} X</div>
     </div>
   );
 }

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -10,6 +10,10 @@ export default function World() {
     const stored = localStorage.getItem('resourceR');
     return stored ? parseInt(stored, 10) : 0;
   });
+  const [xResource, setXResource] = useState(() => {
+    const stored = localStorage.getItem('resourceX');
+    return stored ? parseInt(stored, 10) : 0;
+  });
   const [userId, setUserId] = useState(null);
   const { quests, addQuest, acceptQuest } = useQuests();
   const [showModal, setShowModal] = useState(false);
@@ -66,6 +70,10 @@ export default function World() {
       supabaseClient.from('profiles').update({ resources: resource }).eq('id', userId);
     }
   }, [resource, userId]);
+
+  useEffect(() => {
+    localStorage.setItem('resourceX', xResource);
+  }, [xResource]);
 
   const handleQuestAdd = (q) => {
     addQuest(q);
@@ -140,7 +148,7 @@ export default function World() {
           initialInstinct={profile.instinct || ''}
         />
       )}
-      <div className="resource-box">{resource} R</div>
+      <div className="resource-box">{resource} R | {xResource} X</div>
       {showPublished && (
         <div className="published-popup">
           <span className="checkmark">✔</span> Quest published

--- a/src/resource-indicator.css
+++ b/src/resource-indicator.css
@@ -4,6 +4,8 @@
   left: 50%;
   transform: translateX(-50%);
   pointer-events: none;
+  display: flex;
+  gap: 10px;
 }
 
 .resource-circle {


### PR DESCRIPTION
## Summary
- track a new X resource alongside existing R
- show both R and X in ResourceIndicator
- show both R and X in World screen
- adjust styles for two resource circles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686933f26134832292e2428f51a2c3bd