### PR TITLE
Add image sorting options

### DIFF
--- a/src/image-gallery.css
+++ b/src/image-gallery.css
@@ -236,14 +236,43 @@
   font-size: 1.2rem;
 }
 
-.color-sort-button {
+.sort-dropdown {
   margin-left: auto;
+  position: relative;
+}
+
+.sort-button {
   background: #2a2a2d;
   color: #fff;
   border: 1px solid #3a3a3d;
   padding: 6px 12px;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.sort-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.sort-menu button {
+  background: none;
+  border: none;
+  color: #fff;
+  padding: 6px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sort-menu button:hover {
+  background: #3a3a3d;
 }
 
 .image-card {


### PR DESCRIPTION
## Summary
- Add sorting menu for image gallery to order by original, title, date added, or color
- Implement sorting logic and preserve original order
- Style dropdown and menu for new sorting options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8c36618788322801b264c1c802230