### PR TITLE
Add admin console access from settings modal

### DIFF
--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -44,6 +44,13 @@ export default function SettingsModal({
     setShowBgChoice(false);
   };
 
+  const openAdminConsole = () => {
+    const w = window.open('', '_blank');
+    if (!w) return;
+    w.document.write(`<!DOCTYPE html><html><head><title>Admin Console</title></head><body style="background:white;color:black;font-family:sans-serif;padding:20px;"><h1>Admin Console</h1><button id="reopen">Reopen Day Planner</button><script>document.getElementById('reopen').onclick=function(){try{window.opener?.localStorage.removeItem('plannerDate');window.opener?.postMessage({type:'OPEN_DAY_PLANNER'},'*');}catch(e){console.error(e);}};</script></body></html>`);
+    w.document.close();
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={e => e.stopPropagation()}>
@@ -66,6 +73,9 @@ export default function SettingsModal({
         </label>
         <button className="save-button" onClick={onToggleTheme}>
           {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
+        <button className="save-button" onClick={openAdminConsole}>
+          Admin Console
         </button>
         <button
           className="save-button"


### PR DESCRIPTION
## Summary
- add openAdminConsole helper in settings modal to reopen day planner
- add Admin Console button after theme toggle in settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af15b8c1308322874b97fe63472dc4