### PR TITLE
Disable scrolling on World page

### DIFF
--- a/src/World.jsx
+++ b/src/World.jsx
@@ -78,6 +78,13 @@ export default function World() {
     localStorage.setItem("resourceX", xResource);
   }, [xResource]);
 
+  useEffect(() => {
+    document.body.classList.add("world-page");
+    return () => {
+      document.body.classList.remove("world-page");
+    };
+  }, []);
+
   const handleQuestAdd = (q) => {
     addQuest(q);
     setShowPublished(true);

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,6 +91,15 @@ body.character-page h1 {
   display: none;
 }
 
+body.world-page {
+  overflow: hidden;
+}
+
+body.world-page .content {
+  height: 100vh;
+  overflow: hidden;
+}
+
 .sidebar-avatar {
   width: 50px;
   height: 50px;


### PR DESCRIPTION
## Summary
- add a body class when World mounts
- define `.world-page` CSS rules to hide page overflow

## Testing
- `npx jest` *(fails: Need to install the following packages: jest@30.0.4)*

------
https://chatgpt.com/codex/tasks/task_e_686d48bd50e083229c715f5e5414f01f