### PR TITLE
Add blog feature to training dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import Timeline from './Timeline.jsx';
 import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
+import TrainingBlog from './TrainingBlog.jsx';
 import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
@@ -61,6 +62,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showTypomancy, setShowTypomancy] = useState(false);
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
+  const [showBlog, setShowBlog] = useState(false);
   const [showQuadrantComb, setShowQuadrantComb] = useState(false);
   const [showTodoGoals, setShowTodoGoals] = useState(false);
   const [showActivity, setShowActivity] = useState(false);
@@ -90,6 +92,7 @@ export default function QuadrantPage({ initialTab }) {
       moodtracker: 'Form',
       quadrantComb: 'Form',
       anima: 'Form',
+      blog: 'Form',
       todoGoals: 'Form',
       activity: 'Form',
       characterEvolve: 'Form',
@@ -272,6 +275,8 @@ export default function QuadrantPage({ initialTab }) {
               <QuadrantCombinaisons onBack={() => setShowQuadrantComb(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
+            ) : showBlog ? (
+              <TrainingBlog onBack={() => setShowBlog(false)} />
             ) : showTodoGoals ? (
               <TodoGoals onBack={() => setShowTodoGoals(false)} />
             ) : showActivity ? (
@@ -440,6 +445,18 @@ export default function QuadrantPage({ initialTab }) {
                   >
                     <div className="star-icon">💃</div>
                     <span>Anima</span>
+                  </div>
+                )}
+                {appLayers.blog === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowBlog(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'blog')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'blog')}
+                  >
+                    <div className="star-icon">📰</div>
+                    <span>Training Blog</span>
                   </div>
                 )}
                 {appLayers.todoGoals === activeLayer && (


### PR DESCRIPTION
## Summary
- import `TrainingBlog` component
- track `showBlog` state in app
- allow initial positioning of the blog card
- show the blog when the state is toggled
- add draggable app card for opening the blog

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889393798d48322adce62b711542aaa