### PR TITLE
Add canvas toolbar

### DIFF
--- a/IdeaBoard.test.js
+++ b/IdeaBoard.test.js
@@ -3,6 +3,18 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import IdeaBoard from './src/IdeaBoard.jsx';
 
+jest.mock('react-konva', () => {
+  const React = require('react');
+  return {
+    Stage: ({ children }) => <div>{children}</div>,
+    Layer: ({ children }) => <div>{children}</div>,
+    Group: ({ children }) => <div>{children}</div>,
+    Rect: () => <div />,
+    Text: () => <div />,
+    Transformer: ({ children }) => <div>{children}</div>,
+  };
+});
+
 global.ResizeObserver = class {
   observe() {}
   unobserve() {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,12 @@
         "@supabase/supabase-js": "^2",
         "active-win": "^8.2.1",
         "compromise": "^14.14.4",
+        "konva": "^9.3.22",
         "react": "^19.1.0",
         "react-big-calendar": "^1.19.4",
         "react-dom": "^19.1.0",
         "react-easy-crop": "^5.0.1",
+        "react-konva": "^19.0.7",
         "reactflow": "^11.11.4",
         "styled-components": "^6.1.18"
       },
@@ -4599,6 +4601,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-+WHarFkJevhH1s655qeeSEf/yxFST0dVRsmSqUgxG8mMOKqycgYBv2wVpyubBY7MX8KiX5FQ03rNIwrxfm7Bmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -7616,6 +7627,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -8734,6 +8766,26 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/konva": {
+      "version": "9.3.22",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-9.3.22.tgz",
+      "integrity": "sha512-yQI5d1bmELlD/fowuyfOp9ff+oamg26WOCkyqUyc+nczD/lhRa3EvD2MZOoc4c1293TAubW9n34fSQLgSeEgSw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -10220,6 +10272,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-konva": {
+      "version": "19.0.7",
+      "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-19.0.7.tgz",
+      "integrity": "sha512-uYWCpSv4ajLymTh8S8fV9396fHDX7eDTWiLGkYlBuawud5MoNiuGjapPhA5Avdy/Jfh9P2KaWuNf4i9PI1F9HQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.32.0",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "0.32.0",
+        "scheduler": "0.26.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -10244,6 +10327,21 @@
       "peerDependencies": {
         "react": ">=16.3.0",
         "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "@supabase/supabase-js": "^2",
     "active-win": "^8.2.1",
     "compromise": "^14.14.4",
+    "konva": "^9.3.22",
     "react": "^19.1.0",
     "react-big-calendar": "^1.19.4",
     "react-dom": "^19.1.0",
     "react-easy-crop": "^5.0.1",
+    "react-konva": "^19.0.7",
     "reactflow": "^11.11.4",
     "styled-components": "^6.1.18"
   },

--- a/src/IdeaBoard.jsx
+++ b/src/IdeaBoard.jsx
@@ -1,93 +1,132 @@
-import React, { useCallback, useEffect } from 'react';
-import ReactFlow, {
-  MiniMap,
-  Controls,
-  Background,
-  useNodesState,
-  useEdgesState,
-  addEdge,
-} from 'reactflow';
-import 'reactflow/dist/style.css';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Stage, Layer, Rect, Text, Group, Transformer } from 'react-konva';
 import './idea-board.css';
 
-function TextNode({ id, data }) {
-  const onBlur = (e) => {
-    data.onChange(id, e.target.innerText);
-  };
-
-  return (
-    <div className="text-node">
-      <div contentEditable suppressContentEditableWarning onBlur={onBlur}>
-        {data.label}
-      </div>
-    </div>
-  );
-}
-
 export default function IdeaBoard({ onBack }) {
+  const containerRef = useRef(null);
+  const [size, setSize] = useState({ width: 300, height: 300 });
   const initialNodes = () => {
     try {
-      const stored = JSON.parse(localStorage.getItem('ideaNodes'));
-      if (Array.isArray(stored)) return stored;
+      const stored = JSON.parse(localStorage.getItem('ideaBoardNodes'));
+      if (Array.isArray(stored)) {
+        return stored.map((n) => ({ width: 120, height: 40, ...n }));
+      }
     } catch {}
-    return [
-      { id: '1', type: 'text', data: { label: 'Idea' }, position: { x: 50, y: 50 } },
-    ];
+    return [{ id: '1', text: 'Idea', x: 50, y: 50, width: 120, height: 40 }];
   };
 
-  const initialEdges = () => {
-    try {
-      const stored = JSON.parse(localStorage.getItem('ideaEdges'));
-      if (Array.isArray(stored)) return stored;
-    } catch {}
-    return [];
-  };
-
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes());
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges());
+  const [nodes, setNodes] = useState(initialNodes);
+  const [selectedId, setSelectedId] = useState(null);
+  const [menu, setMenu] = useState(null);
+  const [editingId, setEditingId] = useState(null);
+  const [editPos, setEditPos] = useState({ x: 0, y: 0 });
+  const [editingText, setEditingText] = useState('');
+  const [editSize, setEditSize] = useState({ width: 120, height: 40 });
+  const [tool, setTool] = useState('select');
+  const [shapeMenu, setShapeMenu] = useState(false);
+  const rectRefs = useRef({});
+  const transformerRef = useRef(null);
 
   useEffect(() => {
-    localStorage.setItem('ideaNodes', JSON.stringify(nodes));
+    document.body.classList.add('idea-board-page');
+    return () => {
+      document.body.classList.remove('idea-board-page');
+    };
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('ideaBoardNodes', JSON.stringify(nodes));
   }, [nodes]);
 
