### PR TITLE
Rename Training to Tools and adjust layer controls

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -13,7 +13,7 @@ import Timeline from './Timeline.jsx';
 import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
-import TrainingBlog from './src/TrainingBlog.jsx';
+import ToolsBlog from './src/ToolsBlog.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -28,7 +28,7 @@ const placeholderImg =
   "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'50'%20height%3D'50'%3E%3Crect%20width%3D'50'%20height%3D'50'%20rx%3D'25'%20fill%3D'%23444'%2F%3E%3Ctext%20x%3D'25'%20y%3D'33'%20font-size%3D'26'%20text-anchor%3D'middle'%20fill%3D'%23aaa'%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E";
 
 const tabs = [
-  { label: 'Training', icon: '🧠' },
+  { label: 'Tools', icon: '🧠' },
   { label: 'Character', icon: '👤' },
   { label: 'World', icon: '🌍' },
   { label: 'Friends', icon: '🤝' },
@@ -49,7 +49,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
   // Avoid naming clash with src/App.jsx by giving the blog state a unique name
-  const [showTrainingBlog, setShowTrainingBlog] = useState(false);
+  const [showToolsBlog, setShowToolsBlog] = useState(false);
   const [showAkashicRecords, setShowAkashicRecords] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
@@ -145,8 +145,8 @@ export default function QuadrantPage({ initialTab }) {
       <div className="content">
         <h1>{activeTab}</h1>
         {activeTab === 'Character' && <StatsQuadrant />}
-        {activeTab === 'Training' && (
-          <div className="training-layout">
+        {activeTab === 'Tools' && (
+          <div className="tools-layout">
             {showJournal ? (
               <QuestJournal onBack={() => setShowJournal(false)} />
             ) : showNofap ? (
@@ -169,8 +169,8 @@ export default function QuadrantPage({ initialTab }) {
               <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : showMoodtracker ? (
               <Moodtracker onBack={() => setShowMoodtracker(false)} />
-            ) : showTrainingBlog ? (
-              <TrainingBlog onBack={() => setShowTrainingBlog(false)} />
+            ) : showToolsBlog ? (
+              <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : (
@@ -219,7 +219,7 @@ export default function QuadrantPage({ initialTab }) {
                   <div className="star-icon">😊</div>
                   <span>Moodtracker</span>
                 </div>
-                <div className="app-card" onClick={() => setShowTrainingBlog(true)}>
+                <div className="app-card" onClick={() => setShowToolsBlog(true)}>
                   <div className="star-icon">📝</div>
                   <span>Blog</span>
                 </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import Timeline from './Timeline.jsx';
 import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
-import TrainingBlog from './TrainingBlog.jsx';
+import ToolsBlog from './ToolsBlog.jsx';
 import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
@@ -35,7 +35,7 @@ const placeholderImg =
   "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'50'%20height%3D'50'%3E%3Crect%20width%3D'50'%20height%3D'50'%20rx%3D'25'%20fill%3D'%23444'%2F%3E%3Ctext%20x%3D'25'%20y%3D'33'%20font-size%3D'26'%20text-anchor%3D'middle'%20fill%3D'%23aaa'%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E";
 
 const tabs = [
-  { label: 'Training', icon: '🧠' },
+  { label: 'Tools', icon: '🧠' },
   { label: 'Character', icon: '👤' },
   { label: 'World', icon: '🌍' },
   { label: 'Friends', icon: '🤝' },
@@ -66,7 +66,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   // Blog visibility starts hidden and becomes visible when on the Form layer.
   // Use a unique name to avoid clashes with the top-level App component.
-  const [showTrainingBlog, setShowTrainingBlog] = useState(false);
+  const [showToolsBlog, setShowToolsBlog] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
   const [showBlog, setShowBlog] = useState(false);
   const [showQuadrantComb, setShowQuadrantComb] = useState(false);
@@ -139,10 +139,10 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     localStorage.setItem('charBg', charBg);
   }, [charBg]);
 
-  // Hide the Training blog whenever we switch away from the Form layer
+  // Hide the Tools blog whenever we switch away from the Form layer
   useEffect(() => {
     if (activeLayer !== 'Form') {
-      setShowTrainingBlog(false);
+      setShowToolsBlog(false);
     }
   }, [activeLayer]);
 
@@ -245,6 +245,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
+        <div className="layer-bar">
+          {layers.map((layer) => (
+            <div
+              key={layer.label}
+              className={`layer-dot ${activeLayer === layer.label ? 'active' : ''}`}
+              style={{ backgroundColor: layer.color }}
+              onClick={() => setActiveLayer(layer.label)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => handleDropOnLayer(e, layer.label)}
+            />
+          ))}
+        </div>
         <div className="bottom-buttons">
           <div className="settings-button" onClick={() => setShowSettings(true)}>
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -260,24 +272,12 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
           </div>
         </div>
       </aside>
-      <div className="layer-bar">
-        {layers.map((layer) => (
-          <div
-            key={layer.label}
-            className={`layer-dot ${activeLayer === layer.label ? 'active' : ''}`}
-            style={{ backgroundColor: layer.color }}
-            onClick={() => setActiveLayer(layer.label)}
-            onDragOver={(e) => e.preventDefault()}
-            onDrop={(e) => handleDropOnLayer(e, layer.label)}
-          />
-        ))}
-      </div>
       <div className="content">
         <h1>{activeTab}</h1>
         <h2 className="layer-title">{activeLayer}</h2>
         {activeTab === 'Character' && <StatsQuadrant />}
-        {activeTab === 'Training' && (
-          <div className="training-layout">
+        {activeTab === 'Tools' && (
+          <div className="tools-layout">
             {showJournal ? (
               <QuestJournal onBack={() => setShowJournal(false)} />
             ) : showNofap ? (
@@ -305,7 +305,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : showBlog ? (
-              <TrainingBlog onBack={() => setShowBlog(false)} />
+              <ToolsBlog onBack={() => setShowBlog(false)} />
             ) : showTodoGoals ? (
               <TodoGoals onBack={() => setShowTodoGoals(false)} />
             ) : showActivity ? (
@@ -318,8 +318,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <ImplementationIdeas onBack={() => setShowImplementationIdeas(false)} />
             ) : showOrb ? (
               <Orb onBack={() => setShowOrb(false)} />
-            ) : activeLayer === 'Form' && showTrainingBlog ? (
-              <TrainingBlog onBack={() => setShowTrainingBlog(false)} />
+            ) : activeLayer === 'Form' && showToolsBlog ? (
+              <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : (
               <div className="feature-cards">
                 {appLayers.journal === activeLayer && (
@@ -487,7 +487,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                     onDragStart={(e) => handleDragStart(e, 'blog')}
                   >
                     <div className="star-icon">📰</div>
-                    <span>Training Blog</span>
+                    <span>Tools Blog</span>
                   </div>
                 )}
                 {appLayers.todoGoals === activeLayer && (
@@ -550,8 +550,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                     <span>Implementation Ideas</span>
                   </div>
                 )}
-                {!showTrainingBlog && activeLayer === 'Form' && (
-                  <div className="app-card" onClick={() => setShowTrainingBlog(true)}>
+                {!showToolsBlog && activeLayer === 'Form' && (
+                  <div className="app-card" onClick={() => setShowToolsBlog(true)}>
                     <div className="star-icon">📝</div>
                     <span>Blog</span>
                   </div>

--- a/src/IImain.jsx
+++ b/src/IImain.jsx
@@ -4,7 +4,7 @@ import QuadrantPage from './App.jsx';
 export default function IImain({ menuBg, onChangeMenuBg }) {
   return (
     <QuadrantPage
-      initialTab="Training"
+      initialTab="Tools"
       menuBg={menuBg}
       onChangeMenuBg={onChangeMenuBg}
     />

--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
-import './training-blog.css';
+import './tools-blog.css';
 
-export default function TrainingBlog({ onBack }) {
+export default function ToolsBlog({ onBack }) {
   const [posts, setPosts] = useState(
     Array.from({ length: 10 }, (_, i) => ({ id: i, text: `Post #${i + 1}` }))
   );
@@ -26,14 +26,14 @@ export default function TrainingBlog({ onBack }) {
   };
 
   return (
-    <div className="training-blog" id="training-blog">
+    <div className="tools-blog" id="tools-blog">
       <button className="back-button" onClick={onBack}>Back</button>
       <InfiniteScroll
         dataLength={posts.length}
         next={fetchMore}
         hasMore={hasMore}
         loader={<p>Loading...</p>}
-        scrollableTarget="training-blog"
+        scrollableTarget="tools-blog"
       >
         {posts.map((p) => (
           <div key={p.id} className="blog-post">

--- a/src/styles.css
+++ b/src/styles.css
@@ -44,8 +44,7 @@ body.character-page {
   flex-direction: column;
   align-items: center;
   gap: 10px;
-  width: 40px;
-  padding-top: 20px;
+  margin-top: 20px;
 }
 
 .layer-dot {
@@ -201,7 +200,7 @@ body.idea-board-page .content {
   border-radius: 4px;
 }
 
-.training-layout {
+.tools-layout {
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -1,4 +1,4 @@
-.training-blog {
+.tools-blog {
   background: #000;
   color: #fff;
   height: calc(100vh - 60px);

--- a/styles.css
+++ b/styles.css
@@ -137,7 +137,7 @@ body.character-page h1 {
   border-radius: 4px;
 }
 
-.training-layout {
+.tools-layout {
   display: flex;
   align-items: flex-start;
   gap: 20px;


### PR DESCRIPTION
## Summary
- Rename Training tab and related blog to Tools, updating state and imports.
- Move layer selection dots into the sidebar and tweak styling for the new layout.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fbee2572c832296c03d2f6965b06e