### PR TITLE
Add inline percentage inputs for semi-formless bars

### DIFF
--- a/CharacterEvolve.test.js
+++ b/CharacterEvolve.test.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import CharacterEvolve from './src/CharacterEvolve.jsx';
 
-test('shows evolve bars', () => {
+test('allows manual percentage entry', async () => {
+  const user = userEvent.setup();
   render(<CharacterEvolve onBack={() => {}} />);
-  expect(screen.getByText(/II Love/i)).toBeInTheDocument();
-  expect(screen.getByLabelText('add II')).toBeInTheDocument();
+  await user.click(screen.getByLabelText('add Form'));
+  const input = screen.getByRole('spinbutton');
+  await user.clear(input);
+  await user.type(input, '42{enter}');
+  expect(screen.getByText('42%')).toBeInTheDocument();
 });

--- a/src/CharacterEvolve.jsx
+++ b/src/CharacterEvolve.jsx
@@ -2,11 +2,18 @@ import React, { useState, useEffect } from 'react';
 import './placeholder-app.css';
 import './character-evolve.css';
 
+// Distinct constant name to avoid accidental redeclarations during builds
+const FORM_STATE_BARS = [
+  { key: 'form', text: 'Form' },
+  { key: 'semi', text: 'Semi-formless' },
+  { key: 'formless', text: 'Formless' },
+];
+
 const BARS = [
-  { key: 'II', text: 'Love - Help people' },
-  { key: 'IE', text: 'Fun - Make something deep meaningful, and fun' },
-  { key: 'EI', text: 'Peace - Make things beautiful, be surrounded by beauty' },
-  { key: 'EE', text: 'Awe - Make everything at the max degree possible' },
+  { key: 'II', text: 'Love' },
+  { key: 'IE', text: 'Joy' },
+  { key: 'EI', text: 'Peace' },
+  { key: 'EE', text: 'Awe' },
 ];
 
 export default function CharacterEvolve({ onBack }) {
@@ -17,39 +24,80 @@ export default function CharacterEvolve({ onBack }) {
       return {};
     }
   });
+  const [editingKey, setEditingKey] = useState(null);
+  const [tempValue, setTempValue] = useState('');
 
   useEffect(() => {
     localStorage.setItem('evolveValues', JSON.stringify(values));
   }, [values]);
 
-  const increment = (key) => {
-    setValues((prev) => ({
-      ...prev,
-      [key]: Math.min((prev[key] || 0) + 10, 100),
-    }));
+  const startEdit = (key) => {
+    setEditingKey(key);
+    setTempValue(values[key] ?? '');
   };
+
+  const commitValue = (key) => {
+    const num = Number(tempValue);
+    if (!Number.isNaN(num)) {
+      setValues((prev) => ({
+        ...prev,
+        [key]: Math.max(0, Math.min(num, 100)),
+      }));
+    }
+    setEditingKey(null);
+    setTempValue('');
+  };
+
+  const renderBar = ({ key, display, aria }) => (
+    <div key={key} className="evolve-line">
+      <button
+        className="add-btn"
+        aria-label={`add ${aria}`}
+        type="button"
+        onClick={() => startEdit(key)}
+      >
+        +
+      </button>
+      <div className="label">{display}</div>
+      <div className="evolve-bar">
+        <div
+          className="evolve-fill"
+          style={{ width: `${Math.min(values[key] || 0, 100)}%` }}
+        />
+        <span className="evolve-value">
+          {Math.min(values[key] || 0, 100)}%
+        </span>
+      </div>
+      {editingKey === key && (
+        <input
+          type="number"
+          className="manual-input"
+          value={tempValue}
+          min="0"
+          max="100"
+          onChange={(e) => setTempValue(e.target.value)}
+          onBlur={() => commitValue(key)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commitValue(key);
+          }}
+          autoFocus
+        />
+      )}
+    </div>
+  );
 
   return (
     <div className="placeholder-app character-evolve">
-      <button className="back-button" onClick={onBack}>Back</button>
-        {BARS.map((b) => (
-          <div key={b.key} className="evolve-line">
-            <div className="label">{b.key} {b.text}</div>
-            <div className="evolve-bar">
-              <div
-                className="evolve-fill"
-                style={{ width: `${Math.min(values[b.key] || 0, 100)}%` }}
-              />
-            </div>
-            <button
-              className="add-btn"
-              aria-label={`add ${b.key}`}
-              onClick={() => increment(b.key)}
-            >
-              +
-            </button>
-          </div>
-        ))}
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
+      {FORM_STATE_BARS.map((b) =>
+        renderBar({ key: b.key, display: b.text, aria: b.text })
+      )}
+      <div className="spacer" />
+      {BARS.map((b) =>
+        renderBar({ key: b.key, display: `${b.key} ${b.text}`, aria: b.key })
+      )}
     </div>
   );
 }

--- a/src/character-evolve.css
+++ b/src/character-evolve.css
@@ -1,6 +1,12 @@
 .character-evolve {
   width: 100%;
   padding: 20px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.spacer {
+  height: 20px;
 }
 
 .evolve-line {
@@ -24,6 +30,7 @@
   overflow: hidden;
   box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.8), 0 2px 4px rgba(0, 0, 0, 0.6);
   border: 1px solid #888;
+  position: relative;
 }
 
 .evolve-fill {
@@ -32,6 +39,20 @@
   transition: width 0.3s ease;
   border-radius: 8px;
   box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.7);
+}
+
+.evolve-value {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: bold;
+  pointer-events: none;
 }
 
 .add-btn {
@@ -46,4 +67,13 @@
 
 .add-btn:hover {
   background: #333;
+}
+
+.manual-input {
+  width: 60px;
+  padding: 4px;
+  background: #222;
+  color: #f0f0f0;
+  border: 1px solid #555;
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- Replace prompt-based editing with inline number inputs for each bar
- Persist updated percentages to local storage when values are submitted
- Style new manual input field for consistent appearance

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b640e46248322a6ea610f57a5ef1c