+  const deleteNode = (id) => {
+    setNodes((nds) => nds.filter((n) => n.id !== id));
+    if (selectedId === id) setSelectedId(null);
+    setMenu(null);
+  };
+
   useEffect(() => {
-    localStorage.setItem('ideaEdges', JSON.stringify(edges));
-  }, [edges]);
+    const handleKey = (e) => {
+      if ((e.key === 'Backspace' || e.key === 'Delete') && selectedId) {
+        deleteNode(selectedId);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [selectedId]);
 
-  const onConnect = useCallback(
-    (params) => setEdges((eds) => addEdge(params, eds)),
-    [setEdges]
-  );
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const update = () => {
+      setSize({
+        width: containerRef.current.clientWidth,
+        height: containerRef.current.clientHeight,
+      });
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(containerRef.current);
+    window.addEventListener('resize', update);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, []);
 
-  const handleNodeChange = useCallback(
-    (id, label) => {
-      setNodes((nds) =>
-        nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, label } } : n))
-      );
-    },
-    [setNodes]
-  );
+  useEffect(() => {
+    if (!transformerRef.current) return;
+    const node = rectRefs.current[selectedId]?.current;
+    if (selectedId && node) {
+      transformerRef.current.nodes([node]);
+    } else {
+      transformerRef.current.nodes([]);
+    }
+    transformerRef.current.getLayer()?.batchDraw();
+  }, [selectedId, nodes]);
 
   const addNode = () => {
     const id = Date.now().toString();
-    setNodes((nds) => [
-      ...nds,
-      { id, type: 'text', data: { label: 'New idea', onChange: handleNodeChange }, position: { x: 100, y: 100 } },
-    ]);
+    const newNode = { id, text: '', x: 100, y: 100, width: 120, height: 40 };
+    setNodes((nds) => [...nds, newNode]);
+    setSelectedId(id);
+    setEditPos({ x: newNode.x, y: newNode.y });
+    setEditSize({ width: newNode.width, height: newNode.height });
+    setEditingText('');
+    setEditingId(id);
   };
 
-  // inject handler into nodes
-  useEffect(() => {
-    setNodes((nds) =>
-      nds.map((n) => ({
-        ...n,
-        type: 'text',
-        data: { ...n.data, onChange: handleNodeChange },
-      }))
-    );
-  }, []); // run once
+  const handleDragEnd = (id, e) => {
+    const { x, y } = e.target.position();
+    setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, x, y } : n)));
+  };
 
