### PR TITLE
Embed contract placeholders in World

### DIFF
--- a/src/World.jsx
+++ b/src/World.jsx
@@ -149,6 +149,22 @@ export default function World() {
         />
       )}
       <h3 className="contracts-header">Contracts</h3>
+      <div className="contracts-grid">
+        <div className="contracts-tall-column">
+          <div className="contract-box tall" id="contract-tall-1" />
+          <div className="contract-box tall" id="contract-tall-2" />
+        </div>
+        <div className="contracts-wide-column">
+          <div className="contract-box wide" id="contract-wide-top" />
+          <div className="contract-box wide" id="contract-wide-bottom" />
+        </div>
+        <div className="contracts-small-grid">
+          <div className="contract-box small" id="contract-small-1" />
+          <div className="contract-box small" id="contract-small-2" />
+          <div className="contract-box small" id="contract-small-3" />
+          <div className="contract-box small" id="contract-small-4" />
+        </div>
+      </div>
       <div className="resource-box">{resource} R | {xResource} X</div>
       {showPublished && (
         <div className="published-popup">

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.5.2';
+export const APP_VERSION = '0.5.3';

--- a/src/world.css
+++ b/src/world.css
@@ -141,3 +141,46 @@
   80% { opacity: 1; }
   100% { opacity: 0; }
 }
+
+.contracts-grid {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 10px;
+}
+
+.contracts-tall-column {
+  grid-column: span 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.contracts-wide-column {
+  grid-column: span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.contracts-small-grid {
+  grid-column: span 3;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+
+.contract-box {
+  background: #d1d1d1;
+  border-radius: 12px;
+  width: 100%;
+}
+
+.contract-box.tall {
+  height: 256px;
+}
+
+.contract-box.wide,
+.contract-box.small {
+  height: 112px;
+}


### PR DESCRIPTION
## Summary
- remove unused `ContractWordTab`
- insert contract placeholder layout inside `World`
- style new contract grid
- bump version to 0.5.3

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf99564ec832288a4fce3094ba8a3