### PR TITLE
Integrate ReactKonva board

### DIFF
--- a/IdeaBoard.test.js
+++ b/IdeaBoard.test.js
@@ -3,6 +3,17 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import IdeaBoard from './src/IdeaBoard.jsx';
 
+jest.mock('react-konva', () => {
+  const React = require('react');
+  return {
+    Stage: ({ children }) => <div>{children}</div>,
+    Layer: ({ children }) => <div>{children}</div>,
+    Group: ({ children }) => <div>{children}</div>,
+    Rect: () => <div />,
+    Text: () => <div />,
+  };
+});
+
 global.ResizeObserver = class {
   observe() {}
   unobserve() {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
         "@supabase/supabase-js": "^2",
         "active-win": "^8.2.1",
         "compromise": "^14.14.4",
+        "konva": "^9.3.22",
         "react": "^19.1.0",
         "react-big-calendar": "^1.19.4",
         "react-dom": "^19.1.0",
         "react-easy-crop": "^5.0.1",
+        "react-konva": "^19.0.7",
         "reactflow": "^11.11.4",
         "styled-components": "^6.1.18"
       },
@@ -4599,6 +4601,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-+WHarFkJevhH1s655qeeSEf/yxFST0dVRsmSqUgxG8mMOKqycgYBv2wVpyubBY7MX8KiX5FQ03rNIwrxfm7Bmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -7616,6 +7627,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -8734,6 +8766,26 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/konva": {
+      "version": "9.3.22",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-9.3.22.tgz",
+      "integrity": "sha512-yQI5d1bmELlD/fowuyfOp9ff+oamg26WOCkyqUyc+nczD/lhRa3EvD2MZOoc4c1293TAubW9n34fSQLgSeEgSw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -10220,6 +10272,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-konva": {
+      "version": "19.0.7",
+      "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-19.0.7.tgz",
+      "integrity": "sha512-uYWCpSv4ajLymTh8S8fV9396fHDX7eDTWiLGkYlBuawud5MoNiuGjapPhA5Avdy/Jfh9P2KaWuNf4i9PI1F9HQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.32.0",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "0.32.0",
+        "scheduler": "0.26.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -10244,6 +10327,21 @@
       "peerDependencies": {
         "react": ">=16.3.0",
         "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "@supabase/supabase-js": "^2",
     "active-win": "^8.2.1",
     "compromise": "^14.14.4",
+    "konva": "^9.3.22",
     "react": "^19.1.0",
     "react-big-calendar": "^1.19.4",
     "react-dom": "^19.1.0",
     "react-easy-crop": "^5.0.1",
+    "react-konva": "^19.0.7",
     "reactflow": "^11.11.4",
     "styled-components": "^6.1.18"
   },

--- a/src/IdeaBoard.jsx
+++ b/src/IdeaBoard.jsx
@@ -1,93 +1,55 @@
-import React, { useCallback, useEffect } from 'react';
-import ReactFlow, {
-  MiniMap,
-  Controls,
-  Background,
-  useNodesState,
-  useEdgesState,
-  addEdge,
-} from 'reactflow';
-import 'reactflow/dist/style.css';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Stage, Layer, Rect, Text, Group } from 'react-konva';
 import './idea-board.css';
 
-function TextNode({ id, data }) {
-  const onBlur = (e) => {
-    data.onChange(id, e.target.innerText);
-  };
-
-  return (
-    <div className="text-node">
-      <div contentEditable suppressContentEditableWarning onBlur={onBlur}>
-        {data.label}
-      </div>
-    </div>
-  );
-}
-
 export default function IdeaBoard({ onBack }) {
+  const containerRef = useRef(null);
+  const [size, setSize] = useState({ width: 300, height: 300 });
   const initialNodes = () => {
     try {
-      const stored = JSON.parse(localStorage.getItem('ideaNodes'));
+      const stored = JSON.parse(localStorage.getItem('ideaBoardNodes'));
       if (Array.isArray(stored)) return stored;
     } catch {}
-    return [
-      { id: '1', type: 'text', data: { label: 'Idea' }, position: { x: 50, y: 50 } },
-    ];
+    return [{ id: '1', text: 'Idea', x: 50, y: 50 }];
   };
 
-  const initialEdges = () => {
-    try {
-      const stored = JSON.parse(localStorage.getItem('ideaEdges'));
-      if (Array.isArray(stored)) return stored;
-    } catch {}
-    return [];
-  };
-
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes());
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges());
+  const [nodes, setNodes] = useState(initialNodes);
 
   useEffect(() => {
-    localStorage.setItem('ideaNodes', JSON.stringify(nodes));
+    localStorage.setItem('ideaBoardNodes', JSON.stringify(nodes));
   }, [nodes]);
 
