### PR TITLE
Add local image gallery

### DIFF
--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -65,6 +65,12 @@ export default function FifthMain({ onSelectQuadrant }) {
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>
       <div className="bottom-menu">
+        <button className="side-button" onClick={() => onSelectQuadrant('gallery')}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M3 7.5C3 6.67157 3.67157 6 4.5 6H19.5C20.3284 6 21 6.67157 21 7.5V16.5C21 17.3284 20.3284 18 19.5 18H4.5C3.67157 18 3 17.3284 3 16.5V7.5Z" stroke="white" strokeWidth="2"/>
+            <path d="M8 11L10.5 13.5L13.5 10.5L17 14" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
         <button className="side-button" onClick={() => setShowList(true)}>
           <svg width="27" height="27" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M12 1L12 17M12 1H4.2002C3.08009 1 2.51962 1 2.0918 1.21799C1.71547 1.40973 1.40973 1.71547 1.21799 2.0918C1 2.51962 1 3.08009 1 4.2002V13.8002C1 14.9203 1 15.4796 1.21799 15.9074C1.40973 16.2837 1.71547 16.5905 2.0918 16.7822C2.51921 17 3.07901 17 4.19694 17L12 17M12 1H13.8002C14.9203 1 15.4796 1 15.9074 1.21799C16.2837 1.40973 16.5905 1.71547 16.7822 2.0918C17 2.5192 17 3.079 17 4.19691L17 13.8031C17 14.921 17 15.48 16.7822 15.9074C16.5905 16.2837 16.2837 16.5905 15.9074 16.7822C15.48 17 14.921 17 13.8031 17H12" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import './image-gallery.css';
+
+export default function ImageGallery({ onBack }) {
+  const [images, setImages] = useState([]);
+  const [title, setTitle] = useState('');
+  const [tags, setTags] = useState('');
+  const [file, setFile] = useState(null);
+  const [view, setView] = useState('home'); // 'home' or 'gallery'
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [menu, setMenu] = useState(null);
+  const [lightbox, setLightbox] = useState(null);
+  const [zoom, setZoom] = useState(1);
+  const BASE_SIZE = 180;
+  const filePickerRef = useRef(null);
+
+  // Load saved images from localStorage on mount
+  useEffect(() => {
+    const saved = localStorage.getItem('mazedImages');
+    if (saved) {
+      try {
+        setImages(JSON.parse(saved));
+      } catch (e) {
+        console.error('Failed to parse saved images', e);
+      }
+    }
+  }, []);
+
+  const saveImages = (imgs) => {
+    setImages(imgs);
+    localStorage.setItem('mazedImages', JSON.stringify(imgs));
+  };
+
+  const maxZoom = useMemo(() => {
+    if (images.length === 0) return 1;
+    return Math.max(...images.map((img) => img.width / BASE_SIZE));
+  }, [images]);
+
+  useEffect(() => {
+    const close = () => setMenu(null);
+    window.addEventListener('click', close);
+    return () => window.removeEventListener('click', close);
+  }, []);
+
+  const deleteImage = (id) => {
+    const updated = images.filter((img) => img.id !== id);
+    saveImages(updated);
+  };
+
+  const processFile = (fileObj, imgTitle = '', imgTags = []) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      const imgEl = new Image();
+      imgEl.onload = () => {
+        const newImage = {
+          id: Date.now(),
+          title: imgTitle,
+          tags: imgTags,
+          dataUrl: result,
+          width: imgEl.width,
+          height: imgEl.height,
+        };
+        const updated = [...images, newImage];
+        saveImages(updated);
+      };
+      imgEl.src = result;
+    };
+    reader.readAsDataURL(fileObj);
+  };
+
+  const uploadToServer = async (fileObj) => {
+    setUploading(true);
+    try {
+      const form = new FormData();
+      form.append('file', fileObj);
+      await fetch('/upload', { method: 'POST', body: form });
+    } catch (err) {
+      console.error('Upload failed', err);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleUpload = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+    await uploadToServer(file);
+    processFile(
+      file,
+      title,
+      tags
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+    );
+    setTitle('');
+    setTags('');
+    setFile(null);
+    e.target.reset();
+  };
+
+  const handleDrop = async (e) => {
+    e.preventDefault();
+    if (view !== 'home') return;
+    setIsDragging(false);
+    let droppedFile = e.dataTransfer.files && e.dataTransfer.files[0];
+    if (!droppedFile) {
+      const url =
+        e.dataTransfer.getData('text/uri-list') ||
+        e.dataTransfer.getData('text/plain');
+      if (url) {
+        try {
+          const res = await fetch(url);
+          const blob = await res.blob();
+          droppedFile = new File([blob], 'dropped-image', {
+            type: blob.type || 'image/png',
+          });
+        } catch (err) {
+          console.error('Failed to fetch dropped image', err);
+          return;
+        }
+      }
+    }
+    if (!droppedFile || !droppedFile.type.startsWith('image/')) return;
+    await uploadToServer(droppedFile);
+    processFile(droppedFile);
+  };
+
+  return (
+    <div
+      className={`image-gallery-container ${isDragging ? 'dragging' : ''}`}
+      onDragOver={(e) => {
+        if (view !== 'home') return;
+        e.preventDefault();
+        setIsDragging(true);
+      }}
+      onDragEnter={(e) => {
+        if (view !== 'home') return;
+        e.preventDefault();
+        setIsDragging(true);
+      }}
+      onDragLeave={(e) => {
+        if (view !== 'home') return;
+        e.preventDefault();
+        setIsDragging(false);
+      }}
+      onDrop={view === 'home' ? handleDrop : undefined}
+    >
+      {isDragging && view === 'home' && (
+        <div className="drop-overlay">Upload Image</div>
+      )}
+      {uploading && <div className="upload-status">Uploading…</div>}
+      {view === 'home' ? (
+        <div className="gallery-home">
+          <div className="top-bar">
+            <button className="brand" onClick={onBack}>MZ</button>
+            <input
+              className="search-input"
+              type="text"
+              placeholder="What will you imagine?"
+            />
+            <button className="submit-edit">Submit Edit</button>
+            <button className="view-all" onClick={() => setView('gallery')}>
+              View All →
+            </button>
+          </div>
+          <aside className="side-bar">
+            <button>Move / Resize</button>
+            <button>Paint</button>
+            <button>Smart Select</button>
+          </aside>
+          <main className="home-main">
+            <input
+              type="file"
+              accept="image/*"
+              ref={filePickerRef}
+              style={{ display: 'none' }}
+              onChange={async (e) => {
+                const f = e.target.files[0];
+                if (f) {
+                  setView('gallery');
+                  await uploadToServer(f);
+                  processFile(f);
+                  e.target.value = '';
+                }
+              }}
+            />
+            <div className="option-list">
+              <button
+                className="option-card computer"
+                onClick={() => filePickerRef.current?.click()}
+              >
+                <span className="icon">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                  <path d="M12 5v14" />
+                  <path d="M5 12h14" />
+                </svg>
+              </span>
+                <span className="text">Upload from Computer</span>
+                <span className="arrow">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M5 12h14" />
+                    <path d="M13 5l7 7-7 7" />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="option-card upload"
+                onClick={() => setView('gallery')}
+              >
+                <span className="icon">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                    <circle cx="8.5" cy="8.5" r="1.5" />
+                    <path d="M21 15l-5-5L5 21" />
+                  </svg>
+                </span>
+                <span className="text">Edit Uploaded Images</span>
+                <span className="arrow">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M5 12h14" />
+                    <path d="M13 5l7 7-7 7" />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </main>
+        </div>
+      ) : (
+        <div
+          className="gallery-manager"
+          onWheel={(e) => {
+            if (e.ctrlKey) {
+              e.preventDefault();
+              setZoom((z) => {
+                const next = z + (e.deltaY < 0 ? 0.1 : -0.1);
+                const clamped = Math.min(maxZoom, Math.max(0.5, next));
+                return clamped;
+              });
+            }
+          }}
+        >
+          <div className="image-gallery-header">
+            <button onClick={() => setView('home')} className="back-button">
+              Back
+            </button>
+            <h2>Image Library</h2>
+          </div>
+          <form className="image-upload-form" onSubmit={handleUpload}>
+            <label className="file-input-label">
+              <input
+                type="file"
+                accept="image/*"
+                onChange={(e) => setFile(e.target.files[0])}
+                required={!file}
+              />
+              {file ? file.name : 'Select Image'}
+            </label>
+            <input
+              type="text"
+              placeholder="Title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <input
+              type="text"
+              placeholder="Tags (comma separated)"
+              value={tags}
+              onChange={(e) => setTags(e.target.value)}
+            />
+            <button type="submit">Upload</button>
+          </form>
+          <div className="image-grid">
+            {images.map((img) => {
+              const displayWidth = Math.min(img.width, BASE_SIZE * zoom);
+              return (
+                <div
+                  key={img.id}
+                  className="image-card"
+                  style={{
+                    width: displayWidth,
+                    aspectRatio: `${img.width} / ${img.height}`,
+                  }}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setMenu({ id: img.id, x: e.clientX, y: e.clientY });
+                  }}
+                  onClick={() => setLightbox(img)}
+                >
+                  <img src={img.dataUrl} alt={img.title} />
+                  <div className="image-overlay">
+                    <h3>{img.title}</h3>
+                    {img.tags.length > 0 && (
+                      <div className="tags">
+                        {img.tags.map((t) => (
+                          <span key={t} className="tag">#{t}</span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {menu && (
+            <div className="context-menu" style={{ left: menu.x, top: menu.y }}>
+              <button
+                onClick={() => {
+                  deleteImage(menu.id);
+                  setMenu(null);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          )}
+          {lightbox && (
+            <div className="lightbox" onClick={() => setLightbox(null)}>
+              <img src={lightbox.dataUrl} alt={lightbox.title} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -8,6 +8,7 @@ import Auth from './Auth.jsx';
 import { supabaseClient } from './supabaseClient';
 import ActivityTimer from './ActivityTimer.jsx';
 import ExitVideo from './ExitVideo.jsx';
+import ImageGallery from './ImageGallery.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
@@ -112,6 +113,9 @@ export default function PageRouter() {
       break;
     case 'EE':
       content = <EEmain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
+      break;
+    case 'gallery':
+      content = <ImageGallery onBack={() => setPage('5th')} />;
       break;
     default:
       content = <FifthMain onSelectQuadrant={(label) => setPage(label)} />;

--- a/src/image-gallery.css
+++ b/src/image-gallery.css
@@ -1,0 +1,383 @@
+@import url('https://fonts.googleapis.com/css2?family=Oxanium:wght@400;700&display=swap');
+
+.image-gallery-container {
+  min-height: 100vh;
+  background: #0f0f10;
+  color: #e0e0e0;
+  font-family: 'Oxanium', sans-serif;
+  position: relative;
+}
+
+.image-gallery-container.dragging {
+  cursor: copy;
+}
+
+.drop-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  color: #00f0ff;
+  font-size: 1.5rem;
+  border: 2px dashed #00f0ff;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.upload-status {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #1b1b1e;
+  color: #00f0ff;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  z-index: 1001;
+}
+
+.gallery-manager {
+  padding: 20px;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 20px;
+  background: #1a1a1a;
+}
+
+.top-bar .brand {
+  background: transparent;
+  border: none;
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.search-input {
+  flex: 1;
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  color: #e0e0e0;
+  padding: 6px 10px;
+  border-radius: 4px;
+}
+
+.submit-edit,
+.view-all {
+  background: #2a2a2d;
+  color: #fff;
+  border: 1px solid #3a3a3d;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.view-all {
+  margin-left: auto;
+}
+
+.side-bar {
+  position: absolute;
+  top: 60px;
+  left: 0;
+  bottom: 0;
+  width: 80px;
+  display: flex;
+  flex-direction: column;
+  background: #181819;
+  padding-top: 20px;
+  gap: 10px;
+}
+
+.side-bar button {
+  background: transparent;
+  border: none;
+  color: #ccc;
+  padding: 10px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.home-main {
+  margin-left: 80px;
+  margin-top: 60px;
+  height: calc(100vh - 60px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: repeating-conic-gradient(#1b1b1e 0% 25%, #181818 0% 50%) 0/20px 20px;
+}
+
+.option-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.option-card {
+  width: 500px;
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 0 8px rgba(255, 255, 255, 0.05),
+    0 4px 16px rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.option-card:hover {
+  transform: translateX(4px);
+  box-shadow: inset 0 0 8px rgba(255, 255, 255, 0.07),
+    0 6px 20px rgba(0, 0, 0, 0.6);
+}
+
+
+.option-card.computer {
+  background: linear-gradient(135deg, #1e3c56, #124a7a);
+}
+
+.option-card.upload {
+  background: linear-gradient(135deg, #5a3711, #b36a1d);
+}
+
+.option-card .icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 16px;
+}
+
+.option-card .icon svg {
+  width: 32px;
+  height: 32px;
+}
+
+.option-card .text {
+  flex: 1;
+  letter-spacing: 0.5px;
+}
+
+.option-card .arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 16px;
+  transition: transform 0.2s;
+}
+
+.option-card .arrow svg {
+  width: 24px;
+  height: 24px;
+}
+
+.option-card:hover .arrow {
+  transform: translateX(4px);
+}
+
+.image-gallery-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.image-gallery-header h2 {
+  flex: 1;
+  text-align: center;
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 1px;
+}
+
+.back-button {
+  background: transparent;
+  border: 2px solid #00f0ff;
+  color: #00f0ff;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.3s, color 0.3s;
+}
+
+.back-button:hover {
+  background: #00f0ff;
+  color: #0f0f10;
+}
+
+.image-upload-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 30px;
+  background: #1b1b1e;
+  padding: 15px;
+  border-radius: 8px;
+}
+
+.file-input-label {
+  position: relative;
+  overflow: hidden;
+  background: #121214;
+  border: 1px dashed #00f0ff;
+  color: #00f0ff;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s;
+}
+
+.file-input-label input[type='file'] {
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+.file-input-label:hover {
+  background: #00f0ff;
+  color: #0f0f10;
+}
+
+.image-upload-form input[type='text'] {
+  flex: 1 1 150px;
+  background: #121214;
+  border: 1px solid #2a2a2d;
+  color: #e0e0e0;
+  padding: 6px;
+  border-radius: 4px;
+}
+
+.image-upload-form button {
+  padding: 6px 12px;
+  background-color: #00f0ff;
+  color: #0f0f10;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s;
+}
+
+.image-upload-form button:hover {
+  background-color: #00a9b3;
+  color: #ffffff;
+}
+
+.image-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.image-card {
+  position: relative;
+  background: #1b1b1e;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #2a2a2d;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  transition: border 0.3s, box-shadow 0.3s;
+  flex: 0 0 auto;
+}
+
+.image-card img {
+  width: 100%;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.image-card:hover img {
+  transform: scale(1.05);
+}
+
+.image-card:hover {
+  border-color: #00f0ff;
+  box-shadow: 0 0 10px #00f0ff;
+}
+
+.image-card:hover .image-overlay {
+  opacity: 1;
+}
+
+.image-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 8px;
+  opacity: 0;
+  backdrop-filter: blur(2px);
+  transition: opacity 0.3s;
+}
+
+.image-overlay h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tag {
+  background: #00f0ff;
+  color: #0f0f10;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.75rem;
+}
+
+.context-menu {
+  position: fixed;
+  background: #17181d;
+  color: #e0e0e0;
+  padding: 4px 8px;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  z-index: 1002;
+}
+
+.context-menu button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.lightbox {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1003;
+}
+
+.lightbox img {
+  max-width: 90%;
+  max-height: 90%;
+}
+


### PR DESCRIPTION
## Summary
- replace URL edit option with local file upload
- add drag-and-drop zone that fetches dropped URLs or files and posts them to `/upload`
- show uploading status and drop overlay for visual feedback
- fix upload flow so a file chosen on the home screen automatically uploads without a second click
- allow deleting images via right-click context menu
- size gallery cards according to image aspect ratio so horizontal and vertical shots fit cleanly
- disable drag-and-drop uploads in gallery view and limit them to the landing screen
- open images in a full-screen lightbox and zoom the gallery with Ctrl + mouse wheel up to native image size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20ecc75208322b4218c40f8d56a99