### PR TITLE
Enable dragging of the actual card and 30% default gallery zoom

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -1,15 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import './image-gallery.css';
 
-const EMPTY_DRAG_IMAGE =
-  typeof document !== 'undefined'
-    ? (() => {
-        const canvas = document.createElement('canvas');
-        canvas.width = canvas.height = 1;
-        return canvas;
-      })()
-    : null;
-
 export default function ImageGallery({ onBack }) {
   const [images, setImages] = useState([]);
   const [view, setView] = useState('home'); // 'home' or 'gallery'
@@ -18,15 +9,11 @@ export default function ImageGallery({ onBack }) {
   const [menu, setMenu] = useState(null);
   const [lightbox, setLightbox] = useState(null);
   const [lightboxZoom, setLightboxZoom] = useState(1);
-  const [zoom, setZoom] = useState(() => Number(localStorage.getItem('galleryZoom')) || 0.5);
-  const BASE_SIZE = 180;
+  const [zoom, setZoom] = useState(
+    () => Number(localStorage.getItem('galleryZoom')) || 0.3
+  );
   const filePickerRef = useRef(null);
   const dragIndex = useRef(null);
-  const dragPreview = useMemo(() => {
-    const canvas = document.createElement('canvas');
-    canvas.width = canvas.height = 1;
-    return canvas;
-  }, []);
 
   // Load saved images from localStorage on mount
   useEffect(() => {
@@ -49,10 +36,7 @@ export default function ImageGallery({ onBack }) {
     localStorage.setItem('galleryZoom', zoom);
   }, [zoom]);
 
-  const maxZoom = useMemo(() => {
-    if (images.length === 0) return 1;
-    return Math.max(...images.map((img) => img.width / BASE_SIZE));
-  }, [images]);
+  const maxZoom = 1; // max 100% of native size
 
 
   useEffect(() => {
@@ -313,8 +297,8 @@ export default function ImageGallery({ onBack }) {
             }}
           >
             {images.map((img, index) => {
-              const displayWidth = Math.min(img.width, BASE_SIZE * zoom);
-              const displayHeight = (img.height / img.width) * displayWidth;
+              const displayWidth = img.width * zoom;
+              const displayHeight = img.height * zoom;
               return (
                 <div
                   key={img.id}
@@ -328,7 +312,10 @@ export default function ImageGallery({ onBack }) {
                   onClick={() => setLightbox(img)}
                   onDragStart={(e) => {
                     dragIndex.current = index;
-                    e.dataTransfer.setDragImage(dragPreview, 0, 0);
+                    e.dataTransfer.setDragImage(e.currentTarget, 0, 0);
+                    requestAnimationFrame(() => {
+                      e.currentTarget.classList.add('placeholder');
+                    });
                   }}
                   onDragOver={(e) => e.preventDefault()}
                   onDrop={(e) => {
@@ -341,8 +328,9 @@ export default function ImageGallery({ onBack }) {
                     saveImages(updated);
                     dragIndex.current = null;
                   }}
-                  onDragEnd={() => {
+                  onDragEnd={(e) => {
                     dragIndex.current = null;
+                    e.currentTarget.classList.remove('placeholder');
                   }}>
                   {/* ensure the image tag is self-closing to avoid build errors */}
                   <img
@@ -367,48 +355,13 @@ export default function ImageGallery({ onBack }) {
                       setMenu({ id: img.id, x: e.clientX, y: e.clientY });
                     }}
                     onClick={() => setLightbox(img)}
-                  >
-                    <img
-                      src={img.dataUrl}
-                      alt={img.title}
-                      draggable={false}
-                      onLoad={(e) => {
-                        const w = e.target.naturalWidth;
-                        const h = e.target.naturalHeight;
-                        if (w !== img.width || h !== img.height) {
-                          const updated = images.map((i) =>
-                            i.id === img.id ? { ...i, width: w, height: h } : i
-                          );
-                          saveImages(updated);
-                          if (lightbox && lightbox.id === img.id) {
-                            setLightbox((l) => ({ ...l, width: w, height: h }));
-                          }
-                        }
-                      }}
-                    />
-                    <div className="image-overlay">
-                      <h3>{img.title}</h3>
-                    </div>
+                  />
+                  <div className="image-overlay">
+                    <h3>{img.title}</h3>
                   </div>
-                </React.Fragment>
+                </div>
               );
             })}
-            {dragItem && (
-              <div
-                className="image-card dragging-card"
-                style={{
-                  width: dragItem.width,
-                  height: dragItem.height,
-                  left: dragItem.x - dragItem.offsetX,
-                  top: dragItem.y - dragItem.offsetY,
-                }}
-              >
-                <img src={dragItem.dataUrl} alt={dragItem.title} />
-                <div className="image-overlay">
-                  <h3>{dragItem.title}</h3>
-                </div>
-              </div>
-            )}
           </div>
           {menu && (
             <div className="context-menu" style={{ left: menu.x, top: menu.y }}>


### PR DESCRIPTION
## Summary
- hide original card while dragging so only the moving image is visible
- default gallery thumbnails to 30% of native size

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a37d63d08c83228d9892cf2e7d3cc0