### PR TITLE
Add manual percentage bars for semi-formless

### DIFF
--- a/CharacterEvolve.test.js
+++ b/CharacterEvolve.test.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import CharacterEvolve from './src/CharacterEvolve.jsx';
 
-test('shows evolve bars', () => {
+test('allows manual percentage entry', async () => {
   render(<CharacterEvolve onBack={() => {}} />);
-  expect(screen.getByText(/II Love/i)).toBeInTheDocument();
-  expect(screen.getByLabelText('add II')).toBeInTheDocument();
+  window.prompt = jest.fn().mockReturnValue('42');
+  await userEvent.click(screen.getByLabelText('add Form'));
+  expect(window.prompt).toHaveBeenCalled();
+  expect(screen.getByText('42%')).toBeInTheDocument();
 });

--- a/src/CharacterEvolve.jsx
+++ b/src/CharacterEvolve.jsx
@@ -4,9 +4,21 @@ import './character-evolve.css';
 
 const BARS = [
   { key: 'II', text: 'Love - Help people' },
-  { key: 'IE', text: 'Fun - Make something deep meaningful, and fun' },
-  { key: 'EI', text: 'Peace - Make things beautiful, be surrounded by beauty' },
+  {
+    key: 'IE',
+    text: 'Fun - Make something deep meaningful, and fun',
+  },
+  {
+    key: 'EI',
+    text: 'Peace - Make things beautiful, be surrounded by beauty',
+  },
   { key: 'EE', text: 'Awe - Make everything at the max degree possible' },
+];
+
+const SEMI_FORMLESS_BARS = [
+  { key: 'form', text: 'Form' },
+  { key: 'semi', text: 'Semi-formless' },
+  { key: 'formless', text: 'Formless' },
 ];
 
 export default function CharacterEvolve({ onBack }) {
@@ -22,34 +34,51 @@ export default function CharacterEvolve({ onBack }) {
     localStorage.setItem('evolveValues', JSON.stringify(values));
   }, [values]);
 
-  const increment = (key) => {
-    setValues((prev) => ({
-      ...prev,
-      [key]: Math.min((prev[key] || 0) + 10, 100),
-    }));
+  const setManualValue = (key) => {
+    const input = window.prompt('Enter a value between 0 and 100:');
+    if (input === null) return;
+    const num = parseInt(input, 10);
+    if (!Number.isNaN(num)) {
+      setValues((prev) => ({
+        ...prev,
+        [key]: Math.max(0, Math.min(num, 100)),
+      }));
+    }
   };
+
+  const renderBar = ({ key, display, aria }) => (
+    <div key={key} className="evolve-line">
+      <button
+        className="add-btn"
+        aria-label={`add ${aria}`}
+        onClick={() => setManualValue(key)}
+      >
+        +
+      </button>
+      <div className="label">{display}</div>
+      <div className="evolve-bar">
+        <div
+          className="evolve-fill"
+          style={{ width: `${Math.min(values[key] || 0, 100)}%` }}
+        />
+        <span className="evolve-value">
+          {Math.min(values[key] || 0, 100)}%
+        </span>
+      </div>
+    </div>
+  );
 
   return (
     <div className="placeholder-app character-evolve">
-      <button className="back-button" onClick={onBack}>Back</button>
-        {BARS.map((b) => (
-          <div key={b.key} className="evolve-line">
-            <div className="label">{b.key} {b.text}</div>
-            <div className="evolve-bar">
-              <div
-                className="evolve-fill"
-                style={{ width: `${Math.min(values[b.key] || 0, 100)}%` }}
-              />
-            </div>
-            <button
-              className="add-btn"
-              aria-label={`add ${b.key}`}
-              onClick={() => increment(b.key)}
-            >
-              +
-            </button>
-          </div>
-        ))}
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
+      {BARS.map((b) =>
+        renderBar({ key: b.key, display: `${b.key} ${b.text}`, aria: b.key })
+      )}
+      {SEMI_FORMLESS_BARS.map((b) =>
+        renderBar({ key: b.key, display: b.text, aria: b.text })
+      )}
     </div>
   );
 }

--- a/src/character-evolve.css
+++ b/src/character-evolve.css
@@ -24,6 +24,7 @@
   overflow: hidden;
   box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
   border: 1px solid #888;
+  position: relative;
 }
 
 .evolve-fill {
@@ -32,6 +33,20 @@
   transition: width 0.3s ease;
   border-radius: 8px;
   box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.7);
+}
+
+.evolve-value {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: bold;
+  pointer-events: none;
 }
 
 .add-btn {


### PR DESCRIPTION
## Summary
- Add configurable progress bars for Form, Semi-formless, and Formless in Character Evolve
- Enable manual percentage entry via '+' button and display percentage over each bar
- Style bars to overlay value text and expand coverage to new manual bars
- Test manual entry to ensure entered values render

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b640e46248322a6ea610f57a5ef1c