### PR TITLE
Add orb app and window size setting

### DIFF
--- a/FifthMain.jsx
+++ b/FifthMain.jsx
@@ -3,7 +3,6 @@ import NoteModal from './NoteModal.jsx';
 import NotesListModal from './NotesListModal.jsx';
 import './main-page.css';
 import QuadrantMenu from './QuadrantMenu.jsx';
-import Orb from './Orb.jsx';
 
 export default function FifthMain({ onSelectQuadrant }) {
   const MIN_WIDTH = 253;
@@ -61,9 +60,7 @@ export default function FifthMain({ onSelectQuadrant }) {
       <div className="side left" style={{ width: leftWidth }}>
         <div className="drag-handle" onMouseDown={startLeftDrag}></div>
       </div>
-      <div className="content-area">
-        <Orb />
-      </div>
+      <div className="content-area"></div>
       <div className="side right" style={{ width: rightWidth }}>
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>

--- a/Orb.jsx
+++ b/Orb.jsx
@@ -12,7 +12,7 @@ const zones = [
   { id: 'lore', label: 'Lore / Memory' }
 ];
 
-export default function Orb() {
+export default function Orb({ onBack }) {
   const [text, setText] = useState('');
   const [drops, setDrops] = useState({});
 
@@ -35,7 +35,11 @@ export default function Orb() {
   };
 
   return (
-    <div className="orb-container">
+    <div>
+      {onBack && (
+        <button className="back-button" onClick={onBack}>Back</button>
+      )}
+      <div className="orb-container">
       <textarea
         className="orb-center"
         value={text}
@@ -55,6 +59,7 @@ export default function Orb() {
           {drops[z.id] && <p className="drop-text">{drops[z.id]}</p>}
         </div>
       ))}
+      </div>
     </div>
   );
 }

--- a/SettingsModal.jsx
+++ b/SettingsModal.jsx
@@ -1,17 +1,43 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './note-modal.css';
 
 export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
+  const resolutions = ['800x600', '1024x768', '1280x720', '1600x900', '1920x1080'];
+  const [resolution, setResolution] = useState(() => {
+    const w = localStorage.getItem('windowWidth') || '1600';
+    const h = localStorage.getItem('windowHeight') || '900';
+    return `${w}x${h}`;
+  });
+
+  const changeRes = (e) => {
+    const val = e.target.value;
+    setResolution(val);
+    const [w, h] = val.split('x').map(Number);
+    localStorage.setItem('windowWidth', w);
+    localStorage.setItem('windowHeight', h);
+    if (window.electronAPI && window.electronAPI.setWindowSize) {
+      window.electronAPI.setWindowSize(w, h);
+    }
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
         <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
           <input
             type="checkbox"
             checked={autoLog}
-            onChange={e => onToggleAutoLog(e.target.checked)}
+            onChange={(e) => onToggleAutoLog(e.target.checked)}
           />
           Auto log calendar
+        </label>
+        <label className="note-label">
+          Resolution
+          <select value={resolution} onChange={changeRes}>
+            {resolutions.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
         </label>
       </div>
     </div>

--- a/electron-main.js
+++ b/electron-main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, Menu } = require('electron');
+const { app, BrowserWindow, Menu, ipcMain } = require('electron');
 const activeWindow = require('active-win');
 const path = require('path');
 let mainWindow;
@@ -66,6 +66,12 @@ function createWindow() {
   };
   setInterval(poll, 10000);
 }
+
+ipcMain.handle('set-window-size', (_e, { width, height }) => {
+  if (mainWindow) {
+    mainWindow.setSize(Number(width), Number(height));
+  }
+});
 
 app.whenReady().then(createWindow);
 

--- a/main.jsx
+++ b/main.jsx
@@ -2,4 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import PageRouter from './PageRouter.jsx';
 
+const width = localStorage.getItem('windowWidth');
+const height = localStorage.getItem('windowHeight');
+if (width && height && window.electronAPI && window.electronAPI.setWindowSize) {
+  window.electronAPI.setWindowSize(Number(width), Number(height));
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(<PageRouter />);

--- a/preload.js
+++ b/preload.js
@@ -4,4 +4,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onGoHome: (callback) => ipcRenderer.on('go-home', callback),
   onDisconnect: (callback) => ipcRenderer.on('disconnect', callback),
   onActivity: (callback) => ipcRenderer.on('activity', callback),
+  setWindowSize: (width, height) => ipcRenderer.invoke('set-window-size', { width, height }),
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
 import TodoGoals from './TodoGoals.jsx';
 import ActivityApp from './ActivityApp.jsx';
+import Orb from '../Orb.jsx';
 import SettingsModal from './SettingsModal.jsx';
 import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
@@ -52,6 +53,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showQuadrantComb, setShowQuadrantComb] = useState(false);
   const [showTodoGoals, setShowTodoGoals] = useState(false);
   const [showActivity, setShowActivity] = useState(false);
+  const [showOrb, setShowOrb] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
@@ -170,6 +172,8 @@ export default function QuadrantPage({ initialTab }) {
               <TodoGoals onBack={() => setShowTodoGoals(false)} />
             ) : showActivity ? (
               <ActivityApp onBack={() => setShowActivity(false)} />
+            ) : showOrb ? (
+              <Orb onBack={() => setShowOrb(false)} />
             ) : (
               <div className="feature-cards">
                 <div className="app-card" onClick={() => setShowJournal(true)}>
@@ -231,6 +235,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowActivity(true)}>
                   <div className="star-icon">🏃</div>
                   <span>Activity</span>
+                </div>
+                <div className="app-card" onClick={() => setShowOrb(true)}>
+                  <div className="star-icon">🧿</div>
+                  <span>Orb</span>
                 </div>
               </div>
             )}

