### PR TITLE
fix: preserve newer nofap run when syncing

### DIFF
--- a/NofapCalendar.jsx
+++ b/NofapCalendar.jsx
@@ -48,7 +48,9 @@ export default function NofapCalendar({ onBack }) {
         const active = data.find((r) => r.end === null);
         const completed = data.filter((r) => r.end !== null);
         if (active) {
-          saveRun({ id: active.id, start: active.start });
+          if (!run || active.start > run.start) {
+            saveRun({ id: active.id, start: active.start });
+          }
         }
         if (completed.length) {
           const mapped = completed.map((r) => ({


### PR DESCRIPTION
## Summary
- ensure remote run data doesn't replace a newer local run when app starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ec30a77388322aa5d3e0861457180