### PR TITLE
Add light theme background fixes

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -54,10 +54,18 @@ export default function QuadrantPage({ initialTab }) {
   const [autoLog, setAutoLog] = useState(
     () => localStorage.getItem('autoLog') === 'true'
   );
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem('theme') || 'dark'
+  );
 
   useEffect(() => {
     localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
   }, [autoLog]);
+
+  useEffect(() => {
+    document.body.classList.toggle('light-theme', theme === 'light');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
 
   useEffect(() => {
     const loadAvatar = async () => {
@@ -228,6 +236,10 @@ export default function QuadrantPage({ initialTab }) {
           onClose={() => setShowSettings(false)}
           autoLog={autoLog}
           onToggleAutoLog={setAutoLog}
+          theme={theme}
+          onToggleTheme={() =>
+            setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
+          }
           onOpenAkashicRecords={() => setShowAkashicRecords(true)}
         />
       )}

--- a/SettingsModal.jsx
+++ b/SettingsModal.jsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
-export default function SettingsModal({ onClose, autoLog, onToggleAutoLog, onOpenAkashicRecords }) {
+export default function SettingsModal({
+  onClose,
+  autoLog,
+  onToggleAutoLog,
+  onOpenAkashicRecords,
+  theme,
+  onToggleTheme,
+}) {
   const resolutions = ['800x600', '1024x768', '1280x720', '1600x900', '1920x1080'];
   const [resolution, setResolution] = useState(() => {
     const w = localStorage.getItem('windowWidth') || '1600';
@@ -42,6 +49,9 @@ export default function SettingsModal({ onClose, autoLog, onToggleAutoLog, onOpe
           </select>
           <button className="save-button" onClick={applyResolution}>Validate</button>
         </label>
+        <button className="save-button" onClick={onToggleTheme}>
+          {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
         <button
           className="akashic-button"
           onClick={() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,15 @@ export default function QuadrantPage({ initialTab }) {
     () => localStorage.getItem('autoLog') === 'true'
   );
 
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem('theme') || 'dark'
+  );
+
+  useEffect(() => {
+    document.body.classList.toggle('light-theme', theme === 'light');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
   useEffect(() => {
     localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
   }, [autoLog]);
@@ -293,6 +302,10 @@ export default function QuadrantPage({ initialTab }) {
           onClose={() => setShowSettings(false)}
           autoLog={autoLog}
           onToggleAutoLog={setAutoLog}
+          theme={theme}
+          onToggleTheme={() =>
+            setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
+          }
           onOpenAkashicRecords={() => setShowAkashicRecords(true)}
         />
       )}

--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
-export default function SettingsModal({ onClose, autoLog, onToggleAutoLog, onOpenAkashicRecords }) {
+export default function SettingsModal({
+  onClose,
+  autoLog,
+  onToggleAutoLog,
+  onOpenAkashicRecords,
+  theme,
+  onToggleTheme,
+}) {
   const resolutions = ['800x600', '1024x768', '1280x720', '1600x900', '1920x1080'];
   const [resolution, setResolution] = useState(() => {
     const w = localStorage.getItem('windowWidth') || '1600';
@@ -42,6 +49,9 @@ export default function SettingsModal({ onClose, autoLog, onToggleAutoLog, onOpe
           </select>
           <button className="save-button" onClick={applyResolution}>Validate</button>
         </label>
+        <button className="save-button" onClick={onToggleTheme}>
+          {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
         <button
           className="akashic-button"
           onClick={() => {

--- a/src/idea-board.css
+++ b/src/idea-board.css
@@ -21,6 +21,11 @@
   position: relative;
 }
 
+body.light-theme .idea-board-flow {
+  /* Lighter canvas in light mode */
+  background: #fff;
+}
+
 .idea-board-stage {
   width: 100%;
   height: 100%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -288,6 +288,40 @@ body.idea-board-page .content {
   user-select: none;
 }
 
+body.light-theme {
+  /* Keep the same background image but switch text color */
+  color: #000;
+}
+
+body.light-theme .sidebar {
+  background-color: rgba(200, 200, 200, 0.6);
+}
+
+body.light-theme .tab {
+  background-color: #fff;
+  color: #000;
+}
+
+body.light-theme .tab:hover {
+  background-color: #ccc;
+  color: #000;
+}
+
+body.light-theme .home-button,
+body.light-theme .profile-button,
+body.light-theme .settings-button {
+  background: #f0f0f0;
+  color: #000;
+}
+
+body.light-theme .app-card,
+body.light-theme .back-button,
+body.light-theme .journal-tabs button,
+body.light-theme .journal-tabs button.active {
+  background: #fff;
+  color: #000;
+}
+
 .activity-toggle {
   position: fixed;
   bottom: 8px;

--- a/styles.css
+++ b/styles.css
@@ -204,3 +204,37 @@ body.character-page h1 {
 .journal-tabs button.active {
   background: #0d0e11;
 }
+
+body.light-theme {
+  /* Keep the same background image but switch text color */
+  color: #000;
+}
+
+body.light-theme .sidebar {
+  background-color: rgba(200, 200, 200, 0.6);
+}
+
+body.light-theme .tab {
+  background-color: #fff;
+  color: #000;
+}
+
+body.light-theme .tab:hover {
+  background-color: #ccc;
+  color: #000;
+}
+
+body.light-theme .home-button,
+body.light-theme .profile-button,
+body.light-theme .settings-button {
+  background: #f0f0f0;
+  color: #000;
+}
+
+body.light-theme .app-card,
+body.light-theme .back-button,
+body.light-theme .journal-tabs button,
+body.light-theme .journal-tabs button.active {
+  background: #fff;
+  color: #000;
+}


### PR DESCRIPTION
## Summary
- keep background_EI image when switching themes
- give idea board canvas a light background in light mode

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68767073bbf4832282d61804fcd20616