### PR TITLE
feat: add image metadata editor, zoom indicator and quadrant tags

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -12,6 +12,10 @@ export default function ImageGallery({ onBack }) {
   const [zoom, setZoom] = useState(
     () => Number(localStorage.getItem('galleryZoom')) || 0.35
   );
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleInput, setTitleInput] = useState('');
+  const [descInput, setDescInput] = useState('');
+  const [tagInput, setTagInput] = useState('');
   const filePickerRef = useRef(null);
   const dragIndex = useRef(null);
   const gridRef = useRef(null);
@@ -64,8 +68,14 @@ export default function ImageGallery({ onBack }) {
   }, [zoom]);
 
   useEffect(() => {
-    if (lightbox) setLightboxZoom(1);
-  }, [lightbox]);
+    if (lightbox) {
+      setLightboxZoom(1);
+      setTitleInput(lightbox.title || '');
+      setDescInput(lightbox.description || '');
+      setTagInput('');
+      setEditingTitle(false);
+    }
+  }, [lightbox?.id]);
 
   useEffect(() => {
 
@@ -87,6 +97,15 @@ export default function ImageGallery({ onBack }) {
     const [moved] = updated.splice(fromIndex, 1);
     updated.splice(toIndex, 0, moved);
     saveImages(updated);
+  };
+
+  const updateImage = (id, updates) => {
+    const updated = images.map((img) =>
+      img.id === id ? { ...img, ...updates } : img
+    );
+    saveImages(updated);
+    const next = updated.find((i) => i.id === id);
+    if (next) setLightbox(next);
   };
 
   const resetDrag = () => {
@@ -119,7 +138,9 @@ export default function ImageGallery({ onBack }) {
         const newImage = {
           id: Date.now(),
           title: imgTitle,
+          description: '',
           tags: imgTags,
+          quadrants: [],
           dataUrl: result,
           width: imgEl.width,
           height: imgEl.height,
@@ -443,29 +464,138 @@ export default function ImageGallery({ onBack }) {
               </button>
             </div>
           )}
+          {!lightbox && (
+            <div className="zoom-indicator">{Math.round(zoom * 100)}%</div>
+          )}
           {lightbox && (
             <div className="lightbox" onClick={() => setLightbox(null)}>
-              <div
-                className="lightbox-inner"
-                onClick={(e) => e.stopPropagation()}
-                onWheel={(e) => {
-                  if (e.ctrlKey || e.metaKey) {
-                    e.preventDefault();
-                    setLightboxZoom((z) => {
-                      const next = z + (e.deltaY < 0 ? 0.1 : -0.1);
-                      return Math.min(5, Math.max(0.1, next));
-                    });
-                  }
-                }}
-              >
-                <img
-                  src={lightbox.dataUrl}
-                  alt={lightbox.title}
-                  style={{
-                    width: lightbox.width * lightboxZoom,
-                    height: lightbox.height * lightboxZoom,
+              <div className="lightbox-content" onClick={(e) => e.stopPropagation()}>
+                <div
+                  className="lightbox-inner"
+                  onWheel={(e) => {
+                    if (e.ctrlKey || e.metaKey) {
+                      e.preventDefault();
+                      setLightboxZoom((z) => {
+                        const next = z + (e.deltaY < 0 ? 0.1 : -0.1);
+                        return Math.min(5, Math.max(0.1, next));
+                      });
+                    }
                   }}
-                />
+                >
+                  <img
+                    src={lightbox.dataUrl}
+                    alt={lightbox.title}
+                    style={{
+                      width: lightbox.width * lightboxZoom,
+                      height: lightbox.height * lightboxZoom,
+                    }}
+                  />
+                </div>
+                <div className="lightbox-info">
+                  {editingTitle ? (
+                    <input
+                      type="text"
+                      value={titleInput}
+                      onChange={(e) => setTitleInput(e.target.value)}
+                      onBlur={() => {
+                        updateImage(lightbox.id, { title: titleInput });
+                        setEditingTitle(false);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          updateImage(lightbox.id, { title: titleInput });
+                          setEditingTitle(false);
+                        }
+                      }}
+                      autoFocus
+                    />
+                  ) : (
+                    <h1 onClick={() => setEditingTitle(true)}>
+                      {lightbox.title || 'Untitled'}
+                    </h1>
+                  )}
+                  <textarea
+                    value={descInput}
+                    placeholder="Description"
+                    onChange={(e) => setDescInput(e.target.value)}
+                    onBlur={() => updateImage(lightbox.id, { description: descInput })}
+                  />
+                  <div className="quad-section">
+                    <div className="quad-header">
+                      <h2>Quads</h2>
+                      {(lightbox.quadrants?.length || 0) < 2 && (
+                        <button
+                          className="add-quad-btn"
+                          onClick={() => {
+                            const nq = [...(lightbox.quadrants || []), ''];
+                            updateImage(lightbox.id, { quadrants: nq });
+                          }}
+                        >
+                          +
+                        </button>
+                      )}
+                    </div>
+                    <div className="quad-list">
+                      {(lightbox.quadrants && lightbox.quadrants.length > 0
+                        ? lightbox.quadrants
+                        : ['']
+                      ).map((q, idx) => (
+                        <select
+                          key={idx}
+                          value={q}
+                          className={`quad-select ${q ? 'quad-' + q : ''}`}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            let nq = [...(lightbox.quadrants || [])];
+                            if (val === '') {
+                              nq.splice(idx, 1);
+                            } else {
+                              nq[idx] = val;
+                            }
+                            updateImage(lightbox.id, { quadrants: nq });
+                          }}
+                        >
+                          <option value=""></option>
+                          <option value="II">II</option>
+                          <option value="IE">IE</option>
+                          <option value="EI">EI</option>
+                          <option value="EE">EE</option>
+                        </select>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="tag-list">
+                    {lightbox.tags?.map((tag, idx) => (
+                      <span
+                        key={idx}
+                        className="tag"
+                        onClick={() => {
+                          const nt = lightbox.tags.filter((_, i) => i !== idx);
+                          updateImage(lightbox.id, { tags: nt });
+                        }}
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                    <input
+                      type="text"
+                      value={tagInput}
+                      placeholder="Add tag"
+                      onChange={(e) => setTagInput(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && tagInput.trim()) {
+                          const nt = [...(lightbox.tags || []), tagInput.trim()];
+                          updateImage(lightbox.id, { tags: nt });
+                          setTagInput('');
+                        }
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="zoom-indicator">
+                {Math.round(lightboxZoom * 100)}%
               </div>
             </div>
           )}

--- a/src/image-gallery.css
+++ b/src/image-gallery.css
@@ -331,3 +331,142 @@
   max-height: none;
 }
 
+.zoom-indicator {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #00f0ff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  z-index: 1004;
+}
+
+.lightbox-content {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.lightbox-info {
+  width: 300px;
+  background: #1b1b1e;
+  padding: 20px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.lightbox-info h1 {
+  margin: 0;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.lightbox-info input[type='text'] {
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  color: #e0e0e0;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.lightbox-info textarea {
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  color: #e0e0e0;
+  padding: 4px 8px;
+  border-radius: 4px;
+  resize: vertical;
+  min-height: 80px;
+}
+
+.quad-section {
+  margin-top: 8px;
+}
+
+.quad-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.quad-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.add-quad-btn {
+  margin-left: auto;
+  background: #3a3a3d;
+  border: none;
+  color: #e0e0e0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.quad-list {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.quad-select {
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  border-radius: 4px;
+  color: #e0e0e0;
+  padding: 2px 6px;
+}
+
+.quad-select option {
+  color: #e0e0e0;
+}
+
+.quad-II,
+.quad-select option[value='II'] {
+  color: #27ae60;
+}
+
+.quad-IE,
+.quad-select option[value='IE'] {
+  color: #2980b9;
+}
+
+.quad-EI,
+.quad-select option[value='EI'] {
+  color: #f1c40f;
+}
+
+.quad-EE,
+.quad-select option[value='EE'] {
+  color: #e74c3c;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-list input {
+  flex: 1 0 100%;
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  color: #e0e0e0;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.tag {
+  background: #00f0ff;
+  color: #0f0f10;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- show current zoom level in gallery and lightbox views
- add metadata side panel with editable title, description and tags
- support color-coded quadrant tags with optional secondary tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ae8a9bec83228bff945cd52476cd