### PR TITLE
Add profile disconnect button

### DIFF
--- a/ProfileModal.jsx
+++ b/ProfileModal.jsx
@@ -100,6 +100,14 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
     }
   };
 
+  const handleSignOut = async () => {
+    if (window.electronAPI?.setWindowSize) {
+      window.electronAPI.setWindowSize(1600, 900);
+    }
+    await supabaseClient.auth.signOut();
+    if (onClose) onClose();
+  };
+
   return (
     <div className="modal-overlay profile-overlay" onClick={onClose}>
       <div className="modal profile-modal" onClick={(e) => e.stopPropagation()}>
@@ -132,6 +140,9 @@ export default function ProfileModal({ onClose, onAvatarUpdated }) {
             </div>
           </>
         )}
+        <div className="disconnect-line">
+          <button className="disconnect-btn" onClick={handleSignOut}>Disconnect</button>
+        </div>
       </div>
       {showUpload && (
         <AvatarUploadModal

--- a/profile-modal.css
+++ b/profile-modal.css
@@ -35,6 +35,23 @@
   background: #4752d3;
 }
 
+.disconnect-line {
+  text-align: center;
+  margin-top: 10px;
+}
+
+.disconnect-btn {
+  background: #5865f2;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+}
+.disconnect-btn:hover {
+  background: #4752d3;
+}
+
 .profile-overlay {
   background: transparent;
 }


### PR DESCRIPTION
## Summary
- add sign out button beneath username in profile modal
- style disconnect button to match existing profile controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b073a353c8322a113ea0102dd5796