### PR TITLE
Add Momento Mori tool with drag-and-drop billets

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -14,6 +14,7 @@ import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './src/ToolsBlog.jsx';
+import MomentoMori from './MomentoMori.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -48,6 +49,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showTypomancy, setShowTypomancy] = useState(false);
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
+  const [showMomentoMori, setShowMomentoMori] = useState(false);
   // Avoid naming clash with src/App.jsx by giving the blog state a unique name
   const [showToolsBlog, setShowToolsBlog] = useState(false);
   const [showAkashicRecords, setShowAkashicRecords] = useState(false);
@@ -171,6 +173,8 @@ export default function QuadrantPage({ initialTab }) {
               <Moodtracker onBack={() => setShowMoodtracker(false)} />
             ) : showToolsBlog ? (
               <ToolsBlog onBack={() => setShowToolsBlog(false)} />
+            ) : showMomentoMori ? (
+              <MomentoMori onBack={() => setShowMomentoMori(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : (
@@ -218,6 +222,10 @@ export default function QuadrantPage({ initialTab }) {
                 <div className="app-card" onClick={() => setShowMoodtracker(true)}>
                   <div className="star-icon">😊</div>
                   <span>Moodtracker</span>
+                </div>
+                <div className="app-card" onClick={() => setShowMomentoMori(true)}>
+                  <div className="star-icon">☠️</div>
+                  <span>Momento Mori</span>
                 </div>
                 <div className="app-card" onClick={() => setShowToolsBlog(true)}>
                   <div className="star-icon">📝</div>

--- a/MomentoMori.jsx
+++ b/MomentoMori.jsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import './momento-mori.css';
+
+export default function MomentoMori({ onBack }) {
+  const [columns, setColumns] = useState({
+    canDo: [],
+    cantDo: [],
+    wishes: [],
+  });
+
+  const [newCards, setNewCards] = useState({
+    canDo: { text: '', type: 'Form' },
+    cantDo: { text: '', type: 'Form' },
+    wishes: { text: '', type: 'Form' },
+  });
+
+  const [dragInfo, setDragInfo] = useState(null);
+
+  const handleAdd = (column) => {
+    const entry = newCards[column];
+    if (!entry.text.trim()) return;
+    const card = {
+      id: Date.now(),
+      text: entry.text,
+      type: entry.type,
+    };
+    setColumns((prev) => ({
+      ...prev,
+      [column]: [...prev[column], card],
+    }));
+    setNewCards((prev) => ({
+      ...prev,
+      [column]: { text: '', type: 'Form' },
+    }));
+  };
+
+  const handleDelete = (column, id) => {
+    setColumns((prev) => ({
+      ...prev,
+      [column]: prev[column].filter((c) => c.id !== id),
+    }));
+  };
+
+  const handleEdit = (column, id, text) => {
+    setColumns((prev) => ({
+      ...prev,
+      [column]: prev[column].map((c) => (c.id === id ? { ...c, text } : c)),
+    }));
+  };
+
+  const onDragStart = (column, index) => (e) => {
+    setDragInfo({ column, index });
+  };
+
+  const onDragOver = (e) => {
+    e.preventDefault();
+  };
+
+  const onDrop = (column) => (e) => {
+    e.preventDefault();
+    if (!dragInfo) return;
+    setColumns((prev) => {
+      const fromList = [...prev[dragInfo.column]];
+      const [item] = fromList.splice(dragInfo.index, 1);
+      const toList = [...prev[column], item];
+      return {
+        ...prev,
+        [dragInfo.column]: fromList,
+        [column]: toList,
+      };
+    });
+    setDragInfo(null);
+  };
+
+  const updateNewCardField = (column, field, value) => {
+    setNewCards((prev) => ({
+      ...prev,
+      [column]: { ...prev[column], [field]: value },
+    }));
+  };
+
+  return (
+    <div className="momento-mori">
+      <button className="back-button" onClick={onBack}>
+        ← Back
+      </button>
+      <div className="momento-columns">
+        {['canDo', 'cantDo', 'wishes'].map((col) => (
+          <div
+            key={col}
+            className="momento-column"
+            onDragOver={onDragOver}
+            onDrop={onDrop(col)}
+          >
+            <h2>
+              {col === 'canDo'
+                ? 'Can Do Now'
+                : col === 'cantDo'
+                ? "Can't Do"
+                : 'Wishes'}
+            </h2>
+            {columns[col].map((card, index) => (
+              <div
+                key={card.id}
+                className="momento-card"
+                draggable
+                onDragStart={onDragStart(col, index)}
+              >
+                <span className={`type-tag ${card.type.replace(/\s+/g, '-').toLowerCase()}`}>
+                  {card.type}
+                </span>
+                <EditableText
+                  text={card.text}
+                  onChange={(t) => handleEdit(col, card.id, t)}
+                />
+                <button
+                  className="delete-btn"
+                  onClick={() => handleDelete(col, card.id)}
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+            <div className="add-card">
+              <input
+                type="text"
+                placeholder="New billet"
+                value={newCards[col].text}
+                onChange={(e) => updateNewCardField(col, 'text', e.target.value)}
+              />
+              <select
+                value={newCards[col].type}
+                onChange={(e) => updateNewCardField(col, 'type', e.target.value)}
+              >
+                <option>Form</option>
+                <option>Semi Formless</option>
+                <option>Formless</option>
+              </select>
+              <button onClick={() => handleAdd(col)}>Add</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EditableText({ text, onChange }) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(text);
+
+  const save = () => {
+    onChange(value);
+    setEditing(false);
+  };
+
+  return editing ? (
+    <div className="edit-area">
+      <input value={value} onChange={(e) => setValue(e.target.value)} />
+      <button onClick={save}>Save</button>
+    </div>
+  ) : (
+    <span className="card-text" onDoubleClick={() => setEditing(true)}>
+      {text}
+    </span>
+  );
+}

--- a/momento-mori.css
+++ b/momento-mori.css
@@ -1,0 +1,106 @@
+.momento-mori {
+  padding: 20px;
+}
+
+.momento-columns {
+  display: flex;
+  gap: 20px;
+}
+
+.momento-column {
+  flex: 1;
+  background: #222;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.momento-column h2 {
+  text-align: center;
+  margin-top: 0;
+}
+
+.momento-card {
+  background: #333;
+  color: #fff;
+  padding: 8px;
+  margin-bottom: 8px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.type-tag {
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: #555;
+  text-transform: capitalize;
+}
+
+.type-tag.form {
+  background: #2e8b57;
+}
+
+.type-tag.semi-formless {
+  background: #8b4513;
+}
+
+.type-tag.formless {
+  background: #4682b4;
+}
+
+.delete-btn {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+
+.add-card {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.add-card input,
+.add-card select {
+  padding: 4px;
+  border-radius: 4px;
+  border: 1px solid #444;
+  background: #111;
+  color: white;
+}
+
+.add-card button {
+  padding: 4px;
+  border: none;
+  border-radius: 4px;
+  background: #444;
+  color: white;
+  cursor: pointer;
+}
+
+.edit-area input {
+  padding: 4px;
+  border-radius: 4px;
+  border: 1px solid #444;
+  background: #111;
+  color: white;
+}
+
+.edit-area button {
+  margin-top: 4px;
+  padding: 4px;
+  border: none;
+  border-radius: 4px;
+  background: #444;
+  color: white;
+  cursor: pointer;
+}
+
+.card-text {
+  flex: 1;
+}


### PR DESCRIPTION
## Summary
- add Momento Mori component with three columns for tracking tasks and wishes
- allow adding, editing, deleting and dragging billets between columns
- expose Momento Mori via new card in Tools menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890df1b2a6483229f5e743de88d34b7