--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -3,7 +3,6 @@ import NoteModal from './NoteModal.jsx';
 import NotesListModal from './NotesListModal.jsx';
 import './main-page.css';
 import QuadrantMenu from './QuadrantMenu.jsx';
-import Orb from '../Orb.jsx';
 
 export default function FifthMain({ onSelectQuadrant }) {
   const MIN_WIDTH = 253;
@@ -61,9 +60,7 @@ export default function FifthMain({ onSelectQuadrant }) {
       <div className="side left" style={{ width: leftWidth }}>
         <div className="drag-handle" onMouseDown={startLeftDrag}></div>
       </div>
-      <div className="content-area">
-        <Orb />
-      </div>
+      <div className="content-area"></div>
       <div className="side right" style={{ width: rightWidth }}>
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>

--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -1,7 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './note-modal.css';
 
 export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
+  const resolutions = ['800x600', '1024x768', '1280x720', '1600x900', '1920x1080'];
+  const [resolution, setResolution] = useState(() => {
+    const w = localStorage.getItem('windowWidth') || '1600';
+    const h = localStorage.getItem('windowHeight') || '900';
+    return `${w}x${h}`;
+  });
+
+  const changeRes = (e) => {
+    const val = e.target.value;
+    setResolution(val);
+    const [w, h] = val.split('x').map(Number);
+    localStorage.setItem('windowWidth', w);
+    localStorage.setItem('windowHeight', h);
+    if (window.electronAPI && window.electronAPI.setWindowSize) {
+      window.electronAPI.setWindowSize(w, h);
+    }
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()}>
@@ -12,6 +30,14 @@ export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
             onChange={e => onToggleAutoLog(e.target.checked)}
           />
           Auto log calendar
+        </label>
+        <label className="note-label">
+          Resolution
+          <select value={resolution} onChange={changeRes}>
+            {resolutions.map(r => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
         </label>
       </div>
     </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,4 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import PageRouter from './PageRouter.jsx';
 
+const width = localStorage.getItem('windowWidth');
+const height = localStorage.getItem('windowHeight');
+if (width && height && window.electronAPI && window.electronAPI.setWindowSize) {
+  window.electronAPI.setWindowSize(Number(width), Number(height));
+}
+
 ReactDOM.createRoot(document.getElementById('root')).render(<PageRouter />);


### PR DESCRIPTION
## Summary
- add `Orb` app to training page and remove from main page
- allow resizing of the Electron window via settings
- persist resolution preference and apply on startup

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ccc49fe6483228c8ffd1626cb0102