### PR TITLE
fix: continuous drag movement in gallery

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -91,7 +91,7 @@ export default function ImageGallery({ onBack }) {
 
   const resetDrag = () => {
     if (dragMoveListener.current) {
-      window.removeEventListener('dragover', dragMoveListener.current);
+      window.removeEventListener('drag', dragMoveListener.current);
       dragMoveListener.current = null;
     }
     if (dragPlaceholder.current) {
@@ -366,6 +366,7 @@ export default function ImageGallery({ onBack }) {
                     e.currentTarget.style.zIndex = '1000';
                     e.currentTarget.style.pointerEvents = 'none';
                     dragMoveListener.current = (event) => {
+                      event.preventDefault();
                       const gridRect2 = gridRef.current.getBoundingClientRect();
                       const x =
                         event.clientX - dragOffset.current.x - gridRect2.left;
@@ -376,7 +377,7 @@ export default function ImageGallery({ onBack }) {
                         dragItem.current.style.top = `${y}px`;
                       }
                     };
-                    window.addEventListener('dragover', dragMoveListener.current);
+                    window.addEventListener('drag', dragMoveListener.current);
                   }}
                   onDragOver={(e) => e.preventDefault()}
                   onDrop={(e) => {


### PR DESCRIPTION
## Summary
- ensure ImageGallery cards follow cursor using global drag listener
- prevent default scrolling during drag movement
- clean up drag listener on reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46f3cd6148322b44567dd782ffe3e