### PR TITLE
Add custom Electron window controls

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -25,6 +25,21 @@ import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
 
+const WindowControls = () => (
+  <div className="custom-titlebar">
+    <div className="window-controls">
+      <button
+        className="control-button toggle"
+        onClick={() => window.electronAPI.toggleWindow()}
+      />
+      <button
+        className="control-button close"
+        onClick={() => window.electronAPI.closeWindow()}
+      />
+    </div>
+  </div>
+);
+
 const placeholderImg =
   "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'50'%20height%3D'50'%3E%3Crect%20width%3D'50'%20height%3D'50'%20rx%3D'25'%20fill%3D'%23444'%2F%3E%3Ctext%20x%3D'25'%20y%3D'33'%20font-size%3D'26'%20text-anchor%3D'middle'%20fill%3D'%23aaa'%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E";
 
@@ -110,6 +125,7 @@ export default function QuadrantPage({ initialTab }) {
     return (
       <QuestProvider>
         <ActivityLogger enabled={autoLog} />
+        <WindowControls />
         <AkashicRecords onBack={() => setShowAkashicRecords(false)} />
       </QuestProvider>
     );
@@ -118,6 +134,7 @@ export default function QuadrantPage({ initialTab }) {
   return (
     <QuestProvider>
       <ActivityLogger enabled={autoLog} />
+      <WindowControls />
       <div className="app-container">
       <aside className="sidebar">
         {tabs.map((tab) => (

--- a/electron-main.js
+++ b/electron-main.js
@@ -8,6 +8,8 @@ function createWindow() {
     width: 1600,
     height: 900,
     resizable: false,
+    frame: false,
+    titleBarStyle: 'hidden',
     icon: path.join(__dirname, 'src/assets/icons/mazed_logo_hd.png'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -71,6 +73,21 @@ function createWindow() {
 ipcMain.handle('set-window-size', (_e, { width, height }) => {
   if (mainWindow) {
     mainWindow.setSize(Number(width), Number(height));
+  }
+});
+
+ipcMain.handle('toggle-window', () => {
+  if (!mainWindow) return;
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore();
+  } else {
+    mainWindow.minimize();
+  }
+});
+
+ipcMain.handle('close-window', () => {
+  if (mainWindow) {
+    mainWindow.close();
   }
 });
 

--- a/preload.js
+++ b/preload.js
@@ -5,4 +5,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onDisconnect: (callback) => ipcRenderer.on('disconnect', callback),
   onActivity: (callback) => ipcRenderer.on('activity', callback),
   setWindowSize: (width, height) => ipcRenderer.invoke('set-window-size', { width, height }),
+  toggleWindow: () => ipcRenderer.invoke('toggle-window'),
+  closeWindow: () => ipcRenderer.invoke('close-window'),
 });

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,8 @@ body {
 .app-container {
   display: flex;
   height: 100vh;
+  box-sizing: border-box;
+  padding-top: 30px;
 }
 
 .sidebar {
@@ -178,6 +180,41 @@ body.character-page h1 {
   padding: 6px 12px;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.custom-titlebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  padding-left: 10px;
+  -webkit-app-region: drag;
+  z-index: 1000;
+}
+
+.window-controls {
+  display: flex;
+  gap: 10px;
+}
+
+.control-button {
+  width: 12px;
+  height: 12px;
+  border: none;
+  border-radius: 6px;
+  -webkit-app-region: no-drag;
+  cursor: pointer;
+}
+
+.control-button.toggle {
+  background: #f1c40f;
+}
+
+.control-button.close {
+  background: #e74c3c;
 }
 
 


### PR DESCRIPTION
## Summary
- Remove default Electron frame and expose IPC handlers to toggle or close the window
- Add custom title bar with toggle and close buttons
- Style layout to include draggable title area and padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b122767c48322951a7124af304c05