### PR TITLE
feat: consolidate background selection

### DIFF
--- a/src/BackgroundUploadModal.jsx
+++ b/src/BackgroundUploadModal.jsx
@@ -8,6 +8,7 @@ export default function BackgroundUploadModal({ type, current, onApply, onClose 
   const [recents, setRecents] = useState([]);
 
   const storageKey = `${type}BgRecents`;
+  const bgKey = type === 'main' ? 'mainBg' : 'charBg';
 
   useEffect(() => {
     const stored = localStorage.getItem(storageKey);
@@ -32,11 +33,13 @@ export default function BackgroundUploadModal({ type, current, onApply, onClose 
   const handleApply = () => {
     if (!preview) return;
     saveRecent(preview);
+    localStorage.setItem(bgKey, preview);
     onApply(preview);
     onClose();
   };
 
   const handleSelectRecent = (url) => {
+    localStorage.setItem(bgKey, url);
     onApply(url);
     onClose();
   };

--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -35,6 +35,12 @@ export default function SettingsModal({
   };
 
   const [bgType, setBgType] = useState(null); // 'main' or 'character'
+  const [showBgChoice, setShowBgChoice] = useState(false);
+
+  const openBgModal = (type) => {
+    setBgType(type);
+    setShowBgChoice(false);
+  };
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -59,12 +65,24 @@ export default function SettingsModal({
         <button className="save-button" onClick={onToggleTheme}>
           {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
         </button>
-        <button className="save-button" onClick={() => setBgType('main')}>
-          Change App Background
+        <button
+          className="save-button"
+          onClick={() => setShowBgChoice((s) => !s)}
+        >
+          Change Background
         </button>
-        <button className="save-button" onClick={() => setBgType('character')}>
-          Change Character Background
-        </button>
+        {showBgChoice && (
+          <div className="bg-selection">
+            <div className="bg-option" onClick={() => openBgModal('character')}>
+              <img src={charBg} className="bg-option-preview" />
+              Character
+            </div>
+            <div className="bg-option" onClick={() => openBgModal('main')}>
+              <img src={mainBg} className="bg-option-preview" />
+              App
+            </div>
+          </div>
+        )}
         <button
           className="akashic-button"
           onClick={() => {

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -106,3 +106,26 @@
   align-self: flex-end;
   color: inherit;
 }
+
+.bg-selection {
+  display: flex;
+  justify-content: space-around;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.bg-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+}
+
+.bg-option-preview {
+  width: 80px;
+  height: 45px;
+  object-fit: cover;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- replace separate background buttons with one "Change Background" option
- show Character or App previews before launching background upload modal
- add styles for background selection grid
- persist selected backgrounds in local storage so they survive reloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ecc4961788322aefc5f3b97167889