### PR TITLE
Add layer tabs to sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,8 +40,15 @@ const tabs = [
   { label: 'Friends', icon: '🤝' },
 ];
 
+const layers = [
+  { label: 'Form', color: 'orange' },
+  { label: 'Semi-Formless', color: 'purple' },
+  { label: 'Formless', color: 'white' },
+];
+
 export default function QuadrantPage({ initialTab }) {
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
+  const [activeLayer, setActiveLayer] = useState(layers[0].label);
   const [showJournal, setShowJournal] = useState(false);
   const [showNofap, setShowNofap] = useState(false);
   const [showRatings, setShowRatings] = useState(false);
@@ -163,8 +170,19 @@ export default function QuadrantPage({ initialTab }) {
           </div>
         </div>
       </aside>
+      <div className="layer-bar">
+        {layers.map((layer) => (
+          <div
+            key={layer.label}
+            className={`layer-dot ${activeLayer === layer.label ? 'active' : ''}`}
+            style={{ backgroundColor: layer.color }}
+            onClick={() => setActiveLayer(layer.label)}
+          />
+        ))}
+      </div>
       <div className="content">
         <h1>{activeTab}</h1>
+        <h2 className="layer-title">{activeLayer}</h2>
         {activeTab === 'Character' && <StatsQuadrant />}
         {activeTab === 'Training' && (
           <div className="training-layout">

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,6 +23,31 @@ body {
   padding: 20px 0;
 }
 
+.layer-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  width: 40px;
+  padding-top: 20px;
+}
+
+.layer-dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.layer-dot.active {
+  outline: 2px solid #fff;
+}
+
+.layer-title {
+  margin: 0 0 10px 0;
+}
+
 .tab {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add Form/Semi-Formless/Formless layer selection to QuadrantPage
- display selected layer under the main tab title
- style new layer tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888bedb1c6083228852c05595171e83