### PR TITLE
Add icon components for resources

### DIFF
--- a/AcceptedQuestList.jsx
+++ b/AcceptedQuestList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { RIcon } from './ResourceIcons.jsx';
 import { useQuests } from './QuestContext.jsx';
 import './world.css';
 
@@ -29,8 +30,8 @@ export default function AcceptedQuestList() {
                   {q.urgent && <div className="quest-urgent">Urgent</div>}
                   {q.resource !== 0 && (
                     <div className="quest-resource">
-                      {q.resource > 0 ? '+' : ''}
-                      {q.resource} R
+                  {q.resource > 0 ? '+' : ''}
+                      {q.resource} <RIcon />
                     </div>
                   )}
                 </div>

--- a/ResourceIcons.jsx
+++ b/ResourceIcons.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export function RIcon() {
+  return (
+    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+      <rect width="256" height="256" fill="#D9D9D9"/>
+      <rect width="256" height="256" fill="url(#pattern0_1223_127)"/>
+      <defs>
+        <pattern id="pattern0_1223_127" patternContentUnits="objectBoundingBox" width="1" height="1">
+          <use xlinkHref="#image0_1223_127" transform="translate(0 -0.388587) scale(0.0013587)"/>
+        </pattern>
+        <image id="image0_1223_127" width="736" height="1308" preserveAspectRatio="none" xlinkHref="data:image/jpeg;base64,iVBORw0KGgoAAA=="/>
+      </defs>
+    </svg>
+  );
+}
+
+export function XIcon() {
+  return (
+    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="128" cy="128" r="128" fill="white" />
+    </svg>
+  );
+}

--- a/ResourceIndicator.jsx
+++ b/ResourceIndicator.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useResource } from './ResourceContext.jsx';
+import { RIcon, XIcon } from './ResourceIcons.jsx';
 import './resource-indicator.css';
 
 export default function ResourceIndicator() {
@@ -7,8 +8,12 @@ export default function ResourceIndicator() {
 
   return (
     <div className="resource-box">
-      <div className="resource-circle">{resource} R</div>
-      <div className="resource-circle">{xResource} X</div>
+      <div className="resource-circle">
+        {resource} <RIcon />
+      </div>
+      <div className="resource-circle">
+        {xResource} <XIcon />
+      </div>
     </div>
   );
 }

--- a/src/AcceptedQuestList.jsx
+++ b/src/AcceptedQuestList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { RIcon } from './ResourceIcons.jsx';
 import { useQuests } from './QuestContext.jsx';
 import './world.css';
 
@@ -29,8 +30,8 @@ export default function AcceptedQuestList() {
                   {q.urgent && <div className="quest-urgent">Urgent</div>}
                   {q.resource !== 0 && (
                     <div className="quest-resource">
-                      {q.resource > 0 ? '+' : ''}
-                      {q.resource} R
+                  {q.resource > 0 ? '+' : ''}
+                      {q.resource} <RIcon />
                     </div>
                   )}
                 </div>

--- a/src/ResourceIcons.jsx
+++ b/src/ResourceIcons.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export function RIcon() {
+  return (
+    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+      <rect width="256" height="256" fill="#D9D9D9"/>
+      <rect width="256" height="256" fill="url(#pattern0_1223_127)"/>
+      <defs>
+        <pattern id="pattern0_1223_127" patternContentUnits="objectBoundingBox" width="1" height="1">
+          <use xlinkHref="#image0_1223_127" transform="translate(0 -0.388587) scale(0.0013587)"/>
+        </pattern>
+        <image id="image0_1223_127" width="736" height="1308" preserveAspectRatio="none" xlinkHref="data:image/jpeg;base64,iVBORw0KGgoAAA=="/>
+      </defs>
+    </svg>
+  );
+}
+
+export function XIcon() {
+  return (
+    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="128" cy="128" r="128" fill="white" />
+    </svg>
+  );
+}

--- a/src/ResourceIndicator.jsx
+++ b/src/ResourceIndicator.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useResource } from './ResourceContext.jsx';
+import { RIcon, XIcon } from './ResourceIcons.jsx';
 import './resource-indicator.css';
 
 export default function ResourceIndicator() {
@@ -7,8 +8,12 @@ export default function ResourceIndicator() {
 
   return (
     <div className="resource-box">
-      <div className="resource-circle">{resource} R</div>
-      <div className="resource-circle">{xResource} X</div>
+      <div className="resource-circle">
+        {resource} <RIcon />
+      </div>
+      <div className="resource-circle">
+        {xResource} <XIcon />
+      </div>
     </div>
   );
 }

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { RIcon, XIcon } from "./ResourceIcons.jsx";
 import QuestModal from "./QuestModal.jsx";
 import MainQuestModal from "./MainQuestModal.jsx";
 import { supabaseClient } from "./supabaseClient";
@@ -120,7 +121,7 @@ export default function World() {
                 {q.resource !== 0 && (
                   <div className="quest-resource">
                     {q.resource > 0 ? "+" : ""}
-                    {q.resource} R
+                    {q.resource} <RIcon />
                   </div>
                 )}
               </div>
@@ -180,7 +181,7 @@ export default function World() {
         </div>
       </div>
       <div className="resource-box">
-        {resource} R | {xResource} X
+        {resource} <RIcon /> | {xResource} <XIcon />
       </div>
       {showPublished && (
         <div className="published-popup">


### PR DESCRIPTION
## Summary
- add new `ResourceIcons` component to host resource icons
- swap R and X text with icons in resource indicator
- update quest lists and world display to use icons

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7b8e858c8322a9fbc7bf22eafc7d