### PR TITLE
Handle Escape to navigate back and add keyboard navigation

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -67,20 +67,170 @@ export default function QuadrantPage({ initialTab }) {
   const [showMomentoMori, setShowMomentoMori] = useState(false);
   // Avoid naming clash with src/App.jsx by giving the blog state a unique name
   const [showToolsBlog, setShowToolsBlog] = useState(false);
-  const [showAkashicRecords, setShowAkashicRecords] = useState(false);
-  const [showProfile, setShowProfile] = useState(false);
-  const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
-  const [showSettings, setShowSettings] = useState(false);
-  const [autoLog, setAutoLog] = useState(
-    () => localStorage.getItem('autoLog') === 'true'
-  );
-  const [theme, setTheme] = useState(
-    () => localStorage.getItem('theme') || 'dark'
-  );
+const [showAkashicRecords, setShowAkashicRecords] = useState(false);
+const [showProfile, setShowProfile] = useState(false);
+const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
+const [showSettings, setShowSettings] = useState(false);
+const [autoLog, setAutoLog] = useState(
+  () => localStorage.getItem('autoLog') === 'true'
+);
+const [theme, setTheme] = useState(
+  () => localStorage.getItem('theme') || 'dark'
+);
+const [selectedAppIndex, setSelectedAppIndex] = useState(-1);
+const [sidebarIndex, setSidebarIndex] = useState(() =>
+  tabs.findIndex((t) => t.label === (initialTab || tabs[0].label))
+);
+
+const anyAppOpen =
+  showJournal ||
+  showNofap ||
+  showRatings ||
+  showWhoAmI ||
+  showMusic ||
+  showSinging ||
+  showShadowWork ||
+  showCalendarApp ||
+  showTimeline ||
+  showTypomancy ||
+  showMoodtracker ||
+  showAnima ||
+  showMomentoMori ||
+  showToolsBlog ||
+  showAkashicRecords ||
+  showProfile ||
+  showSettings;
+
+const closeOpenApp = () => {
+  setShowJournal(false);
+  setShowNofap(false);
+  setShowRatings(false);
+  setShowWhoAmI(false);
+  setShowMusic(false);
+  setShowSinging(false);
+  setShowShadowWork(false);
+  setShowCalendarApp(false);
+  setShowTimeline(false);
+  setShowTypomancy(false);
+  setShowMoodtracker(false);
+  setShowAnima(false);
+  setShowMomentoMori(false);
+  setShowToolsBlog(false);
+  setShowAkashicRecords(false);
+  setShowProfile(false);
+  setShowSettings(false);
+};
 
   useEffect(() => {
     localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
   }, [autoLog]);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      const key = e.key.toLowerCase();
+
+      if (anyAppOpen) {
+        if (key === 'escape') {
+          e.preventDefault();
+          closeOpenApp();
+        }
+        return;
+      }
+
+      const totalSidebarItems = tabs.length + 3;
+      if (selectedAppIndex === -1) {
+        if (key === 'w') {
+          setSidebarIndex((prev) => Math.max(0, prev - 1));
+        } else if (key === 's') {
+          setSidebarIndex((prev) => Math.min(totalSidebarItems - 1, prev + 1));
+        } else if (key === 'enter') {
+          if (sidebarIndex < tabs.length) {
+            if (tabs[sidebarIndex].label === 'Tools') {
+              const cards = document.querySelectorAll('.feature-cards .app-card');
+              if (cards.length > 0) {
+                setSelectedAppIndex(0);
+              }
+            }
+          } else {
+            const actionIdx = sidebarIndex - tabs.length;
+            if (actionIdx === 0) {
+              setShowSettings(true);
+            } else if (actionIdx === 1) {
+              setShowProfile(true);
+            } else if (actionIdx === 2) {
+              window.location.reload();
+            }
+          }
+        }
+      } else {
+        const cards = Array.from(
+          document.querySelectorAll('.feature-cards .app-card')
+        );
+        const currentRect = cards[selectedAppIndex].getBoundingClientRect();
+        const cx = currentRect.left + currentRect.width / 2;
+        const cy = currentRect.top + currentRect.height / 2;
+
+        const moveSelection = (dir) => {
+          let best = selectedAppIndex;
+          let bestDist = Infinity;
+          cards.forEach((card, idx) => {
+            if (idx === selectedAppIndex) return;
+            const rect = card.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+            let valid = false;
+            if (dir === 'left') valid = x < cx - 5;
+            if (dir === 'right') valid = x > cx + 5;
+            if (dir === 'up') valid = y < cy - 5;
+            if (dir === 'down') valid = y > cy + 5;
+            if (valid) {
+              const dx = cx - x;
+              const dy = cy - y;
+              const dist = dx * dx + dy * dy;
+              if (dist < bestDist) {
+                bestDist = dist;
+                best = idx;
+              }
+            }
+          });
+          setSelectedAppIndex(best);
+        };
+
+        if (key === 'a') moveSelection('left');
+        else if (key === 'd') moveSelection('right');
+        else if (key === 'w') moveSelection('up');
+        else if (key === 's') moveSelection('down');
+        else if (key === 'enter') {
+          cards[selectedAppIndex]?.click();
+          setSelectedAppIndex(-1);
+        } else if (key === 'escape') {
+          e.preventDefault();
+          setSelectedAppIndex(-1);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [activeTab, anyAppOpen, selectedAppIndex, closeOpenApp, sidebarIndex]);
+
+useEffect(() => {
+  if (sidebarIndex < tabs.length) {
+    setActiveTab(tabs[sidebarIndex].label);
+  }
+}, [sidebarIndex]);
+
+  useEffect(() => {
+    if (activeTab !== 'Tools' || anyAppOpen) {
+      setSelectedAppIndex(-1);
+    }
+  }, [activeTab, anyAppOpen]);
+
+  useEffect(() => {
+    const cards = document.querySelectorAll('.feature-cards .app-card');
+    cards.forEach((card, idx) => {
+      card.classList.toggle('selected', idx === selectedAppIndex);
+    });
+  }, [selectedAppIndex, activeTab]);
 
   useEffect(() => {
     document.body.classList.toggle('light-theme', theme === 'light');
@@ -137,26 +287,47 @@ export default function QuadrantPage({ initialTab }) {
       <WindowControls />
       <div className="app-container">
       <aside className="sidebar">
-        {tabs.map((tab) => (
+        {tabs.map((tab, idx) => (
           <div
             key={tab.label}
-            className={`tab ${activeTab === tab.label ? 'active' : ''}`}
-            onClick={() => setActiveTab(tab.label)}
+            className={`tab ${activeTab === tab.label ? 'active' : ''} ${sidebarIndex === idx ? 'selected' : ''}`}
+            onClick={() => {
+              setActiveTab(tab.label);
+              setSidebarIndex(idx);
+            }}
           >
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
         <div className="bottom-buttons">
-          <div className="settings-button" onClick={() => setShowSettings(true)}>
+          <div
+            className={`settings-button ${sidebarIndex === tabs.length ? 'selected' : ''}`}
+            onClick={() => {
+              setShowSettings(true);
+              setSidebarIndex(tabs.length);
+            }}
+          >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M13.6006 21.0761L19.0608 17.9236C19.6437 17.5871 19.9346 17.4188 20.1465 17.1834C20.3341 16.9751 20.4759 16.7297 20.5625 16.4632C20.6602 16.1626 20.6602 15.8267 20.6602 15.1568V8.84268C20.6602 8.17277 20.6602 7.83694 20.5625 7.53638C20.4759 7.26982 20.3341 7.02428 20.1465 6.816C19.9355 6.58161 19.6453 6.41405 19.0674 6.08043L13.5996 2.92359C13.0167 2.58706 12.7259 2.41913 12.416 2.35328C12.1419 2.295 11.8584 2.295 11.5843 2.35328C11.2744 2.41914 10.9826 2.58706 10.3997 2.92359L4.93843 6.07666C4.35623 6.41279 4.06535 6.58073 3.85352 6.816C3.66597 7.02428 3.52434 7.26982 3.43773 7.53638C3.33984 7.83765 3.33984 8.17436 3.33984 8.84742V15.1524C3.33984 15.8254 3.33984 16.1619 3.43773 16.4632C3.52434 16.7297 3.66597 16.9751 3.85352 17.1834C4.06548 17.4188 4.35657 17.5871 4.93945 17.9236L10.3997 21.0761C10.9826 21.4126 11.2744 21.5806 11.5843 21.6465C11.8584 21.7047 12.1419 21.7047 12.416 21.6465C12.7259 21.5806 13.0177 21.4126 13.6006 21.0761Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
               <path d="M9 11.9998C9 13.6566 10.3431 14.9998 12 14.9998C13.6569 14.9998 15 13.6566 15 11.9998C15 10.3429 13.6569 8.99976 12 8.99976C10.3431 8.99976 9 10.3429 9 11.9998Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </div>
-          <div className="profile-button" onClick={() => setShowProfile(true)}>
+          <div
+            className={`profile-button ${sidebarIndex === tabs.length + 1 ? 'selected' : ''}`}
+            onClick={() => {
+              setShowProfile(true);
+              setSidebarIndex(tabs.length + 1);
+            }}
+          >
             <img className="sidebar-avatar" src={avatarUrl} alt="Profile" />
           </div>
-          <div className="home-button" onClick={() => window.location.reload()}>
+          <div
+            className={`home-button ${sidebarIndex === tabs.length + 2 ? 'selected' : ''}`}
+            onClick={() => {
+              window.location.reload();
+              setSidebarIndex(tabs.length + 2);
+            }}
+          >
             🏠
           </div>
         </div>

--- a/FifthMain.jsx
+++ b/FifthMain.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import NoteModal from './NoteModal.jsx';
 import NotesListModal from './NotesListModal.jsx';
 import './main-page.css';
@@ -12,6 +12,7 @@ export default function FifthMain({ onSelectQuadrant }) {
   const [rightWidth, setRightWidth] = useState(MIN_WIDTH);
   const [showModal, setShowModal] = useState(false);
   const [showList, setShowList] = useState(false);
+  const [menuIndex, setMenuIndex] = useState(0);
 
   const startLeftDrag = (e) => {
     e.preventDefault();
@@ -55,6 +56,44 @@ export default function FifthMain({ onSelectQuadrant }) {
     document.addEventListener('mouseup', onMouseUp);
   };
 
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        if (showModal) {
+          e.preventDefault();
+          setShowModal(false);
+        } else if (showList) {
+          e.preventDefault();
+          setShowList(false);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [showModal, showList]);
+
+  useEffect(() => {
+    const handleNav = (e) => {
+      const key = e.key.toLowerCase();
+      if (key === 'a') {
+        setMenuIndex((prev) => Math.max(0, prev - 1));
+      } else if (key === 'd') {
+        setMenuIndex((prev) => Math.min(5, prev + 1));
+      } else if (key === 'enter') {
+        if (menuIndex === 0) {
+          setShowList(true);
+        } else if (menuIndex === 1) {
+          setShowModal(true);
+        } else {
+          const quadrants = ['II', 'IE', 'EI', 'EE'];
+          onSelectQuadrant(quadrants[menuIndex - 2]);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleNav);
+    return () => window.removeEventListener('keydown', handleNav);
+  }, [menuIndex, onSelectQuadrant]);
+
   return (
     <div className="main-page">
       <div className="side left" style={{ width: leftWidth }}>
@@ -65,18 +104,24 @@ export default function FifthMain({ onSelectQuadrant }) {
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>
       <div className="bottom-menu">
-        <button className="side-button" onClick={() => setShowList(true)}>
+        <button
+          className={`side-button ${menuIndex === 0 ? 'selected' : ''}`}
+          onClick={() => setShowList(true)}
+        >
           <svg width="27" height="27" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M12 1L12 17M12 1H4.2002C3.08009 1 2.51962 1 2.0918 1.21799C1.71547 1.40973 1.40973 1.71547 1.21799 2.0918C1 2.51962 1 3.08009 1 4.2002V13.8002C1 14.9203 1 15.4796 1.21799 15.9074C1.40973 16.2837 1.71547 16.5905 2.0918 16.7822C2.51921 17 3.07901 17 4.19694 17L12 17M12 1H13.8002C14.9203 1 15.4796 1 15.9074 1.21799C16.2837 1.40973 16.5905 1.71547 16.7822 2.0918C17 2.5192 17 3.079 17 4.19691L17 13.8031C17 14.921 17 15.48 16.7822 15.9074C16.5905 16.2837 16.2837 16.5905 15.9074 16.7822C15.48 17 14.921 17 13.8031 17H12" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
         </button>
-        <button className="side-button" onClick={() => setShowModal(true)}>
+        <button
+          className={`side-button ${menuIndex === 1 ? 'selected' : ''}`}
+          onClick={() => setShowModal(true)}
+        >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M6.5 19H17.5C17.9647 19 18.197 18.9999 18.3902 18.9614C19.1836 18.8036 19.8036 18.1836 19.9614 17.3902C19.9999 17.197 19.9999 16.9647 19.9999 16.5C19.9999 16.0353 19.9999 15.8031 19.9614 15.6099C19.8036 14.8165 19.1836 14.1962 18.3902 14.0384C18.197 14 17.9647 14 17.5 14H6.5C6.03534 14 5.80306 14 5.60986 14.0384C4.81648 14.1962 4.19624 14.8165 4.03843 15.6099C4 15.8031 4 16.0354 4 16.5C4 16.9647 4 17.1969 4.03843 17.3901C4.19624 18.1835 4.81648 18.8036 5.60986 18.9614C5.80306 18.9999 6.03535 19 6.5 19Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
             <path d="M6.5 10H17.5C17.9647 10 18.197 9.99986 18.3902 9.96143C19.1836 9.80361 19.8036 9.18356 19.9614 8.39018C19.9999 8.19698 19.9999 7.96465 19.9999 7.5C19.9999 7.03535 19.9999 6.80306 19.9614 6.60986C19.8036 5.81648 19.1836 5.19624 18.3902 5.03843C18.197 5 17.9647 5 17.5 5H6.5C6.03534 5 5.80306 5 5.60986 5.03843C4.81648 5.19624 4.19624 5.81648 4.03843 6.60986C4 6.80306 4 7.03539 4 7.50004C4 7.9647 4 8.19694 4.03843 8.39014C4.19624 9.18352 4.81648 9.80361 5.60986 9.96143C5.80306 9.99986 6.03535 10 6.5 10Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
         </button>
-        <QuadrantMenu onSelect={onSelectQuadrant} />
+        <QuadrantMenu onSelect={onSelectQuadrant} selected={menuIndex - 2} />
       </div>
       {showModal && <NoteModal onClose={() => setShowModal(false)} />}
       {showList && <NotesListModal onClose={() => setShowList(false)} />}

--- a/PageRouter.jsx
+++ b/PageRouter.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import FifthMain from './FifthMain.jsx';
 import IImain from './IImain.jsx';
 import IEmain from './IEmain.jsx';
@@ -11,6 +11,7 @@ import ExitVideo from './ExitVideo.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
+  const history = useRef(['5th']);
   const [user, setUser] = useState(null);
   const [showExitVideo, setShowExitVideo] = useState(false);
   const [pendingResize, setPendingResize] = useState(false);
@@ -50,9 +51,28 @@ export default function PageRouter() {
     prevUser.current = user;
   }, [user]);
 
+  const navigate = useCallback((newPage) => {
+    if (newPage === '5th') {
+      history.current = ['5th'];
+    } else {
+      const current = history.current[history.current.length - 1];
+      if (current !== newPage) {
+        history.current = [...history.current, newPage];
+      }
+    }
+    setPage(newPage);
+  }, []);
+
+  const goBack = useCallback(() => {
+    if (history.current.length > 1) {
+      history.current = history.current.slice(0, -1);
+      setPage(history.current[history.current.length - 1]);
+    }
+  }, []);
+
   useEffect(() => {
     if (window.electronAPI && window.electronAPI.onGoHome) {
-      window.electronAPI.onGoHome(() => setPage('5th'));
+      window.electronAPI.onGoHome(() => navigate('5th'));
     }
     if (window.electronAPI && window.electronAPI.onDisconnect) {
       window.electronAPI.onDisconnect(async () => {
@@ -62,7 +82,17 @@ export default function PageRouter() {
         await supabaseClient.auth.signOut();
       });
     }
-  }, []);
+  }, [navigate]);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && !e.defaultPrevented) {
+        goBack();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [goBack]);
 
   if (!user) {
     return <Auth />;
@@ -97,7 +127,7 @@ export default function PageRouter() {
       content = <EEmain />;
       break;
     default:
-      content = <FifthMain onSelectQuadrant={(label) => setPage(label)} />;
+      content = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;
   }
 
   return (

--- a/QuadrantMenu.jsx
+++ b/QuadrantMenu.jsx
@@ -1,23 +1,35 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
-export default function QuadrantMenu({ onSelect }) {
+export default function QuadrantMenu({ onSelect, selected }) {
   return (
     <StyledWrapper>
       <div className="main">
         <div className="up">
-          <button className="card1" onClick={() => onSelect('II')}>
+          <button
+            className={`card1 ${selected === 0 ? 'selected' : ''}`}
+            onClick={() => onSelect('II')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" viewBox="0,0,256,256" width="30px" height="30px" fillRule="nonzero" className="instagram"><g fillRule="nonzero" stroke="none" strokeWidth={1} strokeLinecap="butt" strokeLinejoin="miter" strokeMiterlimit={10} strokeDasharray strokeDashoffset={0} fontFamily="none" fontWeight="none" fontSize="none" textAnchor="none" style={{mixBlendMode: 'normal'}}><g transform="scale(8,8)"><path d="M11.46875,5c-3.55078,0 -6.46875,2.91406 -6.46875,6.46875v9.0625c0,3.55078 2.91406,6.46875 6.46875,6.46875h9.0625c3.55078,0 6.46875,-2.91406 6.46875,-6.46875v-9.0625c0,-3.55078 -2.91406,-6.46875 -6.46875,-6.46875zM11.46875,7h9.0625c2.47266,0 4.46875,1.99609 4.46875,4.46875v9.0625c0,2.47266 -1.99609,4.46875 -4.46875,4.46875h-9.0625c-2.47266,0 -4.46875,-1.99609 -4.46875,-4.46875v-9.0625c0,-2.47266 1.99609,-4.46875 4.46875,-4.46875zM21.90625,9.1875c-0.50391,0 -0.90625,0.40234 -0.90625,0.90625c0,0.50391 0.40234,0.90625 0.90625,0.90625c0.50391,0 0.90625,-0.40234 0.90625,-0.90625c0,-0.50391 -0.40234,-0.90625 -0.90625,-0.90625zM16,10c-3.30078,0 -6,2.69922 -6,6c0,3.30078 2.69922,6 6,6c3.30078,0 6,-2.69922 6,-6c0,-3.30078 -2.69922,-6 -6,-6zM16,12c2.22266,0 4,1.77734 4,4c0,2.22266 -1.77734,4 -4,4c-2.22266,0 -4,-1.77734 -4,-4c0,-2.22266 1.77734,-4 4,-4z" /></g></g></svg>
           </button>
-          <button className="card2" onClick={() => onSelect('IE')}>
+          <button
+            className={`card2 ${selected === 1 ? 'selected' : ''}`}
+            onClick={() => onSelect('IE')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="30px" height="30px" className="twitter"><path d="M42,12.429c-1.323,0.586-2.746,0.977-4.247,1.162c1.526-0.906,2.7-2.351,3.251-4.058c-1.428,0.837-3.01,1.452-4.693,1.776C34.967,9.884,33.05,9,30.926,9c-4.08,0-7.387,3.278-7.387,7.32c0,0.572,0.067,1.129,0.193,1.67c-6.138-0.308-11.582-3.226-15.224-7.654c-0.64,1.082-1,2.349-1,3.686c0,2.541,1.301,4.778,3.285,6.096c-1.211-0.037-2.351-0.374-3.349-0.914c0,0.022,0,0.055,0,0.086c0,3.551,2.547,6.508,5.923,7.181c-0.617,0.169-1.269,0.263-1.941,0.263c-0.477,0-0.942-0.054-1.392-0.135c0.94,2.902,3.667,5.023,6.898,5.086c-2.528,1.96-5.712,3.134-9.174,3.134c-0.598,0-1.183-0.034-1.761-0.104C9.268,36.786,13.152,38,17.321,38c13.585,0,21.017-11.156,21.017-20.834c0-0.317-0.01-0.633-0.025-0.945C39.763,15.197,41.013,13.905,42,12.429" /></svg>
           </button>
         </div>
         <div className="down">
-          <button className="card3" onClick={() => onSelect('EI')}>
+          <button
+            className={`card3 ${selected === 2 ? 'selected' : ''}`}
+            onClick={() => onSelect('EI')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px" className="github">    <path d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051 c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526 c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769 c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098 c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9 c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594 c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734 c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z" /></svg>
           </button>
-          <button className="card4" onClick={() => onSelect('EE')}>
+          <button
+            className={`card4 ${selected === 3 ? 'selected' : ''}`}
+            onClick={() => onSelect('EE')}
+          >
             <svg height="30px" width="30px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" className="discord"><path d="M40,12c0,0-4.585-3.588-10-4l-0.488,0.976C34.408,10.174,36.654,11.891,39,14c-4.045-2.065-8.039-4-15-4s-10.955,1.935-15,4c2.346-2.109,5.018-4.015,9.488-5.024L18,8c-5.681,0.537-10,4-10,4s-5.121,7.425-6,22c5.162,5.953,13,6,13,6l1.639-2.185C13.857,36.848,10.715,35.121,8,32c3.238,2.45,8.125,5,16,5s12.762-2.55,16-5c-2.715,3.121-5.857,4.848-8.639,5.815L33,40c0,0,7.838-0.047,13-6C45.121,19.425,40,12,40,12z M17.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C21,28.209,19.433,30,17.5,30z M30.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C34,28.209,32.433,30,30.5,30z" /></svg>
           </button>
         </div>
@@ -25,6 +37,15 @@ export default function QuadrantMenu({ onSelect }) {
     </StyledWrapper>
   );
 }
+
+const pulse = keyframes`
+  from {
+    box-shadow: 0 0 0 2px #ffd700;
+  }
+  to {
+    box-shadow: 0 0 0 4px #ffd700;
+  }
+`;
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -154,5 +175,10 @@ const StyledWrapper = styled.div`
 
   .card4:hover .discord {
     fill: white;
+  }
+
+  .selected {
+    animation: ${pulse} 1s infinite alternate;
+    transform: scale(1.1);
   }
 `;

--- a/main-page.css
+++ b/main-page.css
@@ -63,6 +63,11 @@ body {
   padding: 0;
 }
 
+.side-button.selected {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.1);
+}
+
 .side-button svg {
   width: 27px;
   height: 27px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -137,6 +137,68 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     () => localStorage.getItem('theme') || 'dark'
   );
 
+  const [selectedAppIndex, setSelectedAppIndex] = useState(-1);
+  const [sidebarIndex, setSidebarIndex] = useState(() =>
+    tabs.findIndex((t) => t.label === (initialTab || tabs[0].label))
+  );
+
+  const anyAppOpen =
+    showJournal ||
+    showNofap ||
+    showRatings ||
+    showWhoAmI ||
+    showMusic ||
+    showSinging ||
+    showShadowWork ||
+    showCalendarApp ||
+    showTimeline ||
+    showTypomancy ||
+    showMoodtracker ||
+    showMomentoMori ||
+    showQuadrantComb ||
+    showAnima ||
+    showBlog ||
+    showTodoGoals ||
+    showActivity ||
+    showCharacterEvolve ||
+    showSemiCharacter ||
+    showIdeaBoard ||
+    showImplementationIdeas ||
+    showOrb ||
+    showToolsBlog ||
+    showAkashicRecords ||
+    showProfile ||
+    showSettings;
+
+  const closeOpenApp = () => {
+    setShowJournal(false);
+    setShowNofap(false);
+    setShowRatings(false);
+    setShowWhoAmI(false);
+    setShowMusic(false);
+    setShowSinging(false);
+    setShowShadowWork(false);
+    setShowCalendarApp(false);
+    setShowTimeline(false);
+    setShowTypomancy(false);
+    setShowMoodtracker(false);
+    setShowMomentoMori(false);
+    setShowQuadrantComb(false);
+    setShowAnima(false);
+    setShowBlog(false);
+    setShowTodoGoals(false);
+    setShowActivity(false);
+    setShowCharacterEvolve(false);
+    setShowSemiCharacter(false);
+    setShowIdeaBoard(false);
+    setShowImplementationIdeas(false);
+    setShowOrb(false);
+    setShowToolsBlog(false);
+    setShowAkashicRecords(false);
+    setShowProfile(false);
+    setShowSettings(false);
+  };
+
   useEffect(() => {
     document.body.classList.toggle('light-theme', theme === 'light');
     localStorage.setItem('theme', theme);
@@ -172,6 +234,123 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   useEffect(() => {
     localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
   }, [autoLog]);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      const key = e.key.toLowerCase();
+
+      if (anyAppOpen) {
+        if (key === 'escape') {
+          e.preventDefault();
+          closeOpenApp();
+        }
+        return;
+      }
+
+      const totalSidebarItems = tabs.length + 3; // settings, profile, home
+      if (selectedAppIndex === -1) {
+        if (key === 'a') {
+          setActiveLayer((prev) => {
+            const idx = layers.findIndex((l) => l.label === prev);
+            return layers[Math.max(0, idx - 1)].label;
+          });
+        } else if (key === 'd') {
+          setActiveLayer((prev) => {
+            const idx = layers.findIndex((l) => l.label === prev);
+            return layers[Math.min(layers.length - 1, idx + 1)].label;
+          });
+        } else if (key === 'w') {
+          setSidebarIndex((prev) => Math.max(0, prev - 1));
+        } else if (key === 's') {
+          setSidebarIndex((prev) => Math.min(totalSidebarItems - 1, prev + 1));
+        } else if (key === 'enter') {
+          if (sidebarIndex < tabs.length) {
+            if (tabs[sidebarIndex].label === 'Tools') {
+              const cards = document.querySelectorAll('.feature-cards .app-card');
+              if (cards.length > 0) {
+                setSelectedAppIndex(0);
+              }
+            }
+          } else {
+            const actionIdx = sidebarIndex - tabs.length;
+            if (actionIdx === 0) {
+              setShowSettings(true);
+            } else if (actionIdx === 1) {
+              setShowProfile(true);
+            } else if (actionIdx === 2) {
+              window.location.reload();
+            }
+          }
+        }
+      } else {
+        const cards = Array.from(
+          document.querySelectorAll('.feature-cards .app-card')
+        );
+        const currentRect = cards[selectedAppIndex].getBoundingClientRect();
+        const cx = currentRect.left + currentRect.width / 2;
+        const cy = currentRect.top + currentRect.height / 2;
+
+        const moveSelection = (dir) => {
+          let best = selectedAppIndex;
+          let bestDist = Infinity;
+          cards.forEach((card, idx) => {
+            if (idx === selectedAppIndex) return;
+            const rect = card.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+            let valid = false;
+            if (dir === 'left') valid = x < cx - 5;
+            if (dir === 'right') valid = x > cx + 5;
+            if (dir === 'up') valid = y < cy - 5;
+            if (dir === 'down') valid = y > cy + 5;
+            if (valid) {
+              const dx = cx - x;
+              const dy = cy - y;
+              const dist = dx * dx + dy * dy;
+              if (dist < bestDist) {
+                bestDist = dist;
+                best = idx;
+              }
+            }
+          });
+          setSelectedAppIndex(best);
+        };
+
+        if (key === 'a') moveSelection('left');
+        else if (key === 'd') moveSelection('right');
+        else if (key === 'w') moveSelection('up');
+        else if (key === 's') moveSelection('down');
+        else if (key === 'enter') {
+          cards[selectedAppIndex]?.click();
+          setSelectedAppIndex(-1);
+        } else if (key === 'escape') {
+          e.preventDefault();
+          setSelectedAppIndex(-1);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [activeTab, anyAppOpen, selectedAppIndex, closeOpenApp, sidebarIndex]);
+
+  useEffect(() => {
+    if (sidebarIndex < tabs.length) {
+      setActiveTab(tabs[sidebarIndex].label);
+    }
+  }, [sidebarIndex]);
+
+  useEffect(() => {
+    if (activeTab !== 'Tools' || anyAppOpen) {
+      setSelectedAppIndex(-1);
+    }
+  }, [activeTab, anyAppOpen]);
+
+  useEffect(() => {
+    const cards = document.querySelectorAll('.feature-cards .app-card');
+    cards.forEach((card, idx) => {
+      card.classList.toggle('selected', idx === selectedAppIndex);
+    });
+  }, [selectedAppIndex, activeTab, activeLayer]);
 
   useEffect(() => {
     const loadAvatar = async () => {
@@ -249,26 +428,47 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       <ActivityLogger enabled={autoLog} />
       <div className="app-container">
       <aside className="sidebar">
-        {tabs.map((tab) => (
+        {tabs.map((tab, idx) => (
           <div
             key={tab.label}
-            className={`tab ${activeTab === tab.label ? 'active' : ''}`}
-            onClick={() => setActiveTab(tab.label)}
+            className={`tab ${activeTab === tab.label ? 'active' : ''} ${sidebarIndex === idx ? 'selected' : ''}`}
+            onClick={() => {
+              setActiveTab(tab.label);
+              setSidebarIndex(idx);
+            }}
           >
             <span className="icon">{tab.icon}</span>
           </div>
         ))}
         <div className="bottom-buttons">
-          <div className="settings-button" onClick={() => setShowSettings(true)}>
+          <div
+            className={`settings-button ${sidebarIndex === tabs.length ? 'selected' : ''}`}
+            onClick={() => {
+              setShowSettings(true);
+              setSidebarIndex(tabs.length);
+            }}
+          >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M13.6006 21.0761L19.0608 17.9236C19.6437 17.5871 19.9346 17.4188 20.1465 17.1834C20.3341 16.9751 20.4759 16.7297 20.5625 16.4632C20.6602 16.1626 20.6602 15.8267 20.6602 15.1568V8.84268C20.6602 8.17277 20.6602 7.83694 20.5625 7.53638C20.4759 7.26982 20.3341 7.02428 20.1465 6.816C19.9355 6.58161 19.6453 6.41405 19.0674 6.08043L13.5996 2.92359C13.0167 2.58706 12.7259 2.41913 12.416 2.35328C12.1419 2.295 11.8584 2.295 11.5843 2.35328C11.2744 2.41914 10.9826 2.58706 10.3997 2.92359L4.93843 6.07666C4.35623 6.41279 4.06535 6.58073 3.85352 6.816C3.66597 7.02428 3.52434 7.26982 3.43773 7.53638C3.33984 7.83765 3.33984 8.17436 3.33984 8.84742V15.1524C3.33984 15.8254 3.33984 16.1619 3.43773 16.4632C3.52434 16.7297 3.66597 16.9751 3.85352 17.1834C4.06548 17.4188 4.35657 17.5871 4.93945 17.9236L10.3997 21.0761C10.9826 21.4126 11.2744 21.5806 11.5843 21.6465C11.8584 21.7047 12.1419 21.7047 12.416 21.6465C12.7259 21.5806 13.0177 21.4126 13.6006 21.0761Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
               <path d="M9 11.9998C9 13.6566 10.3431 14.9998 12 14.9998C13.6569 14.9998 15 13.6566 15 11.9998C15 10.3429 13.6569 8.99976 12 8.99976C10.3431 8.99976 9 10.3429 9 11.9998Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
           </div>
-          <div className="profile-button" onClick={() => setShowProfile(true)}>
+          <div
+            className={`profile-button ${sidebarIndex === tabs.length + 1 ? 'selected' : ''}`}
+            onClick={() => {
+              setShowProfile(true);
+              setSidebarIndex(tabs.length + 1);
+            }}
+          >
             <img className="sidebar-avatar" src={avatarUrl} alt="Profile" />
           </div>
-          <div className="home-button" onClick={() => window.location.reload()}>
+          <div
+            className={`home-button ${sidebarIndex === tabs.length + 2 ? 'selected' : ''}`}
+            onClick={() => {
+              window.location.reload();
+              setSidebarIndex(tabs.length + 2);
+            }}
+          >
             🏠
           </div>
         </div>

--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import NoteModal from './NoteModal.jsx';
 import NotesListModal from './NotesListModal.jsx';
 import './main-page.css';
@@ -12,6 +12,7 @@ export default function FifthMain({ onSelectQuadrant }) {
   const [rightWidth, setRightWidth] = useState(MIN_WIDTH);
   const [showModal, setShowModal] = useState(false);
   const [showList, setShowList] = useState(false);
+  const [menuIndex, setMenuIndex] = useState(0);
 
   const startLeftDrag = (e) => {
     e.preventDefault();
@@ -55,6 +56,46 @@ export default function FifthMain({ onSelectQuadrant }) {
     document.addEventListener('mouseup', onMouseUp);
   };
 
+  useEffect(() => {
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        if (showModal) {
+          e.preventDefault();
+          setShowModal(false);
+        } else if (showList) {
+          e.preventDefault();
+          setShowList(false);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [showModal, showList]);
+
+  useEffect(() => {
+    const handleNav = (e) => {
+      const key = e.key.toLowerCase();
+      if (key === 'a') {
+        setMenuIndex((prev) => Math.max(0, prev - 1));
+      } else if (key === 'd') {
+        setMenuIndex((prev) => Math.min(6, prev + 1));
+      } else if (key === 'enter') {
+        if (menuIndex === 0) {
+          onSelectQuadrant('gallery');
+        } else if (menuIndex === 1) {
+          setShowList(true);
+        } else if (menuIndex === 2) {
+          setShowModal(true);
+        } else {
+          const quadrants = ['II', 'IE', 'EI', 'EE'];
+          onSelectQuadrant(quadrants[menuIndex - 3]);
+        }
+      }
+    };
+    window.addEventListener('keydown', handleNav);
+    return () => window.removeEventListener('keydown', handleNav);
+  }, [menuIndex, onSelectQuadrant]);
+
   return (
     <div className="main-page">
       <div className="side left" style={{ width: leftWidth }}>
@@ -65,24 +106,36 @@ export default function FifthMain({ onSelectQuadrant }) {
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>
       <div className="bottom-menu">
-        <button className="side-button" onClick={() => onSelectQuadrant('gallery')}>
+        <button
+          className={`side-button ${menuIndex === 0 ? 'selected' : ''}`}
+          onClick={() => onSelectQuadrant('gallery')}
+        >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M3 7.5C3 6.67157 3.67157 6 4.5 6H19.5C20.3284 6 21 6.67157 21 7.5V16.5C21 17.3284 20.3284 18 19.5 18H4.5C3.67157 18 3 17.3284 3 16.5V7.5Z" stroke="white" strokeWidth="2"/>
             <path d="M8 11L10.5 13.5L13.5 10.5L17 14" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
         </button>
-        <button className="side-button" onClick={() => setShowList(true)}>
+        <button
+          className={`side-button ${menuIndex === 1 ? 'selected' : ''}`}
+          onClick={() => setShowList(true)}
+        >
           <svg width="27" height="27" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M12 1L12 17M12 1H4.2002C3.08009 1 2.51962 1 2.0918 1.21799C1.71547 1.40973 1.40973 1.71547 1.21799 2.0918C1 2.51962 1 3.08009 1 4.2002V13.8002C1 14.9203 1 15.4796 1.21799 15.9074C1.40973 16.2837 1.71547 16.5905 2.0918 16.7822C2.51921 17 3.07901 17 4.19694 17L12 17M12 1H13.8002C14.9203 1 15.4796 1 15.9074 1.21799C16.2837 1.40973 16.5905 1.71547 16.7822 2.0918C17 2.5192 17 3.079 17 4.19691L17 13.8031C17 14.921 17 15.48 16.7822 15.9074C16.5905 16.2837 16.2837 16.5905 15.9074 16.7822C15.48 17 14.921 17 13.8031 17H12" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
         </button>
-        <button className="side-button" onClick={() => setShowModal(true)}>
+        <button
+          className={`side-button ${menuIndex === 2 ? 'selected' : ''}`}
+          onClick={() => setShowModal(true)}
+        >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M6.5 19H17.5C17.9647 19 18.197 18.9999 18.3902 18.9614C19.1836 18.8036 19.8036 18.1836 19.9614 17.3902C19.9999 17.197 19.9999 16.9647 19.9999 16.5C19.9999 16.0353 19.9999 15.8031 19.9614 15.6099C19.8036 14.8165 19.1836 14.1962 18.3902 14.0384C18.197 14 17.9647 14 17.5 14H6.5C6.03534 14 5.80306 14 5.60986 14.0384C4.81648 14.1962 4.19624 14.8165 4.03843 15.6099C4 15.8031 4 16.0354 4 16.5C4 16.9647 4 17.1969 4.03843 17.3901C4.19624 18.1835 4.81648 18.8036 5.60986 18.9614C5.80306 18.9999 6.03535 19 6.5 19Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
             <path d="M6.5 10H17.5C17.9647 10 18.197 9.99986 18.3902 9.96143C19.1836 9.80361 19.8036 9.18356 19.9614 8.39018C19.9999 8.19698 19.9999 7.96465 19.9999 7.5C19.9999 7.03535 19.9999 6.80306 19.9614 6.60986C19.8036 5.81648 19.1836 5.19624 18.3902 5.03843C18.197 5 17.9647 5 17.5 5H6.5C6.03534 5 5.80306 5 5.60986 5.03843C4.81648 5.19624 4.19624 5.81648 4.03843 6.60986C4 6.80306 4 7.03539 4 7.50004C4 7.9647 4 8.19694 4.03843 8.39014C4.19624 9.18352 4.81648 9.80361 5.60986 9.96143C5.80306 9.99986 6.03535 10 6.5 10Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
           </svg>
         </button>
-        <QuadrantMenu onSelect={onSelectQuadrant} />
+        <QuadrantMenu
+          onSelect={onSelectQuadrant}
+          selected={menuIndex - 3}
+        />
       </div>
       {showModal && <NoteModal onClose={() => setShowModal(false)} />}
       {showList && <NotesListModal onClose={() => setShowList(false)} />}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import FifthMain from './FifthMain.jsx';
 import IImain from './IImain.jsx';
 import IEmain from './IEmain.jsx';
@@ -12,6 +12,7 @@ import ImageGallery from './ImageGallery.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
+  const history = useRef(['5th']);
   const [user, setUser] = useState(null);
   const [showExitVideo, setShowExitVideo] = useState(false);
   const [pendingResize, setPendingResize] = useState(false);
@@ -55,9 +56,28 @@ export default function PageRouter() {
     prevUser.current = user;
   }, [user]);
 
+  const navigate = useCallback((newPage) => {
+    if (newPage === '5th') {
+      history.current = ['5th'];
+    } else {
+      const current = history.current[history.current.length - 1];
+      if (current !== newPage) {
+        history.current = [...history.current, newPage];
+      }
+    }
+    setPage(newPage);
+  }, []);
+
+  const goBack = useCallback(() => {
+    if (history.current.length > 1) {
+      history.current = history.current.slice(0, -1);
+      setPage(history.current[history.current.length - 1]);
+    }
+  }, []);
+
   useEffect(() => {
     if (window.electronAPI && window.electronAPI.onGoHome) {
-      window.electronAPI.onGoHome(() => setPage('5th'));
+      window.electronAPI.onGoHome(() => navigate('5th'));
     }
     if (window.electronAPI && window.electronAPI.onDisconnect) {
       window.electronAPI.onDisconnect(async () => {
@@ -67,7 +87,17 @@ export default function PageRouter() {
         await supabaseClient.auth.signOut();
       });
     }
-  }, []);
+  }, [navigate]);
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && !e.defaultPrevented) {
+        goBack();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [goBack]);
 
   useEffect(() => {
     document.body.style.setProperty('--menu-bg-url', `url("${menuBg}")`);
@@ -115,10 +145,10 @@ export default function PageRouter() {
       content = <EEmain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
       break;
     case 'gallery':
-      content = <ImageGallery onBack={() => setPage('5th')} />;
+      content = <ImageGallery onBack={() => navigate('5th')} />;
       break;
     default:
-      content = <FifthMain onSelectQuadrant={(label) => setPage(label)} />;
+      content = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;
   }
 
   return (

--- a/src/QuadrantMenu.jsx
+++ b/src/QuadrantMenu.jsx
@@ -1,23 +1,35 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
-export default function QuadrantMenu({ onSelect }) {
+export default function QuadrantMenu({ onSelect, selected }) {
   return (
     <StyledWrapper>
       <div className="main">
         <div className="up">
-          <button className="card1" onClick={() => onSelect('II')}>
+          <button
+            className={`card1 ${selected === 0 ? 'selected' : ''}`}
+            onClick={() => onSelect('II')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" viewBox="0,0,256,256" width="30px" height="30px" fillRule="nonzero" className="instagram"><g fillRule="nonzero" stroke="none" strokeWidth={1} strokeLinecap="butt" strokeLinejoin="miter" strokeMiterlimit={10} strokeDasharray strokeDashoffset={0} fontFamily="none" fontWeight="none" fontSize="none" textAnchor="none" style={{mixBlendMode: 'normal'}}><g transform="scale(8,8)"><path d="M11.46875,5c-3.55078,0 -6.46875,2.91406 -6.46875,6.46875v9.0625c0,3.55078 2.91406,6.46875 6.46875,6.46875h9.0625c3.55078,0 6.46875,-2.91406 6.46875,-6.46875v-9.0625c0,-3.55078 -2.91406,-6.46875 -6.46875,-6.46875zM11.46875,7h9.0625c2.47266,0 4.46875,1.99609 4.46875,4.46875v9.0625c0,2.47266 -1.99609,4.46875 -4.46875,4.46875h-9.0625c-2.47266,0 -4.46875,-1.99609 -4.46875,-4.46875v-9.0625c0,-2.47266 1.99609,-4.46875 4.46875,-4.46875zM21.90625,9.1875c-0.50391,0 -0.90625,0.40234 -0.90625,0.90625c0,0.50391 0.40234,0.90625 0.90625,0.90625c0.50391,0 0.90625,-0.40234 0.90625,-0.90625c0,-0.50391 -0.40234,-0.90625 -0.90625,-0.90625zM16,10c-3.30078,0 -6,2.69922 -6,6c0,3.30078 2.69922,6 6,6c3.30078,0 6,-2.69922 6,-6c0,-3.30078 -2.69922,-6 -6,-6zM16,12c2.22266,0 4,1.77734 4,4c0,2.22266 -1.77734,4 -4,4c-2.22266,0 -4,-1.77734 -4,-4c0,-2.22266 1.77734,-4 4,-4z" /></g></g></svg>
           </button>
-          <button className="card2" onClick={() => onSelect('IE')}>
+          <button
+            className={`card2 ${selected === 1 ? 'selected' : ''}`}
+            onClick={() => onSelect('IE')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="30px" height="30px" className="twitter"><path d="M42,12.429c-1.323,0.586-2.746,0.977-4.247,1.162c1.526-0.906,2.7-2.351,3.251-4.058c-1.428,0.837-3.01,1.452-4.693,1.776C34.967,9.884,33.05,9,30.926,9c-4.08,0-7.387,3.278-7.387,7.32c0,0.572,0.067,1.129,0.193,1.67c-6.138-0.308-11.582-3.226-15.224-7.654c-0.64,1.082-1,2.349-1,3.686c0,2.541,1.301,4.778,3.285,6.096c-1.211-0.037-2.351-0.374-3.349-0.914c0,0.022,0,0.055,0,0.086c0,3.551,2.547,6.508,5.923,7.181c-0.617,0.169-1.269,0.263-1.941,0.263c-0.477,0-0.942-0.054-1.392-0.135c0.94,2.902,3.667,5.023,6.898,5.086c-2.528,1.96-5.712,3.134-9.174,3.134c-0.598,0-1.183-0.034-1.761-0.104C9.268,36.786,13.152,38,17.321,38c13.585,0,21.017-11.156,21.017-20.834c0-0.317-0.01-0.633-0.025-0.945C39.763,15.197,41.013,13.905,42,12.429" /></svg>
           </button>
         </div>
         <div className="down">
-          <button className="card3" onClick={() => onSelect('EI')}>
+          <button
+            className={`card3 ${selected === 2 ? 'selected' : ''}`}
+            onClick={() => onSelect('EI')}
+          >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30px" height="30px" className="github">    <path d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051 c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526 c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769 c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098 c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9 c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594 c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734 c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z" /></svg>
           </button>
-          <button className="card4" onClick={() => onSelect('EE')}>
+          <button
+            className={`card4 ${selected === 3 ? 'selected' : ''}`}
+            onClick={() => onSelect('EE')}
+          >
             <svg height="30px" width="30px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" className="discord"><path d="M40,12c0,0-4.585-3.588-10-4l-0.488,0.976C34.408,10.174,36.654,11.891,39,14c-4.045-2.065-8.039-4-15-4s-10.955,1.935-15,4c2.346-2.109,5.018-4.015,9.488-5.024L18,8c-5.681,0.537-10,4-10,4s-5.121,7.425-6,22c5.162,5.953,13,6,13,6l1.639-2.185C13.857,36.848,10.715,35.121,8,32c3.238,2.45,8.125,5,16,5s12.762-2.55,16-5c-2.715,3.121-5.857,4.848-8.639,5.815L33,40c0,0,7.838-0.047,13-6C45.121,19.425,40,12,40,12z M17.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C21,28.209,19.433,30,17.5,30z M30.5,30c-1.933,0-3.5-1.791-3.5-4c0-2.209,1.567-4,3.5-4s3.5,1.791,3.5,4C34,28.209,32.433,30,30.5,30z" /></svg>
           </button>
         </div>
@@ -25,6 +37,15 @@ export default function QuadrantMenu({ onSelect }) {
     </StyledWrapper>
   );
 }
+
+const pulse = keyframes`
+  from {
+    box-shadow: 0 0 0 2px #ffd700;
+  }
+  to {
+    box-shadow: 0 0 0 4px #ffd700;
+  }
+`;
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -154,5 +175,10 @@ const StyledWrapper = styled.div`
 
   .card4:hover .discord {
     fill: white;
+  }
+
+  .selected {
+    animation: ${pulse} 1s infinite alternate;
+    transform: scale(1.1);
   }
 `;

--- a/src/main-page.css
+++ b/src/main-page.css
@@ -63,6 +63,11 @@ body {
   padding: 0;
 }
 
+.side-button.selected {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.1);
+}
+
 .side-button svg {
   width: 27px;
   height: 27px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,6 +17,15 @@ body.menu-page {
   background-size: cover;
 }
 
+@keyframes pulse {
+  from {
+    box-shadow: 0 0 4px gold;
+  }
+  to {
+    box-shadow: 0 0 12px gold;
+  }
+}
+
 body.character-page {
   background: var(--char-bg-url) no-repeat center center fixed;
   background-size: cover;
@@ -57,6 +66,7 @@ body.character-page {
 
 .tab.active {
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
+  animation: pulse 1s infinite alternate;
 }
 
 .tab:hover {
@@ -85,6 +95,7 @@ body.character-page {
 
 .layer-tab.active {
   background-color: rgba(0, 0, 0, 0.4);
+  animation: pulse 1s infinite alternate;
 }
 
 .layer-tab:hover {
@@ -189,6 +200,17 @@ body.idea-board-page .content {
 
 .app-card:hover {
   background: #17181d;
+}
+
+.app-card.selected {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.05);
+}
+
+.sidebar .tab.selected,
+.sidebar .bottom-buttons > div.selected {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.1);
 }
 
 .calendar-preview {

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,15 @@ body {
   color: #e6e7eb;
 }
 
+@keyframes pulse {
+  from {
+    box-shadow: 0 0 4px gold;
+  }
+  to {
+    box-shadow: 0 0 12px gold;
+  }
+}
+
 
 .app-container {
   display: flex;
@@ -43,6 +52,7 @@ body {
 
 .tab.active {
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
+  animation: pulse 1s infinite alternate;
 }
 
 .tab:hover {
@@ -126,6 +136,17 @@ body.character-page h1 {
 
 .app-card:hover {
   background: #17181d;
+}
+
+.app-card.selected {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.05);
+}
+
+.sidebar .tab.selected,
+.sidebar .bottom-buttons > div.selected {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.1);
 }
 
 .calendar-preview {


### PR DESCRIPTION
## Summary
- Extend WASD navigation so sidebar tabs and bottom buttons can be reached and activated, including Settings and Profile
- Allow app cards to be navigated in all directions with WASD instead of linear left/right only
- Let home screen WASD control cover side buttons and quadrant buttons with selection highlighting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc31d04248322a9b8787a5723656e