### PR TITLE
Add image sorting options

### DIFF
--- a/src/colorUtils.js
+++ b/src/colorUtils.js
@@ -77,7 +77,9 @@ function ciede2000(lab1, lab2) {
     0.32 * Math.cos(3 * hp + Math.PI / 30) -
     0.20 * Math.cos(4 * hp - (63 * Math.PI) / 180);
 
-  const dTheta = (30 * Math.PI / 180) * Math.exp(-((hp * 180 / Math.PI - 275) / 25) ** 2);
+  const dTheta =
+    (30 * Math.PI / 180) *
+    Math.exp(-(((hp * 180 / Math.PI - 275) / 25) ** 2));
   const R_C = 2 * Math.sqrt(Math.pow(Cp, 7) / (Math.pow(Cp, 7) + Math.pow(25, 7)));
   const S_L = 1 + (0.015 * (Lp - 50) * (Lp - 50)) / Math.sqrt(20 + (Lp - 50) * (Lp - 50));
   const S_C = 1 + 0.045 * Cp;

--- a/src/image-gallery.css
+++ b/src/image-gallery.css
@@ -236,14 +236,43 @@
   font-size: 1.2rem;
 }
 
-.color-sort-button {
+.sort-dropdown {
   margin-left: auto;
+  position: relative;
+}
+
+.sort-button {
   background: #2a2a2d;
   color: #fff;
   border: 1px solid #3a3a3d;
   padding: 6px 12px;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.sort-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  z-index: 10;
+}
+
+.sort-menu button {
+  background: none;
+  border: none;
+  color: #fff;
+  padding: 6px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sort-menu button:hover {
+  background: #3a3a3d;
 }
 
 .image-card {


### PR DESCRIPTION
## Summary
- Add sorting menu for image gallery to order by original, title, date added, or color
- Implement sorting logic and preserve original order
- Style dropdown and menu for new sorting options
- Fix color delta exponent expression to resolve build error

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c36618788322801b264c1c802230