### PR TITLE
feat: allow custom backgrounds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,6 +47,9 @@ const layers = [
   { label: 'Formless', color: 'white' },
 ];
 
+const defaultMainBg = './assets/backgrounds/background_EI.jpg';
+const defaultCharBg = './assets/backgrounds/Viego_0.jpg';
+
 export default function QuadrantPage({ initialTab }) {
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
   const [activeLayer, setActiveLayer] = useState(layers[0].label);
@@ -77,6 +80,12 @@ export default function QuadrantPage({ initialTab }) {
   const [showProfile, setShowProfile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
+  const [mainBg, setMainBg] = useState(
+    () => localStorage.getItem('mainBg') || defaultMainBg
+  );
+  const [charBg, setCharBg] = useState(
+    () => localStorage.getItem('charBg') || defaultCharBg
+  );
 
   const initialAppLayers = () => {
     const stored = localStorage.getItem('appLayers');
@@ -119,6 +128,16 @@ export default function QuadrantPage({ initialTab }) {
     document.body.classList.toggle('light-theme', theme === 'light');
     localStorage.setItem('theme', theme);
   }, [theme]);
+
+  useEffect(() => {
+    document.body.style.setProperty('--main-bg-url', `url("${mainBg}")`);
+    localStorage.setItem('mainBg', mainBg);
+  }, [mainBg]);
+
+  useEffect(() => {
+    document.body.style.setProperty('--char-bg-url', `url("${charBg}")`);
+    localStorage.setItem('charBg', charBg);
+  }, [charBg]);
 
   // Hide the Training blog whenever we switch away from the Form layer
   useEffect(() => {
@@ -572,6 +591,10 @@ export default function QuadrantPage({ initialTab }) {
             setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
           }
           onOpenAkashicRecords={() => setShowAkashicRecords(true)}
+          mainBg={mainBg}
+          onChangeMainBg={setMainBg}
+          charBg={charBg}
+          onChangeCharBg={setCharBg}
         />
       )}
       {contextMenu && (

--- a/src/BackgroundUploadModal.jsx
+++ b/src/BackgroundUploadModal.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './note-modal.css';
+import './background-upload-modal.css';
+
+export default function BackgroundUploadModal({ type, current, onApply, onClose }) {
+  const inputRef = useRef(null);
+  const [preview, setPreview] = useState(null);
+  const [recents, setRecents] = useState([]);
+
+  const storageKey = `${type}BgRecents`;
+
+  useEffect(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) setRecents(JSON.parse(stored));
+  }, [storageKey]);
+
+  const saveRecent = (url) => {
+    const newRecents = [url, ...recents.filter((r) => r !== url)].slice(0, 5);
+    localStorage.setItem(storageKey, JSON.stringify(newRecents));
+    setRecents(newRecents);
+  };
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => setPreview(ev.target.result);
+    reader.readAsDataURL(file);
+    inputRef.current.value = '';
+  };
+
+  const handleApply = () => {
+    if (!preview) return;
+    saveRecent(preview);
+    onApply(preview);
+    onClose();
+  };
+
+  const handleSelectRecent = (url) => {
+    onApply(url);
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal background-upload-modal" onClick={(e) => e.stopPropagation()}>
+        <h2>Change {type === 'main' ? 'App' : 'Character'} Background</h2>
+        <div className="preview-grid">
+          <div>
+            <div className="preview-label">Current</div>
+            <img src={current} className="preview-image" />
+          </div>
+          {preview && (
+            <div>
+              <div className="preview-label">New</div>
+              <img src={preview} className="preview-image" />
+            </div>
+          )}
+        </div>
+        <div className="background-drop-area" onClick={() => inputRef.current?.click()}>
+          Click to upload image
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
+        {preview && (
+          <button className="save-button" onClick={handleApply}>
+            Apply
+          </button>
+        )}
+        {recents.length > 0 && (
+          <>
+            <div className="recents-header">Recents</div>
+            <div className="recents-grid">
+              {recents.map((r, idx) => (
+                <img
+                  key={idx}
+                  src={r}
+                  className="recent-bg"
+                  onClick={() => handleSelectRecent(r)}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import './note-modal.css';
+import BackgroundUploadModal from './BackgroundUploadModal.jsx';
 
 export default function SettingsModal({
   onClose,
@@ -8,6 +9,10 @@ export default function SettingsModal({
   onOpenAkashicRecords,
   theme,
   onToggleTheme,
+  mainBg,
+  onChangeMainBg,
+  charBg,
+  onChangeCharBg,
 }) {
   const resolutions = ['800x600', '1024x768', '1280x720', '1600x900', '1920x1080'];
   const [resolution, setResolution] = useState(() => {
@@ -28,6 +33,8 @@ export default function SettingsModal({
       window.electronAPI.setWindowSize(w, h);
     }
   };
+
+  const [bgType, setBgType] = useState(null); // 'main' or 'character'
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -51,6 +58,12 @@ export default function SettingsModal({
         </label>
         <button className="save-button" onClick={onToggleTheme}>
           {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
+        <button className="save-button" onClick={() => setBgType('main')}>
+          Change App Background
+        </button>
+        <button className="save-button" onClick={() => setBgType('character')}>
+          Change Character Background
         </button>
         <button
           className="akashic-button"
@@ -86,6 +99,17 @@ export default function SettingsModal({
           </svg>
         </button>
       </div>
+      {bgType && (
+        <BackgroundUploadModal
+          type={bgType === 'main' ? 'main' : 'character'}
+          current={bgType === 'main' ? mainBg : charBg}
+          onApply={(url) => {
+            if (bgType === 'main') onChangeMainBg(url);
+            else onChangeCharBg(url);
+          }}
+          onClose={() => setBgType(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/background-upload-modal.css
+++ b/src/background-upload-modal.css
@@ -1,0 +1,55 @@
+.background-upload-modal .background-drop-area {
+  width: 100%;
+  height: 120px;
+  border: 2px dashed #5865f2;
+  color: #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin: 10px 0;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.background-upload-modal .preview-grid {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+.background-upload-modal .preview-label {
+  font-size: 0.9em;
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.background-upload-modal .preview-image {
+  width: 120px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.background-upload-modal .recents-header {
+  text-align: center;
+  font-weight: bold;
+  margin-top: 10px;
+}
+
+.background-upload-modal .recents-grid {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 5px;
+}
+
+.background-upload-modal .recent-bg {
+  width: 60px;
+  height: 40px;
+  object-fit: cover;
+  cursor: pointer;
+  border-radius: 4px;
+}

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -5,11 +5,7 @@
   font-style: normal;
 }
 
-body.character-page {
-  background-image: url('./assets/backgrounds/Viego_0.jpg');
-  background-size: cover;
-  background-position: center;
-}
+
 
 .stats-quadrant {
   position: relative;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,10 +1,20 @@
+:root {
+  --main-bg-url: url('./assets/backgrounds/background_EI.jpg');
+  --char-bg-url: url('./assets/backgrounds/Viego_0.jpg');
+}
+
 body {
   margin: 0;
   font-family: sans-serif;
-  /* Replace solid background with custom image */
-  background: url('./assets/backgrounds/background_EI.jpg') no-repeat center center fixed;
+  background: var(--main-bg-url) no-repeat center center fixed;
   background-size: cover;
   color: #e6e7eb;
+}
+
+body.character-page {
+  background: var(--char-bg-url) no-repeat center center fixed;
+  background-size: cover;
+  background-position: center;
 }
 
 


### PR DESCRIPTION
## Summary
- allow choosing app and character backgrounds
- show preview and recent selections before applying
- persist backgrounds via CSS variables and local storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec8d6b9448322bb034b7af5909cbf