### PR TITLE
Enhance activity tab with drag-and-drop launcher

### DIFF
--- a/src/activity-app.css
+++ b/src/activity-app.css
@@ -29,3 +29,43 @@
   gap: 8px;
   flex-wrap: wrap;
 }
+
+.activity-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.activity-icon {
+  margin-right: 4px;
+}
+
+.reward-label {
+  margin-left: 4px;
+}
+
+.xp-bar {
+  width: 100px;
+  height: 8px;
+  background: #333;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.xp-fill {
+  height: 100%;
+  background: #4caf50;
+}
+
+.activity-launcher {
+  width: 100%;
+  padding: 10px;
+  border: 2px dashed #555;
+  border-radius: 6px;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+.timer {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- expand suggestions list with specific activities
- add drag-and-drop activity launcher with timer display
- compute reward when changing duration
- style launcher and timer

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686a8679de488322bfc21d28b9628c91