### PR TITLE
Enable fluid dragging for gallery images

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -91,7 +91,8 @@ export default function ImageGallery({ onBack }) {
 
   const resetDrag = () => {
     if (dragMoveListener.current) {
-      window.removeEventListener('drag', dragMoveListener.current);
+      // Use dragover events so the actual element follows the pointer
+      window.removeEventListener('dragover', dragMoveListener.current);
       dragMoveListener.current = null;
     }
     if (dragPlaceholder.current) {
@@ -377,7 +378,8 @@ export default function ImageGallery({ onBack }) {
                         dragItem.current.style.top = `${y}px`;
                       }
                     };
-                    window.addEventListener('drag', dragMoveListener.current);
+                    // Listen on dragover so we get continuous mouse positions
+                    window.addEventListener('dragover', dragMoveListener.current);
                   }}
                   onDragOver={(e) => e.preventDefault()}
                   onDrop={(e) => {


### PR DESCRIPTION
## Summary
- Use `dragover` events so dragged images follow the cursor
- Remove listeners when drag ends to keep DOM clean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4764a5ad88322a51a6519b33bb686