### PR TITLE
Allow zoom with Ctrl or Cmd keys

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -41,7 +41,7 @@ export default function ImageGallery({ onBack }) {
   useEffect(() => {
     if (view !== 'gallery') return;
     const handleWheel = (e) => {
-      if (e.ctrlKey) {
+      if (e.ctrlKey || e.metaKey) {
         e.preventDefault();
         setZoom((z) => {
           const next = z + (e.deltaY < 0 ? 0.1 : -0.1);
@@ -373,7 +373,7 @@ export default function ImageGallery({ onBack }) {
                 className="lightbox-inner"
                 onClick={(e) => e.stopPropagation()}
                 onWheel={(e) => {
-                  if (e.ctrlKey) {
+                  if (e.ctrlKey || e.metaKey) {
                     e.preventDefault();
                     setLightboxZoom((z) => {
                       const next = z + (e.deltaY < 0 ? 0.1 : -0.1);


### PR DESCRIPTION
## Summary
- Let ImageGallery zoom when pressing either Ctrl or Cmd key
- Same zoom support added to lightbox view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a305ecd7fc8322934039706779f0ae