### PR TITLE
Move image cards directly during drag

### DIFF
--- a/src/image-gallery.css
+++ b/src/image-gallery.css
@@ -222,6 +222,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
+  position: relative;
 }
 
 .image-card {
@@ -252,6 +253,14 @@
 
 .image-card:hover .image-overlay {
   opacity: 1;
+}
+
+.dragging-card {
+  position: absolute;
+  pointer-events: none;
+  box-shadow: 0 0 10px #00f0ff;
+  border: 1px solid #00f0ff;
+  z-index: 1000;
 }
 
 .image-overlay {


### PR DESCRIPTION
## Summary
- allow reordering by dragging image cards in the Image Library
- add overlay element so the card itself follows the pointer instead of a ghost
- style dragging card with absolute positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3323496e88322aef1c0fdf873ede8