-  useEffect(() => {
-    localStorage.setItem('ideaEdges', JSON.stringify(edges));
-  }, [edges]);
-
-  const onConnect = useCallback(
-    (params) => setEdges((eds) => addEdge(params, eds)),
-    [setEdges]
-  );
-
-  const handleNodeChange = useCallback(
-    (id, label) => {
-      setNodes((nds) =>
-        nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, label } } : n))
-      );
-    },
-    [setNodes]
-  );
+  useLayoutEffect(() => {
+    const update = () => {
+      if (containerRef.current) {
+        setSize({
+          width: containerRef.current.offsetWidth,
+          height: containerRef.current.offsetHeight,
+        });
+      }
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
 
   const addNode = () => {
     const id = Date.now().toString();
-    setNodes((nds) => [
-      ...nds,
-      { id, type: 'text', data: { label: 'New idea', onChange: handleNodeChange }, position: { x: 100, y: 100 } },
-    ]);
+    setNodes((nds) => [...nds, { id, text: 'New idea', x: 100, y: 100 }]);
   };
 
-  // inject handler into nodes
-  useEffect(() => {
-    setNodes((nds) =>
-      nds.map((n) => ({
-        ...n,
-        type: 'text',
-        data: { ...n.data, onChange: handleNodeChange },
-      }))
-    );
-  }, []); // run once
+  const handleDragEnd = (id, e) => {
+    const { x, y } = e.target.position();
+    setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, x, y } : n)));
+  };
 
-  const nodeTypes = { text: TextNode };
+  const handleEdit = (id) => {
+    const node = nodes.find((n) => n.id === id);
+    const text = prompt('Edit idea', node.text);
+    if (text !== null) {
+      setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, text } : n)));
+    }
+  };
 
   return (
     <div className="idea-board">
@@ -95,20 +57,24 @@ export default function IdeaBoard({ onBack }) {
         <button className="back-button" onClick={onBack}>Back</button>
         <button className="action-button" onClick={addNode}>Add Idea</button>
       </div>
-      <div className="idea-board-flow">
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          nodeTypes={nodeTypes}
-          fitView
-        >
-          <MiniMap />
-          <Controls />
-          <Background color="#aaa" gap={16} />
-        </ReactFlow>
+      <div className="idea-board-flow" ref={containerRef}>
+        <Stage width={size.width} height={size.height} className="idea-board-stage">
+          <Layer>
+            {nodes.map((n) => (
+              <Group
+                key={n.id}
+                x={n.x}
+                y={n.y}
+                draggable
+                onDragEnd={(e) => handleDragEnd(n.id, e)}
+                onDblClick={() => handleEdit(n.id)}
+              >
+                <Rect width={120} height={40} fill="#ffffff" cornerRadius={4} shadowBlur={2} />
+                <Text text={n.text} fontSize={16} fill="#000" width={120} padding={8} />
+              </Group>
+            ))}
+          </Layer>
+        </Stage>
       </div>
     </div>
   );

--- a/src/idea-board.css
+++ b/src/idea-board.css
@@ -15,13 +15,10 @@
   border: 1px solid #444;
   border-radius: 4px;
   background: #111;
+  position: relative;
 }
 
-.text-node div[contenteditable] {
-  outline: none;
-  padding: 4px 8px;
-  background: #fff;
-  color: #000;
-  border-radius: 4px;
-  min-width: 60px;
+.idea-board-stage {
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
## Summary
- install `react-konva` and `konva`
- replace existing `ReactFlow` idea board with a canvas powered by ReactKonva
- adjust board styles
- mock `react-konva` in `IdeaBoard` unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875236e1f2c8322b46964dc700a6853