### PR TITLE
Handle Escape to navigate back and add keyboard navigation

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -83,6 +83,25 @@ export default function QuadrantPage({ initialTab }) {
   }, [autoLog]);
 
   useEffect(() => {
+    const handleKeyDown = (e) => {
+      const key = e.key.toLowerCase();
+      if (key === 'w') {
+        setActiveTab((prev) => {
+          const idx = tabs.findIndex((t) => t.label === prev);
+          return tabs[Math.max(0, idx - 1)].label;
+        });
+      } else if (key === 's') {
+        setActiveTab((prev) => {
+          const idx = tabs.findIndex((t) => t.label === prev);
+          return tabs[Math.min(tabs.length - 1, idx + 1)].label;
+        });
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  useEffect(() => {
     document.body.classList.toggle('light-theme', theme === 'light');
     localStorage.setItem('theme', theme);
   }, [theme]);

--- a/PageRouter.jsx
+++ b/PageRouter.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import FifthMain from './FifthMain.jsx';
 import IImain from './IImain.jsx';
 import IEmain from './IEmain.jsx';
@@ -11,6 +11,7 @@ import ExitVideo from './ExitVideo.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
+  const history = useRef(['5th']);
   const [user, setUser] = useState(null);
   const [showExitVideo, setShowExitVideo] = useState(false);
   const [pendingResize, setPendingResize] = useState(false);
@@ -50,9 +51,28 @@ export default function PageRouter() {
     prevUser.current = user;
   }, [user]);
 
+  const navigate = useCallback((newPage) => {
+    if (newPage === '5th') {
+      history.current = ['5th'];
+    } else {
+      const current = history.current[history.current.length - 1];
+      if (current !== newPage) {
+        history.current = [...history.current, newPage];
+      }
+    }
+    setPage(newPage);
+  }, []);
+
+  const goBack = useCallback(() => {
+    if (history.current.length > 1) {
+      history.current = history.current.slice(0, -1);
+      setPage(history.current[history.current.length - 1]);
+    }
+  }, []);
+
   useEffect(() => {
     if (window.electronAPI && window.electronAPI.onGoHome) {
-      window.electronAPI.onGoHome(() => setPage('5th'));
+      window.electronAPI.onGoHome(() => navigate('5th'));
     }
     if (window.electronAPI && window.electronAPI.onDisconnect) {
       window.electronAPI.onDisconnect(async () => {
@@ -62,7 +82,17 @@ export default function PageRouter() {
         await supabaseClient.auth.signOut();
       });
     }
-  }, []);
+  }, [navigate]);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        goBack();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [goBack]);
 
   if (!user) {
     return <Auth />;
@@ -97,7 +127,7 @@ export default function PageRouter() {
       content = <EEmain />;
       break;
     default:
-      content = <FifthMain onSelectQuadrant={(label) => setPage(label)} />;
+      content = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;
   }
 
   return (

--- a/QuadrantMenu.jsx
+++ b/QuadrantMenu.jsx
@@ -1,23 +1,57 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useEffect, useState } from 'react';
+import styled, { keyframes } from 'styled-components';
 
 export default function QuadrantMenu({ onSelect }) {
+  const [selected, setSelected] = useState(0);
+  const quadrants = ['II', 'IE', 'EI', 'EE'];
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      const key = e.key.toLowerCase();
+      if (key === 'w') {
+        setSelected((prev) => (prev >= 2 ? prev - 2 : prev));
+      } else if (key === 's') {
+        setSelected((prev) => (prev <= 1 ? prev + 2 : prev));
+      } else if (key === 'a') {
+        setSelected((prev) => (prev % 2 === 1 ? prev - 1 : prev));
+      } else if (key === 'd') {
+        setSelected((prev) => (prev % 2 === 0 ? prev + 1 : prev));
+      } else if (key === 'enter') {
+        onSelect(quadrants[selected]);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onSelect, selected]);
+
   return (
     <StyledWrapper>
       <div className="main">
         <div className="up">
-          <button className="card1" onClick={() => onSelect('II')}>
+          <button
+            className={`card1 ${selected === 0 ? 'selected' : ''}`}
+            onClick={() => onSelect('II')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" viewBox="0,0,256,256" width="30px" height="30px" fillRule="nonzero" className="instagram"><g fillRule="nonzero" stroke="none" strokeWidth={1} strokeLinecap="butt" strokeLinejoin="miter" strokeMiterlimit={10} strokeDasharray strokeDashoffset={0} fontFamily="none" fontWeight="none" fontSize="none" textAnchor="none" style={{mixBlendMode: 'normal'}}><g transform="scale(8,8)"><path d="M11.46875,5c-3.55078,0 -6.46875,2.91406 -6.46875,6.46875v9.0625c0,3.55078 2.91406,6.46875 6.46875,6.46875h9.0625c3.55078,0 6.46875,-2.91406 6.46875,-6.46875v-9.0625c0,-3.55078 -2.91406,-6.46875 -6.46875,-6.46875zM11.46875,7h9.0625c2.47266,0 4.46875,1.99609 4.46875,4.46875v9.0625c0,2.47266 -1.99609,4.46875 -4.46875,4.46875h-9.0625c-2.47266,0 -4.46875,-1.99609 -4.46875,-4.46875v-9.0625c0,-2.47266 1.99609,-4.46875 4.46875,-4.46875zM21.90625,9.1875c-0.50391,0 -0.90625,0.40234 -0.90625,0.90625c0,0.50391 0.40234,0.90625 0.90625,0.90625c0.50391,0 0.90625,-0.40234 0.90625,-0.90625c0,-0.50391 -0.40234,-0.90625 -0.90625,-0.90625zM16,10c-3.30078,0 -6,2.69922 -6,6c0,3.30078 2.69922,6 6,6c3.30078,0 6,-2.69922 6,-6c0,-3.30078 -2.69922,-6 -6,-6zM16,12c2.22266,0 4,1.77734 4,4c0,2.22266 -1.77734,4 -4,4c-2.22266,0 -4,-1.77734 -4,-4c0,-2.22266 1.77734,-4 4,-4z" /></g></g></svg>
           </button>
-          <button className="card2" onClick={() => onSelect('IE')}>
+          <button
+            className={`card2 ${selected === 1 ? 'selected' : ''}`}
+            onClick={() => onSelect('IE')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="30px" height="30px" className="twitter"><path d="M42,12.429c-1.323,0.586-2.746,0.977-4.247,1.162c1.526-0.906,2.7-2.351,3.251-4.058c-1.428,0.837-3.01,1.452-4.693,1.776C34.967,9.884,33.05,9,30.926,9c-4.08,0-7.387,3.278-7.387,7.32c0,0.572,0.067,1.129,0.193,1.67c-6.138-0.308-11.582-3.226-15.224-7.654c-0.64,1.082-1,2.349-1,3.686c0,2.541,1.301,4.778,3.285,6.096c-1.211-0.037-2.351-0.374-3.349-0.914c0,0.022,0,0.055,0,0.086c0,3.551,2.547,6.508,5.923,7.181c-0.617,0.169-1.269,0.263-1.941,0.263c-0.477,0-0.942-0.054-1.392-0.135c0.94,2.902,3.667,5.023,6.898,5.086c-2.528,1.96-5.712,3.134-9.174,3.134c-0.598,0-1.183-0.034-1.761-0.104C9.268,36.786,13.152,38,17.321,38c13.585,0,21.017-11.156,21.017-20.834c0-0.317-0.01-0.633-0.025-0.945C39.763,15.197,41.013,13.905,42,12.429" /></svg>
           </button>
         </div>
         <div className="down">
-          <button className="card3" onClick={() => onSelect('EI')}>
+          <button
+            className={`card3 ${selected === 2 ? 'selected' : ''}`}
+            onClick={() => onSelect('EI')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px" className="github">    <path d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051 c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526 c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769 c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098 c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9 c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594 c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734 c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z" /></svg>
           </button>
-          <button className="card4" onClick={() => onSelect('EE')}>
+          <button
+            className={`card4 ${selected === 3 ? 'selected' : ''}`}
+            onClick={() => onSelect('EE')}
+          >
             <svg height="30px" width="30px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" className="discord"><path d="M40,12c0,0-4.585-3.588-10-4l-0.488,0.976C34.408,10.174,36.654,11.891,39,14c-4.045-2.065-8.039-4-15-4s-10.955,1.935-15,4c2.346-2.109,5.018-4.015,9.488-5.024L18,8c-5.681,0.537-10,4-10,4s-5.121,7.425-6,22c5.162,5.953,13,6,13,6l1.639-2.185C13.857,36.848,10.715,35.121,8,32c3.238,2.45,8.125,5,16,5s12.762-2.55,16-5c-2.715,3.121-5.857,4.848-8.639,5.815L33,40c0,0,7.838-0.047,13-6C45.121,19.425,40,12,40,12z M17.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C21,28.209,19.433,30,17.5,30z M30.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C34,28.209,32.433,30,30.5,30z" /></svg>
           </button>
         </div>
@@ -25,6 +59,15 @@ export default function QuadrantMenu({ onSelect }) {
     </StyledWrapper>
   );
 }
+
+const pulse = keyframes`
+  from {
+    box-shadow: 0 0 0 2px #ffd700;
+  }
+  to {
+    box-shadow: 0 0 0 4px #ffd700;
+  }
+`;
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -154,5 +197,10 @@ const StyledWrapper = styled.div`
 
   .card4:hover .discord {
     fill: white;
+  }
+
+  .selected {
+    animation: ${pulse} 1s infinite alternate;
+    transform: scale(1.1);
   }
 `;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -174,6 +174,35 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   }, [autoLog]);
 
   useEffect(() => {
+    const handleKeyDown = (e) => {
+      const key = e.key.toLowerCase();
+      if (key === 'a') {
+        setActiveLayer((prev) => {
+          const idx = layers.findIndex((l) => l.label === prev);
+          return layers[Math.max(0, idx - 1)].label;
+        });
+      } else if (key === 'd') {
+        setActiveLayer((prev) => {
+          const idx = layers.findIndex((l) => l.label === prev);
+          return layers[Math.min(layers.length - 1, idx + 1)].label;
+        });
+      } else if (key === 'w') {
+        setActiveTab((prev) => {
+          const idx = tabs.findIndex((t) => t.label === prev);
+          return tabs[Math.max(0, idx - 1)].label;
+        });
+      } else if (key === 's') {
+        setActiveTab((prev) => {
+          const idx = tabs.findIndex((t) => t.label === prev);
+          return tabs[Math.min(tabs.length - 1, idx + 1)].label;
+        });
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  useEffect(() => {
     const loadAvatar = async () => {
       const {
         data: { user },

--- a/src/QuadrantMenu.jsx
+++ b/src/QuadrantMenu.jsx
@@ -1,23 +1,57 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useEffect, useState } from 'react';
+import styled, { keyframes } from 'styled-components';
 
 export default function QuadrantMenu({ onSelect }) {
+  const [selected, setSelected] = useState(0);
+  const quadrants = ['II', 'IE', 'EI', 'EE'];
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      const key = e.key.toLowerCase();
+      if (key === 'w') {
+        setSelected((prev) => (prev >= 2 ? prev - 2 : prev));
+      } else if (key === 's') {
+        setSelected((prev) => (prev <= 1 ? prev + 2 : prev));
+      } else if (key === 'a') {
+        setSelected((prev) => (prev % 2 === 1 ? prev - 1 : prev));
+      } else if (key === 'd') {
+        setSelected((prev) => (prev % 2 === 0 ? prev + 1 : prev));
+      } else if (key === 'enter') {
+        onSelect(quadrants[selected]);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onSelect, selected]);
+
   return (
     <StyledWrapper>
       <div className="main">
         <div className="up">
-          <button className="card1" onClick={() => onSelect('II')}>
+          <button
+            className={`card1 ${selected === 0 ? 'selected' : ''}`}
+            onClick={() => onSelect('II')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" viewBox="0,0,256,256" width="30px" height="30px" fillRule="nonzero" className="instagram"><g fillRule="nonzero" stroke="none" strokeWidth={1} strokeLinecap="butt" strokeLinejoin="miter" strokeMiterlimit={10} strokeDasharray strokeDashoffset={0} fontFamily="none" fontWeight="none" fontSize="none" textAnchor="none" style={{mixBlendMode: 'normal'}}><g transform="scale(8,8)"><path d="M11.46875,5c-3.55078,0 -6.46875,2.91406 -6.46875,6.46875v9.0625c0,3.55078 2.91406,6.46875 6.46875,6.46875h9.0625c3.55078,0 6.46875,-2.91406 6.46875,-6.46875v-9.0625c0,-3.55078 -2.91406,-6.46875 -6.46875,-6.46875zM11.46875,7h9.0625c2.47266,0 4.46875,1.99609 4.46875,4.46875v9.0625c0,2.47266 -1.99609,4.46875 -4.46875,4.46875h-9.0625c-2.47266,0 -4.46875,-1.99609 -4.46875,-4.46875v-9.0625c0,-2.47266 1.99609,-4.46875 4.46875,-4.46875zM21.90625,9.1875c-0.50391,0 -0.90625,0.40234 -0.90625,0.90625c0,0.50391 0.40234,0.90625 0.90625,0.90625c0.50391,0 0.90625,-0.40234 0.90625,-0.90625c0,-0.50391 -0.40234,-0.90625 -0.90625,-0.90625zM16,10c-3.30078,0 -6,2.69922 -6,6c0,3.30078 2.69922,6 6,6c3.30078,0 6,-2.69922 6,-6c0,-3.30078 -2.69922,-6 -6,-6zM16,12c2.22266,0 4,1.77734 4,4c0,2.22266 -1.77734,4 -4,4c-2.22266,0 -4,-1.77734 -4,-4c0,-2.22266 1.77734,-4 4,-4z" /></g></g></svg>
           </button>
-          <button className="card2" onClick={() => onSelect('IE')}>
+          <button
+            className={`card2 ${selected === 1 ? 'selected' : ''}`}
+            onClick={() => onSelect('IE')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="30px" height="30px" className="twitter"><path d="M42,12.429c-1.323,0.586-2.746,0.977-4.247,1.162c1.526-0.906,2.7-2.351,3.251-4.058c-1.428,0.837-3.01,1.452-4.693,1.776C34.967,9.884,33.05,9,30.926,9c-4.08,0-7.387,3.278-7.387,7.32c0,0.572,0.067,1.129,0.193,1.67c-6.138-0.308-11.582-3.226-15.224-7.654c-0.64,1.082-1,2.349-1,3.686c0,2.541,1.301,4.778,3.285,6.096c-1.211-0.037-2.351-0.374-3.349-0.914c0,0.022,0,0.055,0,0.086c0,3.551,2.547,6.508,5.923,7.181c-0.617,0.169-1.269,0.263-1.941,0.263c-0.477,0-0.942-0.054-1.392-0.135c0.94,2.902,3.667,5.023,6.898,5.086c-2.528,1.96-5.712,3.134-9.174,3.134c-0.598,0-1.183-0.034-1.761-0.104C9.268,36.786,13.152,38,17.321,38c13.585,0,21.017-11.156,21.017-20.834c0-0.317-0.01-0.633-0.025-0.945C39.763,15.197,41.013,13.905,42,12.429" /></svg>
           </button>
         </div>
         <div className="down">
-          <button className="card3" onClick={() => onSelect('EI')}>
+          <button
+            className={`card3 ${selected === 2 ? 'selected' : ''}`}
+            onClick={() => onSelect('EI')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px" className="github">    <path d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051 c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526 c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769 c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098 c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9 c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594 c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734 c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z" /></svg>
           </button>
-          <button className="card4" onClick={() => onSelect('EE')}>
+          <button
+            className={`card4 ${selected === 3 ? 'selected' : ''}`}
+            onClick={() => onSelect('EE')}
+          >
             <svg height="30px" width="30px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" className="discord"><path d="M40,12c0,0-4.585-3.588-10-4l-0.488,0.976C34.408,10.174,36.654,11.891,39,14c-4.045-2.065-8.039-4-15-4s-10.955,1.935-15,4c2.346-2.109,5.018-4.015,9.488-5.024L18,8c-5.681,0.537-10,4-10,4s-5.121,7.425-6,22c5.162,5.953,13,6,13,6l1.639-2.185C13.857,36.848,10.715,35.121,8,32c3.238,2.45,8.125,5,16,5s12.762-2.55,16-5c-2.715,3.121-5.857,4.848-8.639,5.815L33,40c0,0,7.838-0.047,13-6C45.121,19.425,40,12,40,12z M17.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C21,28.209,19.433,30,17.5,30z M30.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C34,28.209,32.433,30,30.5,30z" /></svg>
           </button>
         </div>
@@ -25,6 +59,15 @@ export default function QuadrantMenu({ onSelect }) {
     </StyledWrapper>
   );
 }
+
+const pulse = keyframes`
+  from {
+    box-shadow: 0 0 0 2px #ffd700;
+  }
+  to {
+    box-shadow: 0 0 0 4px #ffd700;
+  }
+`;
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -154,5 +197,10 @@ const StyledWrapper = styled.div`
 
   .card4:hover .discord {
     fill: white;
+  }
+
+  .selected {
+    animation: ${pulse} 1s infinite alternate;
+    transform: scale(1.1);
   }
 `;

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,6 +17,15 @@ body.menu-page {
   background-size: cover;
 }
 
+@keyframes pulse {
+  from {
+    box-shadow: 0 0 4px gold;
+  }
+  to {
+    box-shadow: 0 0 12px gold;
+  }
+}
+
 body.character-page {
   background: var(--char-bg-url) no-repeat center center fixed;
   background-size: cover;
@@ -57,6 +66,7 @@ body.character-page {
 
 .tab.active {
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
+  animation: pulse 1s infinite alternate;
 }
 
 .tab:hover {
@@ -85,6 +95,7 @@ body.character-page {
 
 .layer-tab.active {
   background-color: rgba(0, 0, 0, 0.4);
+  animation: pulse 1s infinite alternate;
 }
 
 .layer-tab:hover {

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,15 @@ body {
   color: #e6e7eb;
 }
 
+@keyframes pulse {
+  from {
+    box-shadow: 0 0 4px gold;
+  }
+  to {
+    box-shadow: 0 0 12px gold;
+  }
+}
+
 
 .app-container {
   display: flex;
@@ -43,6 +52,7 @@ body {
 
 .tab.active {
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
+  animation: pulse 1s infinite alternate;
 }
 
 .tab:hover {


### PR DESCRIPTION
## Summary
- Add navigation history to PageRouter
- Map Escape key to go back or return home
- Navigate quadrants and tabs with WASD keys
- Highlight selected items with pulse animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc31d04248322a9b8787a5723656e