### PR TITLE
Fix idea board theme toggle positioning

### DIFF
--- a/src/IdeaBoard.jsx
+++ b/src/IdeaBoard.jsx
@@ -199,36 +199,23 @@ export default function IdeaBoard({ onBack }) {
         <button className="back-button" onClick={onBack}>Back</button>
         <button className="action-button" onClick={addNode}>Add Idea</button>
       </div>
+      <button
+        aria-label="toggle board theme"
+        className="board-theme-toggle"
+        onClick={() =>
+          setBoardTheme((t) => (t === 'dark' ? 'light' : 'dark'))
+        }
+        style={{
+          background: boardTheme === 'light' ? '#fff' : '#333',
+          color: boardTheme === 'light' ? '#000' : '#fff',
+        }}
+      >
+        {boardTheme === 'light' ? '☀️' : '🌙'}
+      </button>
       <div
         className={`idea-board-flow${boardTheme === 'light' ? ' light' : ''}`}
         ref={containerRef}
       >
-        <button
-          aria-label="toggle board theme"
-          className="board-theme-toggle"
-          onClick={() =>
-            setBoardTheme((t) => (t === 'dark' ? 'light' : 'dark'))
-          }
-          style={{
-            position: 'fixed',
-            top: 8,
-            right: 8,
-            width: 32,
-            height: 32,
-            borderRadius: '50%',
-            border: 'none',
-            cursor: 'pointer',
-            fontSize: 18,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            zIndex: 20,
-            background: boardTheme === 'light' ? '#fff' : '#333',
-            color: boardTheme === 'light' ? '#000' : '#fff',
-          }}
-        >
-          {boardTheme === 'light' ? '☀️' : '🌙'}
-        </button>
         <Stage
           width={size.width}
           height={size.height}

--- a/src/idea-board.css
+++ b/src/idea-board.css
@@ -5,6 +5,7 @@
   height: 100%;
   flex: 1;
   width: 100%;
+  position: relative;
 }
 
 .idea-board-controls {
@@ -27,7 +28,7 @@
 }
 
 .board-theme-toggle {
-  position: fixed;
+  position: absolute;
   top: 8px;
   right: 8px;
   width: 32px;


### PR DESCRIPTION
## Summary
- keep idea board theme toggle anchored by moving it outside the board flow
- set the idea board container to relative positioning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687688ac6edc8322b9e542a1b9eedae6