### PR TITLE
Replace sidebar layer buttons with top mode tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -256,18 +256,6 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
-        <div className="layer-bar">
-          {layers.map((layer) => (
-            <div
-              key={layer.label}
-              className={`layer-dot ${activeLayer === layer.label ? 'active' : ''}`}
-              style={{ backgroundColor: layer.color }}
-              onClick={() => setActiveLayer(layer.label)}
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={(e) => handleDropOnLayer(e, layer.label)}
-            />
-          ))}
-        </div>
         <div className="bottom-buttons">
           <div className="settings-button" onClick={() => setShowSettings(true)}>
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -284,8 +272,27 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
         </div>
       </aside>
       <div className="content">
+        <div className="layer-tabs">
+          {layers.map((layer) => (
+            <div
+              key={layer.label}
+              className={`layer-tab ${activeLayer === layer.label ? 'active' : ''}`}
+              style={{
+                borderBottom:
+                  activeLayer === layer.label
+                    ? `3px solid ${layer.color}`
+                    : '3px solid transparent',
+                color: activeLayer === layer.label ? layer.color : '#e6e7eb',
+              }}
+              onClick={() => setActiveLayer(layer.label)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => handleDropOnLayer(e, layer.label)}
+            >
+              {layer.label}
+            </div>
+          ))}
+        </div>
         <h1>{activeTab}</h1>
-        <h2 className="layer-title">{activeLayer}</h2>
         {activeTab === 'Character' && <StatsQuadrant />}
         {activeTab === 'Tools' && (
           <div className="tools-layout">

--- a/src/styles.css
+++ b/src/styles.css
@@ -39,30 +39,6 @@ body.character-page {
   padding: 20px 0;
 }
 
-.layer-bar {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 10px;
-  margin-top: 20px;
-}
-
-.layer-dot {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-}
-
-.layer-dot.active {
-  outline: 2px solid #fff;
-}
-
-.layer-title {
-  margin: 0 0 10px 0;
-}
-
 .tab {
   display: flex;
   align-items: center;
@@ -87,6 +63,32 @@ body.character-page {
   background-color: #222;
   color: #fff;
   background-color: #e0e0e0
+}
+
+.layer-tabs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.layer-tab {
+  padding: 8px 16px;
+  background-color: rgba(128, 128, 128, 0.6);
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+  user-select: none;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+  filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+  transition: background-color 0.2s;
+  border-bottom: 3px solid transparent;
+}
+
+.layer-tab.active {
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.layer-tab:hover {
+  background-color: rgba(128, 128, 128, 0.8);
 }
 
 .content {


### PR DESCRIPTION
## Summary
- Replace left sidebar layer dots with top-aligned mode tabs for Form, Semi-Formless, and Formless modes
- Add new styling for layer tabs and remove old layer dot styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a00a91d0c8322941be510c0ceaddc