### PR TITLE
Switch app resolution after login

### DIFF
--- a/PageRouter.jsx
+++ b/PageRouter.jsx
@@ -29,11 +29,30 @@ export default function PageRouter() {
   }, []);
 
   useEffect(() => {
+    if (window.electronAPI && window.electronAPI.setWindowSize) {
+      if (user) {
+        localStorage.setItem('windowWidth', '1920');
+        localStorage.setItem('windowHeight', '1080');
+        window.electronAPI.setWindowSize(1920, 1080);
+      } else {
+        localStorage.setItem('windowWidth', '1600');
+        localStorage.setItem('windowHeight', '900');
+        window.electronAPI.setWindowSize(1600, 900);
+      }
+    }
+  }, [user]);
+
+  useEffect(() => {
     if (window.electronAPI && window.electronAPI.onGoHome) {
       window.electronAPI.onGoHome(() => setPage('5th'));
     }
     if (window.electronAPI && window.electronAPI.onDisconnect) {
       window.electronAPI.onDisconnect(async () => {
+        if (window.electronAPI.setWindowSize) {
+          localStorage.setItem('windowWidth', '1600');
+          localStorage.setItem('windowHeight', '900');
+          window.electronAPI.setWindowSize(1600, 900);
+        }
         await supabaseClient.auth.signOut();
       });
     }

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -29,11 +29,30 @@ export default function PageRouter() {
   }, []);
 
   useEffect(() => {
+    if (window.electronAPI && window.electronAPI.setWindowSize) {
+      if (user) {
+        localStorage.setItem('windowWidth', '1920');
+        localStorage.setItem('windowHeight', '1080');
+        window.electronAPI.setWindowSize(1920, 1080);
+      } else {
+        localStorage.setItem('windowWidth', '1600');
+        localStorage.setItem('windowHeight', '900');
+        window.electronAPI.setWindowSize(1600, 900);
+      }
+    }
+  }, [user]);
+
+  useEffect(() => {
     if (window.electronAPI && window.electronAPI.onGoHome) {
       window.electronAPI.onGoHome(() => setPage('5th'));
     }
     if (window.electronAPI && window.electronAPI.onDisconnect) {
       window.electronAPI.onDisconnect(async () => {
+        if (window.electronAPI.setWindowSize) {
+          localStorage.setItem('windowWidth', '1600');
+          localStorage.setItem('windowHeight', '900');
+          window.electronAPI.setWindowSize(1600, 900);
+        }
         await supabaseClient.auth.signOut();
       });
     }


### PR DESCRIPTION
## Summary
- resize window to 1600x900 on login screen
- resize window to 1920x1080 once authenticated
- shrink window again when manually disconnecting

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6872b92610a48322a2d8f4283476107c