-  const nodeTypes = { text: TextNode };
+  const finishEdit = () => {
+    if (editingId) {
+      setNodes((nds) =>
+        nds.map((n) =>
+          n.id === editingId ? { ...n, text: editingText || 'Idea' } : n
+        )
+      );
+    }
+    setEditingId(null);
+  };
+
+  const handleEdit = (id) => {
+    const node = nodes.find((n) => n.id === id);
+    setEditingText(node.text);
+    setEditPos({ x: node.x, y: node.y });
+    setEditSize({ width: node.width, height: node.height });
+    setEditingId(id);
+  };
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (shapeMenu && !e.target.closest('.shape-menu')) {
+        setShapeMenu(false);
+      }
+    };
+    window.addEventListener('click', handler);
+    return () => window.removeEventListener('click', handler);
+  }, [shapeMenu]);
 
   return (
     <div className="idea-board">
@@ -95,21 +134,155 @@ export default function IdeaBoard({ onBack }) {
         <button className="back-button" onClick={onBack}>Back</button>
         <button className="action-button" onClick={addNode}>Add Idea</button>
       </div>
-      <div className="idea-board-flow">
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          nodeTypes={nodeTypes}
-          fitView
+      <div className="idea-board-flow" ref={containerRef}>
+        <Stage
+          width={size.width}
+          height={size.height}
+          className="idea-board-stage"
+          onMouseDown={(e) => {
+            if (e.target === e.target.getStage()) setSelectedId(null);
+            if (!e.target.hasName('tool-button')) setShapeMenu(false);
+            setMenu(null);
+          }}
         >
-          <MiniMap />
-          <Controls />
-          <Background color="#aaa" gap={16} />
-        </ReactFlow>
+          <Layer>
+            {nodes.map((n) => (
+              <Group
+                key={n.id}
+                x={n.x}
+                y={n.y}
+                draggable
+                onDragEnd={(e) => handleDragEnd(n.id, e)}
+                onDblClick={() => handleEdit(n.id)}
+                onClick={() => setSelectedId(n.id)}
+                onContextMenu={(e) => {
+                  e.evt.preventDefault();
+                  const rect = containerRef.current.getBoundingClientRect();
+                  setMenu({ id: n.id, x: e.evt.clientX - rect.left, y: e.evt.clientY - rect.top });
+                  setSelectedId(n.id);
+                }}
+              >
+                <Rect
+                  ref={(el) => {
+                    if (el) rectRefs.current[n.id] = { current: el };
+                  }}
+                  width={n.width}
+                  height={n.height}
+                  fill="#ffffff"
+                  cornerRadius={4}
+                  shadowBlur={2}
+                  stroke={selectedId === n.id ? '#1646F1' : undefined}
+                  onTransformEnd={(e) => {
+                    const node = e.target;
+                    const width = node.width() * node.scaleX();
+                    const height = node.height() * node.scaleY();
+                    node.scaleX(1);
+                    node.scaleY(1);
+                    setNodes((nds) =>
+                      nds.map((nn) => (nn.id === n.id ? { ...nn, width, height } : nn))
+                    );
+                  }}
+                />
+                <Text text={n.text} fontSize={16} fill="#000" width={n.width} height={n.height} padding={8} />
+              </Group>
+            ))}
+            <Transformer ref={transformerRef} rotateEnabled={false} />
+            {(() => {
+              const TOOL_SIZE = 96;
+              const GAP = 8;
+              const PAD = 10;
+              const tools = [
+                { name: 'select', icon: '🖱️' },
+                { name: 'frame', icon: '▭' },
+                { name: 'shape', icon: '□▾' },
+                { name: 'pencil', icon: '✏️' },
+                { name: 'text', icon: 'T' },
+              ];
+              const toolbarWidth =
+                PAD * 2 + tools.length * TOOL_SIZE + (tools.length - 1) * GAP;
+              const toolbarHeight = TOOL_SIZE + PAD * 2;
+              const x = size.width / 2 - toolbarWidth / 2;
+              const y = size.height - toolbarHeight - 35;
+              return (
+                <Group x={x} y={y} name="toolbar">
+                  <Rect
+                    width={toolbarWidth}
+                    height={toolbarHeight}
+                    fill="#fff"
+                    cornerRadius={8}
+                    shadowBlur={4}
+                  />
+                  {tools.map((t, i) => (
+                    <Group
+                      key={t.name}
+                      name="tool-button"
+                      x={PAD + i * (TOOL_SIZE + GAP)}
+                      y={PAD}
+                      onClick={() => {
+                        setTool(t.name);
+                        if (t.name === 'shape') setShapeMenu((o) => !o);
+                        else setShapeMenu(false);
+                      }}
+                    >
+                      <Rect
+                        width={TOOL_SIZE}
+                        height={TOOL_SIZE}
+                        fill="#fff"
+                        stroke={tool === t.name ? '#1646F1' : '#000'}
+                        strokeWidth={2}
+                        cornerRadius={4}
+                      />
+                      <Text
+                        text={t.icon}
+                        fontSize={TOOL_SIZE * 0.6}
+                        width={TOOL_SIZE}
+                        height={TOOL_SIZE}
+                        align="center"
+                        verticalAlign="middle"
+                        fill="#000"
+                      />
+                    </Group>
+                  ))}
+                </Group>
+              );
+            })()}
+          </Layer>
+        </Stage>
+        {editingId && (
+          <textarea
+            className="idea-edit-input"
+            style={{ left: editPos.x, top: editPos.y, width: editSize.width, height: editSize.height }}
+            value={editingText}
+            onChange={(e) => setEditingText(e.target.value)}
+            onBlur={finishEdit}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                finishEdit();
+              }
+            }}
+            autoFocus
+          />
+        )}
+        {menu && (
+          <div
+            className="context-menu"
+            style={{ left: menu.x, top: menu.y }}
+          >
+            <button onClick={() => deleteNode(menu.id)}>Delete</button>
+          </div>
+        )}
       </div>
