### PR TITLE
Add local image gallery

### DIFF
--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -65,6 +65,12 @@ export default function FifthMain({ onSelectQuadrant }) {
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>
       <div className="bottom-menu">
+        <button className="side-button" onClick={() => onSelectQuadrant('gallery')}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3 7.5C3 6.67157 3.67157 6 4.5 6H19.5C20.3284 6 21 6.67157 21 7.5V16.5C21 17.3284 20.3284 18 19.5 18H4.5C3.67157 18 3 17.3284 3 16.5V7.5Z" stroke="white" strokeWidth="2"/>
+            <path d="M8 11L10.5 13.5L13.5 10.5L17 14" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
         <button className="side-button" onClick={() => setShowList(true)}>
           <svg width="27" height="27" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M12 1L12 17M12 1H4.2002C3.08009 1 2.51962 1 2.0918 1.21799C1.71547 1.40973 1.40973 1.71547 1.21799 2.0918C1 2.51962 1 3.08009 1 4.2002V13.8002C1 14.9203 1 15.4796 1.21799 15.9074C1.40973 16.2837 1.71547 16.5905 2.0918 16.7822C2.51921 17 3.07901 17 4.19694 17L12 17M12 1H13.8002C14.9203 1 15.4796 1 15.9074 1.21799C16.2837 1.40973 16.5905 1.71547 16.7822 2.0918C17 2.5192 17 3.079 17 4.19691L17 13.8031C17 14.921 17 15.48 16.7822 15.9074C16.5905 16.2837 16.2837 16.5905 15.9074 16.7822C15.48 17 14.921 17 13.8031 17H12" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import './image-gallery.css';
+
+export default function ImageGallery({ onBack }) {
+  const [images, setImages] = useState([]);
+  const [title, setTitle] = useState('');
+  const [tags, setTags] = useState('');
+  const [file, setFile] = useState(null);
+
+  // Load saved images from localStorage on mount
+  useEffect(() => {
+    const saved = localStorage.getItem('mazedImages');
+    if (saved) {
+      try {
+        setImages(JSON.parse(saved));
+      } catch (e) {
+        console.error('Failed to parse saved images', e);
+      }
+    }
+  }, []);
+
+  const saveImages = (imgs) => {
+    setImages(imgs);
+    localStorage.setItem('mazedImages', JSON.stringify(imgs));
+  };
+
+  const handleUpload = (e) => {
+    e.preventDefault();
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const newImage = {
+        id: Date.now(),
+        title,
+        tags: tags.split(',').map((t) => t.trim()).filter(Boolean),
+        dataUrl: reader.result,
+      };
+      const updated = [...images, newImage];
+      saveImages(updated);
+      setTitle('');
+      setTags('');
+      setFile(null);
+      e.target.reset();
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="image-gallery-container">
+      <div className="image-gallery-header">
+        <button onClick={onBack} className="back-button">Back</button>
+        <h2>Image Library</h2>
+      </div>
+      <form className="image-upload-form" onSubmit={handleUpload}>
+        <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files[0])} required />
+        <input
+          type="text"
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Tags (comma separated)"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+        />
+        <button type="submit">Upload</button>
+      </form>
+      <div className="image-grid">
+        {images.map((img) => (
+          <div key={img.id} className="image-card">
+            <img src={img.dataUrl} alt={img.title} />
+            <div className="image-info">
+              <h3>{img.title}</h3>
+              {img.tags.length > 0 && (
+                <p className="tags">{img.tags.map((t) => `#${t}`).join(' ')}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -8,6 +8,7 @@ import Auth from './Auth.jsx';
 import { supabaseClient } from './supabaseClient';
 import ActivityTimer from './ActivityTimer.jsx';
 import ExitVideo from './ExitVideo.jsx';
+import ImageGallery from './ImageGallery.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
@@ -112,6 +113,9 @@ export default function PageRouter() {
       break;
     case 'EE':
       content = <EEmain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
+      break;
+    case 'gallery':
+      content = <ImageGallery onBack={() => setPage('5th')} />;
       break;
     default:
       content = <FifthMain onSelectQuadrant={(label) => setPage(label)} />;

--- a/src/image-gallery.css
+++ b/src/image-gallery.css
@@ -1,0 +1,77 @@
+.image-gallery-container {
+  padding: 20px;
+  color: #fff;
+}
+
+.image-gallery-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.image-gallery-header h2 {
+  flex: 1;
+  text-align: center;
+  margin: 0;
+}
+
+.back-button {
+  background: #444;
+  border: none;
+  color: white;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.image-upload-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.image-upload-form input[type='text'] {
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.image-upload-form button {
+  align-self: flex-start;
+  padding: 6px 12px;
+  background-color: #5a5a5a;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 15px;
+}
+
+.image-card {
+  background: #222;
+  padding: 10px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.image-card img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+.image-info h3 {
+  margin: 10px 0 5px;
+  font-size: 1rem;
+}
+
+.tags {
+  color: #999;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add ImageGallery page to upload and tag images stored locally
- provide button on main page and router entry to access the image gallery
- style gallery view with grid layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a20ecc75208322b4218c40f8d56a99