### PR TITLE
Enhance activity tab with meditation XP bar

### DIFF
--- a/src/activity-app.css
+++ b/src/activity-app.css
@@ -29,3 +29,30 @@
   gap: 8px;
   flex-wrap: wrap;
 }
+
+.activity-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.activity-icon {
+  margin-right: 4px;
+}
+
+.reward-label {
+  margin-left: 4px;
+}
+
+.xp-bar {
+  width: 100px;
+  height: 8px;
+  background: #333;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.xp-fill {
+  height: 100%;
+  background: #4caf50;
+}


### PR DESCRIPTION
## Summary
- tweak Activity app to focus on **Meditation**
- compute rewards based on activity duration and add an icon
- track minutes in `localStorage` and display an XP bar for each suggestion
- style new activity suggestion elements

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686a8679de488322bfc21d28b9628c91