### PR TITLE
Add login transition video

### DIFF
--- a/src/ExitVideo.jsx
+++ b/src/ExitVideo.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import exitVideo from './assets/backgrounds/mazed_exit.mp4';
+import './exit-video.css';
+
+export default function ExitVideo({ onEnded }) {
+  return (
+    <div className="exit-video-container">
+      <video
+        className="exit-video"
+        autoPlay
+        playsInline
+        onEnded={onEnded}
+      >
+        <source src={exitVideo} type="video/mp4" />
+      </video>
+    </div>
+  );
+}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import FifthMain from './FifthMain.jsx';
 import IImain from './IImain.jsx';
 import IEmain from './IEmain.jsx';
@@ -7,10 +7,13 @@ import EEmain from './EEmain.jsx';
 import Auth from './Auth.jsx';
 import { supabaseClient } from './supabaseClient';
 import ActivityTimer from './ActivityTimer.jsx';
+import ExitVideo from './ExitVideo.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
   const [user, setUser] = useState(null);
+  const [showExitVideo, setShowExitVideo] = useState(false);
+  const prevUser = useRef(null);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -30,17 +33,24 @@ export default function PageRouter() {
   }, []);
 
   useEffect(() => {
-    if (window.electronAPI && window.electronAPI.setWindowSize) {
-      if (user) {
-        localStorage.setItem('windowWidth', '1920');
-        localStorage.setItem('windowHeight', '1080');
-        window.electronAPI.setWindowSize(1920, 1080);
-      } else {
-        localStorage.setItem('windowWidth', '1600');
-        localStorage.setItem('windowHeight', '900');
-        window.electronAPI.setWindowSize(1600, 900);
-      }
+    if (!window.electronAPI || !window.electronAPI.setWindowSize) return;
+
+    if (user && !prevUser.current) {
+      setShowExitVideo(true);
+      localStorage.setItem('windowWidth', '1920');
+      localStorage.setItem('windowHeight', '1080');
+      window.electronAPI.setWindowSize(1920, 1080);
+    } else if (!user && prevUser.current) {
+      localStorage.setItem('windowWidth', '1600');
+      localStorage.setItem('windowHeight', '900');
+      window.electronAPI.setWindowSize(1600, 900);
     }
+
+    if (!user) {
+      setShowExitVideo(false);
+    }
+
+    prevUser.current = user;
   }, [user]);
 
   useEffect(() => {
@@ -61,6 +71,10 @@ export default function PageRouter() {
 
   if (!user) {
     return <Auth />;
+  }
+
+  if (showExitVideo) {
+    return <ExitVideo onEnded={() => setShowExitVideo(false)} />;
   }
 
   let content;

--- a/src/exit-video.css
+++ b/src/exit-video.css
@@ -1,0 +1,15 @@
+.exit-video-container {
+  position: fixed;
+  inset: 0;
+  background: black;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.exit-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,10 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import PageRouter from './PageRouter.jsx';
 
-const width = localStorage.getItem('windowWidth');
-const height = localStorage.getItem('windowHeight');
-if (width && height && window.electronAPI && window.electronAPI.setWindowSize) {
-  window.electronAPI.setWindowSize(Number(width), Number(height));
+if (window.electronAPI && window.electronAPI.setWindowSize) {
+  window.electronAPI.setWindowSize(1600, 900);
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(<PageRouter />);


### PR DESCRIPTION
## Summary
- always start the Electron window at 1600x900
- show a short video when the user logs in
- resize the window to 1920x1080 after login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68879b7a7788832288f868f5fac8fa7c