### PR TITLE
Add resolution confirmation button

### DIFF
--- a/SettingsModal.jsx
+++ b/SettingsModal.jsx
@@ -10,9 +10,11 @@ export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
   });
 
   const changeRes = (e) => {
-    const val = e.target.value;
-    setResolution(val);
-    const [w, h] = val.split('x').map(Number);
+    setResolution(e.target.value);
+  };
+
+  const applyResolution = () => {
+    const [w, h] = resolution.split('x').map(Number);
     localStorage.setItem('windowWidth', w);
     localStorage.setItem('windowHeight', h);
     if (window.electronAPI && window.electronAPI.setWindowSize) {
@@ -38,6 +40,7 @@ export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
               <option key={r} value={r}>{r}</option>
             ))}
           </select>
+          <button className="save-button" onClick={applyResolution}>Validate</button>
         </label>
       </div>
     </div>

--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -10,9 +10,11 @@ export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
   });
 
   const changeRes = (e) => {
-    const val = e.target.value;
-    setResolution(val);
-    const [w, h] = val.split('x').map(Number);
+    setResolution(e.target.value);
+  };
+
+  const applyResolution = () => {
+    const [w, h] = resolution.split('x').map(Number);
     localStorage.setItem('windowWidth', w);
     localStorage.setItem('windowHeight', h);
     if (window.electronAPI && window.electronAPI.setWindowSize) {
@@ -38,6 +40,7 @@ export default function SettingsModal({ onClose, autoLog, onToggleAutoLog }) {
               <option key={r} value={r}>{r}</option>
             ))}
           </select>
+          <button className="save-button" onClick={applyResolution}>Validate</button>
         </label>
       </div>
     </div>

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.5.4';
+export const APP_VERSION = '0.5.5';


### PR DESCRIPTION
## Summary
- allow users to apply resolution changes through a Validate button
- bump app version to keep track of updates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4f78519483229b622aa48092cf9f