### PR TITLE
feat: add reusable level rating component

### DIFF
--- a/src/LevelRating.jsx
+++ b/src/LevelRating.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import './level-rating.css';
+
+export const RARITY_LEVELS = [
+  { key: 'transcendent', label: 'Transcendent', color: '#e6e6fa', textColor: '#000' },
+  { key: 'rainbow', label: 'Rainbow', color: 'linear-gradient(90deg, red, orange, yellow, green, blue, indigo, violet)', textColor: '#000' },
+  { key: 'jackpot', label: 'Jackpot', color: '#ff1493', textColor: '#000' },
+  { key: 'white', label: 'White', color: '#ffffff', textColor: '#000' },
+  { key: 'golden', label: 'Golden', color: '#ffd700', textColor: '#000' },
+  { key: 'blue', label: 'Blue', color: '#1e90ff', textColor: '#fff' },
+  { key: 'green', label: 'Green', color: '#32cd32', textColor: '#000' },
+  { key: 'yellow', label: 'Yellow', color: '#ffff00', textColor: '#000' },
+  { key: 'red', label: 'Red', color: '#ff4500', textColor: '#fff' },
+  { key: 'purple', label: 'Purple', color: '#800080', textColor: '#fff' },
+  { key: 'dark', label: 'Dark', color: '#2f4f4f', textColor: '#fff' },
+  { key: 'buglight', label: 'Buglight', color: 'linear-gradient(45deg, #00ffff, #ff00ff)', textColor: '#000' },
+  { key: 'darkskull', label: 'Dark (Skull)', color: '#000000', textColor: '#fff' },
+  { key: 'black', label: 'Black', color: '#000000', textColor: '#fff' },
+  { key: 'doom', label: 'Doom', color: '#000000', textColor: '#ff0000' },
+];
+
+export default function LevelRating({ value, onChange, readOnly = false }) {
+  if (readOnly) {
+    const r = RARITY_LEVELS.find((lvl) => lvl.key === value);
+    if (!r) return null;
+    return (
+      <div className="level-rating readonly">
+        <div
+          className="level-option selected"
+          style={{ background: r.color, color: r.textColor }}
+        >
+          {r.label}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="level-rating">
+      {RARITY_LEVELS.map((r) => (
+        <div
+          key={r.key}
+          className={`level-option ${value === r.key ? 'selected' : ''}`}
+          style={{ background: r.color, color: r.textColor }}
+          onClick={() => onChange(r.key)}
+        >
+          {r.label}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/VersionModal.jsx
+++ b/src/VersionModal.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import './note-modal.css';
+import LevelRating, { RARITY_LEVELS } from './LevelRating.jsx';
 
 export default function VersionModal({ onAdd, onClose }) {
   const [name, setName] = useState('');
-  const [rating, setRating] = useState('');
+  const [rating, setRating] = useState(RARITY_LEVELS[0].key);
   const [liked, setLiked] = useState(false);
   const [ii, setII] = useState('');
   const [ie, setIE] = useState('');
@@ -15,7 +16,7 @@ export default function VersionModal({ onAdd, onClose }) {
     onAdd({
       id: Date.now(),
       name: name || 'Unnamed',
-      rating: parseInt(rating, 10) || 0,
+      rating,
       liked,
       quadrants: { II: ii, IE: ie, EI: ei, EE: ee },
       notes,
@@ -32,13 +33,7 @@ export default function VersionModal({ onAdd, onClose }) {
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        <input
-          className="note-title"
-          type="number"
-          placeholder="Rating"
-          value={rating}
-          onChange={(e) => setRating(e.target.value)}
-        />
+        <LevelRating value={rating} onChange={setRating} />
         <label style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
           <input
             type="checkbox"

--- a/src/VersionRating.jsx
+++ b/src/VersionRating.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import VersionModal from './VersionModal.jsx';
+import LevelRating, { RARITY_LEVELS } from './LevelRating.jsx';
 import './version-rating.css';
 
 export default function VersionRating({ onBack }) {
@@ -21,7 +22,10 @@ export default function VersionRating({ onBack }) {
     setVersions(versions.filter((v) => v.id !== id));
   };
 
-  const sorted = [...versions].sort((a, b) => b.rating - a.rating);
+  const rarityOrder = RARITY_LEVELS.map((r) => r.key);
+  const sorted = [...versions].sort(
+    (a, b) => rarityOrder.indexOf(a.rating) - rarityOrder.indexOf(b.rating)
+  );
 
   return (
     <div className="version-rating">
@@ -31,7 +35,9 @@ export default function VersionRating({ onBack }) {
           <div key={v.id} className="version-card">
             <div className="version-header">
               <div className="version-name">{v.name}</div>
-              <div className="version-score">{v.rating}</div>
+            <div className="version-score">
+              <LevelRating value={v.rating} readOnly />
+            </div>
               <div className="version-like">{v.liked ? '👍' : '👎'}</div>
               <button
                 className="delete-button"

--- a/src/level-rating.css
+++ b/src/level-rating.css
@@ -1,0 +1,22 @@
+.level-rating {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.level-option {
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8em;
+  border: 1px solid #555;
+  user-select: none;
+}
+
+.level-option.selected {
+  outline: 2px solid #fff;
+}
+
+.level-rating.readonly .level-option {
+  cursor: default;
+}


### PR DESCRIPTION
## Summary
- add LevelRating component with color-coded rarity levels
- use LevelRating in VersionModal and VersionRating for tagging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0bdaee988322a49a7a769afabe72