### PR TITLE
Add persistent big goal slots to TodoGoals

### DIFF
--- a/src/TodoGoals.jsx
+++ b/src/TodoGoals.jsx
@@ -20,6 +20,12 @@ export default function TodoGoals({ onBack }) {
     return stored ? JSON.parse(stored) : [];
   });
   const [input, setInput] = useState('');
+  const [bigGoals, setBigGoals] = useState(() => {
+    const stored = localStorage.getItem('todoBigGoals');
+    return stored
+      ? JSON.parse(stored)
+      : { transcendent: '', jackpot: '', rainbow: '', mirror: '' };
+  });
 
   useEffect(() => {
     localStorage.setItem('todoDoneLog', JSON.stringify(doneLog));
@@ -28,6 +34,10 @@ export default function TodoGoals({ onBack }) {
   useEffect(() => {
     localStorage.setItem('todoGoals', JSON.stringify(tasks));
   }, [tasks]);
+
+  useEffect(() => {
+    localStorage.setItem('todoBigGoals', JSON.stringify(bigGoals));
+  }, [bigGoals]);
 
   const handleAdd = () => {
     if (!input.trim()) return;
@@ -40,6 +50,10 @@ export default function TodoGoals({ onBack }) {
       return next;
     });
     setInput('');
+  };
+
+  const handleBigGoalChange = (key, value) => {
+    setBigGoals((prev) => ({ ...prev, [key]: value }));
   };
 
   const handleDragStart = (e, task, timeframe) => {
@@ -137,6 +151,40 @@ export default function TodoGoals({ onBack }) {
 
   return (
     <div className="todo-goals">
+      <div className="big-goals">
+        <div className="big-goal-wrapper">
+          <label>Transcendent Goal</label>
+          <input
+            value={bigGoals.transcendent}
+            onChange={(e) => handleBigGoalChange('transcendent', e.target.value)}
+            placeholder="Set transcendent goal"
+          />
+        </div>
+        <div className="big-goal-wrapper">
+          <label>Jackpot Goal</label>
+          <input
+            value={bigGoals.jackpot}
+            onChange={(e) => handleBigGoalChange('jackpot', e.target.value)}
+            placeholder="Set jackpot goal"
+          />
+        </div>
+        <div className="big-goal-wrapper">
+          <label>Rainbow Goal</label>
+          <input
+            value={bigGoals.rainbow}
+            onChange={(e) => handleBigGoalChange('rainbow', e.target.value)}
+            placeholder="Set rainbow goal"
+          />
+        </div>
+        <div className="big-goal-wrapper">
+          <label>Mirror Goal</label>
+          <input
+            value={bigGoals.mirror}
+            onChange={(e) => handleBigGoalChange('mirror', e.target.value)}
+            placeholder="Set mirror goal"
+          />
+        </div>
+      </div>
       <div className="main-panel">
         {onBack && (
           <button className="back-button" onClick={onBack}>Back</button>

--- a/src/todo-goals.css
+++ b/src/todo-goals.css
@@ -6,6 +6,34 @@
   height: 100%;
 }
 
+.big-goals {
+  flex-basis: 20%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.big-goal-wrapper {
+  background: #2c2d33;
+  padding: 8px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.big-goal-wrapper label {
+  margin-bottom: 4px;
+  font-size: 14px;
+}
+
+.big-goal-wrapper input {
+  background: #17181d;
+  color: #e6e7eb;
+  border: none;
+  padding: 6px;
+  border-radius: 4px;
+}
+
 .done-log {
   flex-basis: 25%;
   display: flex;


### PR DESCRIPTION
## Summary
- Add editable "Transcendent", "Jackpot", "Rainbow", and "Mirror" goal slots to TodoGoals
- Persist big goals in local storage and show them in a new left-side panel
- Style the big goal panel for consistent layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac304ad9a8832295fdf02d9597f3b4