### PR TITLE
Fix idea board theme toggle positioning

### DIFF
--- a/src/IdeaBoard.jsx
+++ b/src/IdeaBoard.jsx
@@ -210,7 +210,7 @@ export default function IdeaBoard({ onBack }) {
             setBoardTheme((t) => (t === 'dark' ? 'light' : 'dark'))
           }
           style={{
-            position: 'fixed',
+            position: 'absolute',
             top: 8,
             right: 8,
             width: 32,

--- a/src/idea-board.css
+++ b/src/idea-board.css
@@ -27,7 +27,7 @@
 }
 
 .board-theme-toggle {
-  position: fixed;
+  position: absolute;
   top: 8px;
   right: 8px;
   width: 32px;


### PR DESCRIPTION
## Summary
- keep idea board theme toggle anchored to the board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687688ac6edc8322b9e542a1b9eedae6