### PR TITLE
Restore drag reordering for image cards

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -9,9 +9,15 @@ export default function ImageGallery({ onBack }) {
   const [menu, setMenu] = useState(null);
   const [lightbox, setLightbox] = useState(null);
   const [lightboxZoom, setLightboxZoom] = useState(1);
-  const [zoom, setZoom] = useState(0.5);
+  const [zoom, setZoom] = useState(() => Number(localStorage.getItem('galleryZoom')) || 0.5);
   const BASE_SIZE = 180;
   const filePickerRef = useRef(null);
+  const dragIndex = useRef(null);
+  const dragPreview = useMemo(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = 1;
+    return canvas;
+  }, []);
 
   // Load saved images from localStorage on mount
   useEffect(() => {
@@ -29,6 +35,10 @@ export default function ImageGallery({ onBack }) {
     setImages(imgs);
     localStorage.setItem('mazedImages', JSON.stringify(imgs));
   };
+
+  useEffect(() => {
+    localStorage.setItem('galleryZoom', zoom);
+  }, [zoom]);
 
   const maxZoom = useMemo(() => {
     if (images.length === 0) return 1;
@@ -264,22 +274,55 @@ export default function ImageGallery({ onBack }) {
             </button>
             <h2>Image Library</h2>
           </div>
-          <div className="image-grid">
-            {images.map((img) => {
+          <div
+            className="image-grid"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              e.preventDefault();
+              const from = dragIndex.current;
+              if (from == null) return;
+              const updated = [...images];
+              const [moved] = updated.splice(from, 1);
+              updated.push(moved);
+              saveImages(updated);
+              dragIndex.current = null;
+            }}
+          >
+            {images.map((img, index) => {
               const displayWidth = Math.min(img.width, BASE_SIZE * zoom);
               const displayHeight = (img.height / img.width) * displayWidth;
               return (
                 <div
                   key={img.id}
                   className="image-card"
+                  draggable
                   style={{ width: displayWidth, height: displayHeight }}
                   onContextMenu={(e) => {
                     e.preventDefault();
                     setMenu({ id: img.id, x: e.clientX, y: e.clientY });
                   }}
                   onClick={() => setLightbox(img)}
+                  onDragStart={(e) => {
+                    dragIndex.current = index;
+                    e.dataTransfer.setDragImage(dragPreview, 0, 0);
+                  }}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const from = dragIndex.current;
+                    if (from == null || from === index) return;
+                    const updated = [...images];
+                    const [moved] = updated.splice(from, 1);
+                    updated.splice(index, 0, moved);
+                    saveImages(updated);
+                    dragIndex.current = null;
+                  }}
+                  onDragEnd={() => {
+                    dragIndex.current = null;
+                  }}
                 >
                   <img
+                    draggable={false}
                     src={img.dataUrl}
                     alt={img.title}
                     onLoad={(e) => {

--- a/src/image-gallery.css
+++ b/src/image-gallery.css
@@ -233,6 +233,11 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   transition: border 0.3s, box-shadow 0.3s;
   flex: 0 0 auto;
+  cursor: grab;
+}
+
+.image-card:active {
+  cursor: grabbing;
 }
 
 .image-card img {


### PR DESCRIPTION
## Summary
- revert broken direct card movement and bring back simple drag-and-drop reordering
- hide the browser's default drag ghost with a transparent preview
- persist gallery zoom level in local storage
- disable native image dragging to avoid stray ghost previews

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3323496e88322aef1c0fdf873ede8