### PR TITLE
Add quest info button and new implementation ideas app

### DIFF
--- a/src/AcceptedQuestList.jsx
+++ b/src/AcceptedQuestList.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { RIcon } from './ResourceIcons.jsx';
 import { useQuests } from './QuestContext.jsx';
 import './world.css';
 
 export default function AcceptedQuestList() {
   const { quests, completeQuest } = useQuests();
+  const [expanded, setExpanded] = useState(null);
 
   const accepted = quests.filter((q) => q.accepted && !q.completed);
   const groups = accepted.reduce((acc, q) => {
@@ -22,25 +23,42 @@ export default function AcceptedQuestList() {
           <h5>{type.charAt(0).toUpperCase() + type.slice(1)} Quests</h5>
           <div className="quest-list">
             {list.map((q) => (
-              <div key={q.id} className="quest-banner">
-                <div className="quest-info">
-                  <div className="quest-name">{q.name}</div>
-                  <div className="quest-quadrant">{q.quadrant}</div>
-                  <div className="quest-rarity">{q.rarity || 'C'}</div>
-                  {q.urgent && <div className="quest-urgent">Urgent</div>}
-                  {q.resource !== 0 && (
-                    <div className="quest-resource">
-                  {q.resource > 0 ? '+' : ''}
-                      {q.resource} <RIcon />
-                    </div>
-                  )}
+              <div key={q.id}>
+                <div className="quest-banner">
+                  <div className="quest-info">
+                    <div className="quest-name">{q.name}</div>
+                    <div className="quest-quadrant">{q.quadrant}</div>
+                    <div className="quest-rarity">{q.rarity || 'C'}</div>
+                    {q.urgent && <div className="quest-urgent">Urgent</div>}
+                    {q.resource !== 0 && (
+                      <div className="quest-resource">
+                        {q.resource > 0 ? '+' : ''}
+                        {q.resource} <RIcon />
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: '4px' }}>
+                    {q.description && (
+                      <button
+                        className="info-button"
+                        onClick={() =>
+                          setExpanded(expanded === q.id ? null : q.id)
+                        }
+                      >
+                        i
+                      </button>
+                    )}
+                    <button
+                      className="accept-button"
+                      onClick={() => completeQuest(q.id)}
+                    >
+                      Complete
+                    </button>
+                  </div>
                 </div>
-                <button
-                  className="accept-button"
-                  onClick={() => completeQuest(q.id)}
-                >
-                  Complete
-                </button>
+                {expanded === q.id && q.description && (
+                  <div className="quest-log">{q.description}</div>
+                )}
               </div>
             ))}
           </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import TodoGoals from './TodoGoals.jsx';
 import ActivityApp from './ActivityApp.jsx';
 import Orb from '../Orb.jsx';
 import IdeaBoard from './IdeaBoard.jsx';
+import ImplementationIdeas from './ImplementationIdeas.jsx';
 import CharacterEvolve from './CharacterEvolve.jsx';
 import SettingsModal from './SettingsModal.jsx';
 import AkashicRecords from './AkashicRecords.jsx';
@@ -58,6 +59,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showActivity, setShowActivity] = useState(false);
   const [showCharacterEvolve, setShowCharacterEvolve] = useState(false);
   const [showIdeaBoard, setShowIdeaBoard] = useState(false);
+  const [showImplementationIdeas, setShowImplementationIdeas] = useState(false);
   const [showOrb, setShowOrb] = useState(false);
   const [showAkashicRecords, setShowAkashicRecords] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
@@ -191,6 +193,8 @@ export default function QuadrantPage({ initialTab }) {
               <CharacterEvolve onBack={() => setShowCharacterEvolve(false)} />
             ) : showIdeaBoard ? (
               <IdeaBoard onBack={() => setShowIdeaBoard(false)} />
+            ) : showImplementationIdeas ? (
+              <ImplementationIdeas onBack={() => setShowImplementationIdeas(false)} />
             ) : showOrb ? (
               <Orb onBack={() => setShowOrb(false)} />
             ) : (
@@ -262,6 +266,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowIdeaBoard(true)}>
                   <div className="star-icon">📝</div>
                   <span>Idea Board</span>
+                </div>
+                <div className="app-card" onClick={() => setShowImplementationIdeas(true)}>
+                  <div className="star-icon">📑</div>
+                  <span>Implementation Ideas</span>
                 </div>
                 <div className="app-card" onClick={() => setShowOrb(true)}>
                   <div className="star-icon">🧿</div>

--- a/src/ImplementationIdeas.jsx
+++ b/src/ImplementationIdeas.jsx
@@ -1,0 +1,121 @@
+import React, { useState, useEffect } from 'react';
+import './placeholder-app.css';
+import './implementation-ideas.css';
+
+export default function ImplementationIdeas({ onBack }) {
+  const [ideas, setIdeas] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('implementationIdeas')) || [];
+    } catch {
+      return [];
+    }
+  });
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [importance, setImportance] = useState(1);
+  const [implemented, setImplemented] = useState(false);
+  const [view, setView] = useState(null);
+
+  useEffect(() => {
+    localStorage.setItem('implementationIdeas', JSON.stringify(ideas));
+  }, [ideas]);
+
+  const addIdea = () => {
+    if (!name.trim()) return;
+    const entry = {
+      id: Date.now(),
+      name: name.trim(),
+      description,
+      implemented,
+      importance,
+      date: new Date().toISOString(),
+    };
+    setIdeas((prev) => [...prev, entry]);
+    setName('');
+    setDescription('');
+    setImportance(1);
+    setImplemented(false);
+  };
+
+  return (
+    <div className="placeholder-app implementation-ideas">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <div className="idea-form">
+        <input
+          className="idea-input"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <textarea
+          className="idea-textarea"
+          placeholder="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <label className="idea-label">
+          Importance
+          <input
+            type="number"
+            min="1"
+            max="5"
+            value={importance}
+            onChange={(e) => setImportance(Number(e.target.value))}
+          />
+        </label>
+        <label className="idea-label">
+          Implemented
+          <input
+            type="checkbox"
+            checked={implemented}
+            onChange={(e) => setImplemented(e.target.checked)}
+          />
+        </label>
+        <button className="save-button" onClick={addIdea}>Add</button>
+      </div>
+      <table className="ideas-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Implemented</th>
+            <th>Date</th>
+            <th>Importance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ideas.map((i) => (
+            <tr key={i.id}>
+              <td>{i.name}</td>
+              <td>
+                {i.description.length > 30 ? (
+                  <button className="desc-button" onClick={() => setView(i)}>
+                    {i.description.slice(0, 30)}...
+                  </button>
+                ) : (
+                  i.description
+                )}
+              </td>
+              <td>{i.implemented ? 'Yes' : 'No'}</td>
+              <td>{new Date(i.date).toLocaleDateString()}</td>
+              <td>{i.importance}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {view && (
+        <div className="modal-overlay" onClick={() => setView(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <h3>{view.name}</h3>
+            <pre className="idea-desc">{view.description}</pre>
+            <div className="actions">
+              <button className="save-button" onClick={() => setView(null)}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -17,6 +17,7 @@ export default function World() {
   });
   const [userId, setUserId] = useState(null);
   const { quests, addQuest, acceptQuest } = useQuests();
+  const [expanded, setExpanded] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [profile, setProfile] = useState({});
   const [needsMainQuest, setNeedsMainQuest] = useState(false);
@@ -114,23 +115,40 @@ export default function World() {
         {quests
           .filter((q) => !q.accepted && !q.completed)
           .map((q) => (
-            <div key={q.id} className="quest-banner">
-              <div className="quest-info">
-                <div className="quest-name">{q.name}</div>
-                <div className="quest-quadrant">{q.quadrant}</div>
-                {q.resource !== 0 && (
-                  <div className="quest-resource">
-                    {q.resource > 0 ? "+" : ""}
-                    {q.resource} <RIcon />
-                  </div>
-                )}
+            <div key={q.id}>
+              <div className="quest-banner">
+                <div className="quest-info">
+                  <div className="quest-name">{q.name}</div>
+                  <div className="quest-quadrant">{q.quadrant}</div>
+                  {q.resource !== 0 && (
+                    <div className="quest-resource">
+                      {q.resource > 0 ? "+" : ""}
+                      {q.resource} <RIcon />
+                    </div>
+                  )}
+                </div>
+                <div style={{ display: 'flex', gap: '4px' }}>
+                  {q.description && (
+                    <button
+                      className="info-button"
+                      onClick={() =>
+                        setExpanded(expanded === q.id ? null : q.id)
+                      }
+                    >
+                      i
+                    </button>
+                  )}
+                  <button
+                    className="accept-button"
+                    onClick={() => acceptQuest(q.id)}
+                  >
+                    ✔
+                  </button>
+                </div>
               </div>
-              <button
-                className="accept-button"
-                onClick={() => acceptQuest(q.id)}
-              >
-                ✔
-              </button>
+              {expanded === q.id && q.description && (
+                <div className="quest-log">{q.description}</div>
+              )}
             </div>
           ))}
       </div>

--- a/src/implementation-ideas.css
+++ b/src/implementation-ideas.css
@@ -1,0 +1,31 @@
+.implementation-ideas .idea-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 300px;
+}
+
+.implementation-ideas .ideas-table {
+  margin-top: 10px;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.implementation-ideas th,
+.implementation-ideas td {
+  border: 1px solid #ccc;
+  padding: 4px 6px;
+  text-align: left;
+}
+
+.desc-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+}
+
+.idea-desc {
+  white-space: pre-wrap;
+}

--- a/src/world.css
+++ b/src/world.css
@@ -103,6 +103,16 @@
   cursor: pointer;
 }
 
+.info-button {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+}
+
 .completed-section > summary {
   padding: 8px 12px;
   background: rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
## Summary
- allow toggling quest description via new `info` button
- add Implementation Ideas app with spreadsheet-style notes
- support new app from the Training tab

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ffcadb4748322b13890c9ed0caed7