+      {shapeMenu && (
+        <div className="shape-menu">
+          <button onClick={() => setShapeMenu(false)}>Rectangle</button>
+          <button onClick={() => setShapeMenu(false)}>Line</button>
+          <button onClick={() => setShapeMenu(false)}>Arrow</button>
+          <button onClick={() => setShapeMenu(false)}>Ellipse</button>
+          <button onClick={() => setShapeMenu(false)}>Polygon</button>
+          <button onClick={() => setShapeMenu(false)}>Image</button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/idea-board.css
+++ b/src/idea-board.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   gap: 10px;
   height: 100%;
+  flex: 1;
+  width: 100%;
 }
 
 .idea-board-controls {
@@ -12,16 +14,64 @@
 
 .idea-board-flow {
   flex: 1;
+  width: 100%;
   border: 1px solid #444;
   border-radius: 4px;
   background: #111;
+  position: relative;
 }
 
-.text-node div[contenteditable] {
-  outline: none;
+.idea-board-stage {
+  width: 100%;
+  height: 100%;
+}
+
+.context-menu {
+  position: absolute;
+  background: #17181d;
+  color: #e6e7eb;
   padding: 4px 8px;
-  background: #fff;
-  color: #000;
   border-radius: 4px;
-  min-width: 60px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+.context-menu button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.idea-edit-input {
+  position: absolute;
+  width: 120px;
+  height: 40px;
+  box-sizing: border-box;
+  padding: 4px;
+  font-size: 16px;
+  border: 1px solid #444;
+  border-radius: 4px;
+  z-index: 20;
+}
+
+.shape-menu {
+  position: absolute;
+  bottom: 120px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  background: #17181d;
+  padding: 4px;
+  border-radius: 4px;
+  gap: 4px;
+}
+
+.shape-menu button {
+  background: none;
+  border: none;
+  color: #e6e7eb;
+  cursor: pointer;
+  text-align: left;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -102,6 +102,20 @@ body.world-page .content {
   overflow: hidden;
 }
 
+body.idea-board-page {
+  overflow: hidden;
+}
+
+body.idea-board-page h1 {
+  display: none;
+}
+
+body.idea-board-page .content {
+  height: 100vh;
+  padding: 0;
+  align-items: stretch;
+}
+
 .sidebar-avatar {
   width: 50px;
   height: 50px;
@@ -150,6 +164,7 @@ body.world-page .content {
   display: flex;
   align-items: flex-start;
   gap: 20px;
+  flex: 1;
 }
 
 .feature-cards {


### PR DESCRIPTION
## Summary
- rebuild IdeaBoard bottom toolbar as a Konva group so it sits inside the canvas
- place the toolbar centered near the bottom and show bigger icons
- adjust CSS to remove the old fixed toolbar and reposition the shape menu

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6875236e1f2c8322b46964dc700a6853