### PR TITLE
feat: consolidate background selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ const layers = [
 const defaultMainBg = './assets/backgrounds/background_EI.jpg';
 const defaultCharBg = './assets/backgrounds/Viego_0.jpg';
 
-export default function QuadrantPage({ initialTab }) {
+export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
   const [activeLayer, setActiveLayer] = useState(layers[0].label);
   const [showJournal, setShowJournal] = useState(false);
@@ -595,6 +595,8 @@ export default function QuadrantPage({ initialTab }) {
           onChangeMainBg={setMainBg}
           charBg={charBg}
           onChangeCharBg={setCharBg}
+          menuBg={menuBg}
+          onChangeMenuBg={onChangeMenuBg}
         />
       )}
       {contextMenu && (

--- a/src/BackgroundUploadModal.jsx
+++ b/src/BackgroundUploadModal.jsx
@@ -8,6 +8,8 @@ export default function BackgroundUploadModal({ type, current, onApply, onClose 
   const [recents, setRecents] = useState([]);
 
   const storageKey = `${type}BgRecents`;
+  const bgKey =
+    type === 'main' ? 'mainBg' : type === 'character' ? 'charBg' : 'menuBg';
 
   useEffect(() => {
     const stored = localStorage.getItem(storageKey);
@@ -32,11 +34,13 @@ export default function BackgroundUploadModal({ type, current, onApply, onClose 
   const handleApply = () => {
     if (!preview) return;
     saveRecent(preview);
+    localStorage.setItem(bgKey, preview);
     onApply(preview);
     onClose();
   };
 
   const handleSelectRecent = (url) => {
+    localStorage.setItem(bgKey, url);
     onApply(url);
     onClose();
   };
@@ -44,7 +48,15 @@ export default function BackgroundUploadModal({ type, current, onApply, onClose 
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal background-upload-modal" onClick={(e) => e.stopPropagation()}>
-        <h2>Change {type === 'main' ? 'App' : 'Character'} Background</h2>
+        <h2>
+          Change
+          {type === 'main'
+            ? ' App'
+            : type === 'character'
+            ? ' Character'
+            : ' Main Menu'}{' '}
+          Background
+        </h2>
         <div className="preview-grid">
           <div>
             <div className="preview-label">Current</div>

--- a/src/EEmain.jsx
+++ b/src/EEmain.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import QuadrantPage from './App.jsx';
 
-export default function EEmain() {
-  return <QuadrantPage initialTab="Friends" />;
+export default function EEmain({ menuBg, onChangeMenuBg }) {
+  return (
+    <QuadrantPage
+      initialTab="Friends"
+      menuBg={menuBg}
+      onChangeMenuBg={onChangeMenuBg}
+    />
+  );
 }

--- a/src/EImain.jsx
+++ b/src/EImain.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import QuadrantPage from './App.jsx';
 
-export default function EImain() {
-  return <QuadrantPage initialTab="World" />;
+export default function EImain({ menuBg, onChangeMenuBg }) {
+  return (
+    <QuadrantPage
+      initialTab="World"
+      menuBg={menuBg}
+      onChangeMenuBg={onChangeMenuBg}
+    />
+  );
 }

--- a/src/IEmain.jsx
+++ b/src/IEmain.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import QuadrantPage from './App.jsx';
 
-export default function IEmain() {
-  return <QuadrantPage initialTab="Character" />;
+export default function IEmain({ menuBg, onChangeMenuBg }) {
+  return (
+    <QuadrantPage
+      initialTab="Character"
+      menuBg={menuBg}
+      onChangeMenuBg={onChangeMenuBg}
+    />
+  );
 }

--- a/src/IImain.jsx
+++ b/src/IImain.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import QuadrantPage from './App.jsx';
 
-export default function IImain() {
-  return <QuadrantPage initialTab="Training" />;
+export default function IImain({ menuBg, onChangeMenuBg }) {
+  return (
+    <QuadrantPage
+      initialTab="Training"
+      menuBg={menuBg}
+      onChangeMenuBg={onChangeMenuBg}
+    />
+  );
 }

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -15,6 +15,10 @@ export default function PageRouter() {
   const [showExitVideo, setShowExitVideo] = useState(false);
   const [pendingResize, setPendingResize] = useState(false);
   const prevUser = useRef(null);
+  const defaultMenuBg = './assets/backgrounds/background_EI.jpg';
+  const [menuBg, setMenuBg] = useState(
+    () => localStorage.getItem('menuBg') || defaultMenuBg
+  );
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -64,6 +68,19 @@ export default function PageRouter() {
     }
   }, []);
 
+  useEffect(() => {
+    document.body.style.setProperty('--menu-bg-url', `url("${menuBg}")`);
+    localStorage.setItem('menuBg', menuBg);
+  }, [menuBg]);
+
+  useEffect(() => {
+    if (page === '5th') {
+      document.body.classList.add('menu-page');
+    } else {
+      document.body.classList.remove('menu-page');
+    }
+  }, [page]);
+
   if (!user) {
     return <Auth />;
   }
@@ -85,16 +102,16 @@ export default function PageRouter() {
   let content;
   switch (page) {
     case 'II':
-      content = <IImain />;
+      content = <IImain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
       break;
     case 'IE':
-      content = <IEmain />;
+      content = <IEmain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
       break;
     case 'EI':
-      content = <EImain />;
+      content = <EImain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
       break;
     case 'EE':
-      content = <EEmain />;
+      content = <EEmain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
       break;
     default:
       content = <FifthMain onSelectQuadrant={(label) => setPage(label)} />;

--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -13,6 +13,8 @@ export default function SettingsModal({
   onChangeMainBg,
   charBg,
   onChangeCharBg,
+  menuBg,
+  onChangeMenuBg,
 }) {
   const resolutions = ['800x600', '1024x768', '1280x720', '1600x900', '1920x1080'];
   const [resolution, setResolution] = useState(() => {
@@ -34,7 +36,13 @@ export default function SettingsModal({
     }
   };
 
-  const [bgType, setBgType] = useState(null); // 'main' or 'character'
+  const [bgType, setBgType] = useState(null); // 'main', 'character', or 'menu'
+  const [showBgChoice, setShowBgChoice] = useState(false);
+
+  const openBgModal = (type) => {
+    setBgType(type);
+    setShowBgChoice(false);
+  };
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -59,12 +67,28 @@ export default function SettingsModal({
         <button className="save-button" onClick={onToggleTheme}>
           {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
         </button>
-        <button className="save-button" onClick={() => setBgType('main')}>
-          Change App Background
+        <button
+          className="save-button"
+          onClick={() => setShowBgChoice((s) => !s)}
+        >
+          Change Background
         </button>
-        <button className="save-button" onClick={() => setBgType('character')}>
-          Change Character Background
-        </button>
+        {showBgChoice && (
+          <div className="bg-selection">
+            <div className="bg-option" onClick={() => openBgModal('character')}>
+              <img src={charBg} className="bg-option-preview" />
+              Character
+            </div>
+            <div className="bg-option" onClick={() => openBgModal('main')}>
+              <img src={mainBg} className="bg-option-preview" />
+              App
+            </div>
+            <div className="bg-option" onClick={() => openBgModal('menu')}>
+              <img src={menuBg} className="bg-option-preview" />
+              Main Menu
+            </div>
+          </div>
+        )}
         <button
           className="akashic-button"
           onClick={() => {
@@ -101,11 +125,18 @@ export default function SettingsModal({
       </div>
       {bgType && (
         <BackgroundUploadModal
-          type={bgType === 'main' ? 'main' : 'character'}
-          current={bgType === 'main' ? mainBg : charBg}
+          type={bgType}
+          current={
+            bgType === 'main'
+              ? mainBg
+              : bgType === 'character'
+              ? charBg
+              : menuBg
+          }
           onApply={(url) => {
             if (bgType === 'main') onChangeMainBg(url);
-            else onChangeCharBg(url);
+            else if (bgType === 'character') onChangeCharBg(url);
+            else onChangeMenuBg(url);
           }}
           onClose={() => setBgType(null)}
         />

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -106,3 +106,26 @@
   align-self: flex-end;
   color: inherit;
 }
+
+.bg-selection {
+  display: flex;
+  justify-content: space-around;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.bg-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+}
+
+.bg-option-preview {
+  width: 80px;
+  height: 45px;
+  object-fit: cover;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,7 @@
 :root {
   --main-bg-url: url('./assets/backgrounds/background_EI.jpg');
   --char-bg-url: url('./assets/backgrounds/Viego_0.jpg');
+  --menu-bg-url: url('./assets/backgrounds/background_EI.jpg');
 }
 
 body {
@@ -9,6 +10,11 @@ body {
   background: var(--main-bg-url) no-repeat center center fixed;
   background-size: cover;
   color: #e6e7eb;
+}
+
+body.menu-page {
+  background: var(--menu-bg-url) no-repeat center center fixed;
+  background-size: cover;
 }
 
 body.character-page {


### PR DESCRIPTION
## Summary
- replace separate background buttons with one "Change Background" option
- show Character, App, or Main Menu previews before launching background upload modal
- add styles and routing to persist backgrounds in local storage so they survive reloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ecc4961788322aefc5f3b97167889