### PR TITLE
Wire up daily planner overlay and admin console

### DIFF
--- a/DayPlanner.jsx
+++ b/DayPlanner.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import Calendar from './src/Calendar.jsx';
+import './day-planner.css';
+
+export default function DayPlanner({ onComplete }) {
+  const [goals, setGoals] = useState({
+    transcendent: '',
+    jackpot: '',
+    rainbow: '',
+    mirror: '',
+  });
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('todoBigGoals') || '{}');
+      setGoals({
+        transcendent: stored.transcendent || '',
+        jackpot: stored.jackpot || '',
+        rainbow: stored.rainbow || '',
+        mirror: stored.mirror || '',
+      });
+    } catch {}
+  }, []);
+
+  return (
+    <div className="day-planner-overlay">
+      <div className="day-planner">
+        <div className="planner-calendar">
+          <Calendar onBack={onComplete} backLabel="Start Day" />
+        </div>
+        <div className="planner-goals">
+          <h2>Big Goals</h2>
+          <ul>
+            <li><strong>Transcendent:</strong> {goals.transcendent}</li>
+            <li><strong>Jackpot:</strong> {goals.jackpot}</li>
+            <li><strong>Rainbow:</strong> {goals.rainbow}</li>
+            <li><strong>Mirror:</strong> {goals.mirror}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/FifthMain.jsx
+++ b/FifthMain.jsx
@@ -3,6 +3,7 @@ import NoteModal from './NoteModal.jsx';
 import NotesListModal from './NotesListModal.jsx';
 import './main-page.css';
 import QuadrantMenu from './QuadrantMenu.jsx';
+import DayPlanner from './DayPlanner.jsx';
 
 export default function FifthMain({ onSelectQuadrant }) {
   const MIN_WIDTH = 253;
@@ -13,6 +14,7 @@ export default function FifthMain({ onSelectQuadrant }) {
   const [showModal, setShowModal] = useState(false);
   const [showList, setShowList] = useState(false);
   const [menuIndex, setMenuIndex] = useState(0);
+  const [showPlanner, setShowPlanner] = useState(false);
 
   const startLeftDrag = (e) => {
     e.preventDefault();
@@ -54,6 +56,30 @@ export default function FifthMain({ onSelectQuadrant }) {
 
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+  };
+
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    const last = localStorage.getItem('plannerDate');
+    if (last !== today) {
+      setShowPlanner(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleMessage = (e) => {
+      if (e.data && e.data.type === 'OPEN_DAY_PLANNER') {
+        setShowPlanner(true);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  const handlePlannerComplete = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('plannerDate', today);
+    setShowPlanner(false);
   };
 
   useEffect(() => {
@@ -125,6 +151,7 @@ export default function FifthMain({ onSelectQuadrant }) {
       </div>
       {showModal && <NoteModal onClose={() => setShowModal(false)} />}
       {showList && <NotesListModal onClose={() => setShowList(false)} />}
+      {showPlanner && <DayPlanner onComplete={handlePlannerComplete} />}
     </div>
   );
 }

--- a/SettingsModal.jsx
+++ b/SettingsModal.jsx
@@ -29,6 +29,13 @@ export default function SettingsModal({
     }
   };
 
+  const openAdminConsole = () => {
+    const w = window.open('', '_blank');
+    if (!w) return;
+    w.document.write(`<!DOCTYPE html><html><head><title>Admin Console</title></head><body style="background:white;color:black;font-family:sans-serif;padding:20px;"><h1>Admin Console</h1><button id="reopen">Reopen Day Planner</button><script>document.getElementById('reopen').onclick=function(){try{window.opener?.localStorage.removeItem('plannerDate');window.opener?.postMessage({type:'OPEN_DAY_PLANNER'},'*');}catch(e){console.error(e);}};</script></body></html>`);
+    w.document.close();
+  };
+
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
@@ -51,6 +58,9 @@ export default function SettingsModal({
         </label>
         <button className="save-button" onClick={onToggleTheme}>
           {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
+        <button className="save-button" onClick={openAdminConsole}>
+          Admin Console
         </button>
         <button
           className="akashic-button"

--- a/day-planner.css
+++ b/day-planner.css
@@ -1,0 +1,48 @@
+.day-planner-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.day-planner {
+  background: #222;
+  color: #fff;
+  width: 90%;
+  height: 90%;
+  display: flex;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.planner-calendar {
+  flex: 3;
+  margin-right: 1rem;
+  display: flex;
+}
+
+.planner-goals {
+  flex: 1;
+  border-left: 1px solid #444;
+  padding-left: 1rem;
+  overflow-y: auto;
+}
+
+.planner-goals h2 {
+  margin-top: 0;
+}
+
+.planner-goals ul {
+  list-style: none;
+  padding: 0;
+}
+
+.planner-goals li {
+  margin-bottom: 0.5rem;
+}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -28,7 +28,7 @@ function CalendarEvent({ event, onDelete }) {
   );
 }
 
-export default function Calendar({ onBack }) {
+export default function Calendar({ onBack, backLabel = 'Back' }) {
   const roundSlot = (date) => {
     const d = new Date(date);
     d.setMinutes(Math.floor(d.getMinutes() / 30) * 30, 0, 0);
@@ -277,7 +277,7 @@ export default function Calendar({ onBack }) {
   return (
     <div className="calendar-app">
       <button className="back-button" onClick={onBack}>
-        Back
+        {backLabel}
       </button>
       <div className="calendar-container" ref={containerRef}>
         <DnDCalendar

--- a/src/DayPlanner.jsx
+++ b/src/DayPlanner.jsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import Calendar from './Calendar.jsx';
+import './day-planner.css';
+
+export default function DayPlanner({ onComplete }) {
+  const [goals, setGoals] = useState({
+    transcendent: '',
+    jackpot: '',
+    rainbow: '',
+    mirror: '',
+  });
+
+  useEffect(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem('todoBigGoals') || '{}');
+      setGoals({
+        transcendent: stored.transcendent || '',
+        jackpot: stored.jackpot || '',
+        rainbow: stored.rainbow || '',
+        mirror: stored.mirror || '',
+      });
+    } catch {}
+  }, []);
+
+  return (
+    <div className="day-planner-overlay">
+      <div className="day-planner">
+        <div className="planner-calendar">
+          <Calendar onBack={onComplete} backLabel="Start Day" />
+        </div>
+        <div className="planner-goals">
+          <h2>Big Goals</h2>
+          <ul>
+            <li><strong>Transcendent:</strong> {goals.transcendent}</li>
+            <li><strong>Jackpot:</strong> {goals.jackpot}</li>
+            <li><strong>Rainbow:</strong> {goals.rainbow}</li>
+            <li><strong>Mirror:</strong> {goals.mirror}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -3,6 +3,7 @@ import NoteModal from './NoteModal.jsx';
 import NotesListModal from './NotesListModal.jsx';
 import './main-page.css';
 import QuadrantMenu from './QuadrantMenu.jsx';
+import DayPlanner from './DayPlanner.jsx';
 
 export default function FifthMain({ onSelectQuadrant }) {
   const MIN_WIDTH = 253;
@@ -13,6 +14,7 @@ export default function FifthMain({ onSelectQuadrant }) {
   const [showModal, setShowModal] = useState(false);
   const [showList, setShowList] = useState(false);
   const [menuIndex, setMenuIndex] = useState(0);
+  const [showPlanner, setShowPlanner] = useState(false);
 
   const startLeftDrag = (e) => {
     e.preventDefault();
@@ -65,12 +67,39 @@ export default function FifthMain({ onSelectQuadrant }) {
         } else if (showList) {
           e.preventDefault();
           setShowList(false);
+        } else if (showPlanner) {
+          e.preventDefault();
+          setShowPlanner(false);
         }
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [showModal, showList]);
+  }, [showModal, showList, showPlanner]);
+
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    const last = localStorage.getItem('plannerDate');
+    if (last !== today) {
+      setShowPlanner(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleMessage = (e) => {
+      if (e.data && e.data.type === 'OPEN_DAY_PLANNER') {
+        setShowPlanner(true);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  const handlePlannerComplete = () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('plannerDate', today);
+    setShowPlanner(false);
+  };
 
   useEffect(() => {
     const handleNav = (e) => {
@@ -139,6 +168,7 @@ export default function FifthMain({ onSelectQuadrant }) {
       </div>
       {showModal && <NoteModal onClose={() => setShowModal(false)} />}
       {showList && <NotesListModal onClose={() => setShowList(false)} />}
+      {showPlanner && <DayPlanner onComplete={handlePlannerComplete} />}
     </div>
   );
 }

--- a/src/SettingsModal.jsx
+++ b/src/SettingsModal.jsx
@@ -36,6 +36,15 @@ export default function SettingsModal({
     }
   };
 
+  const openAdminConsole = () => {
+    const w = window.open('', '_blank');
+    if (!w) return;
+    w.document.write(
+      `<!DOCTYPE html><html><head><title>Admin Console</title></head><body style="background:white;color:black;font-family:sans-serif;padding:20px;"><h1>Admin Console</h1><button id="reopen">Reopen Day Planner</button><script>document.getElementById('reopen').onclick=function(){try{window.opener?.localStorage.removeItem('plannerDate');window.opener?.postMessage({type:'OPEN_DAY_PLANNER'},'*');}catch(e){console.error(e);}};</script></body></html>`
+    );
+    w.document.close();
+  };
+
   const [bgType, setBgType] = useState(null); // 'main', 'character', or 'menu'
   const [showBgChoice, setShowBgChoice] = useState(false);
 
@@ -66,6 +75,9 @@ export default function SettingsModal({
         </label>
         <button className="save-button" onClick={onToggleTheme}>
           {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
+        <button className="save-button" onClick={openAdminConsole}>
+          Admin Console
         </button>
         <button
           className="save-button"

--- a/src/day-planner.css
+++ b/src/day-planner.css
@@ -1,0 +1,48 @@
+.day-planner-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.day-planner {
+  background: #222;
+  color: #fff;
+  width: 90%;
+  height: 90%;
+  display: flex;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.planner-calendar {
+  flex: 3;
+  margin-right: 1rem;
+  display: flex;
+}
+
+.planner-goals {
+  flex: 1;
+  border-left: 1px solid #444;
+  padding-left: 1rem;
+  overflow-y: auto;
+}
+
+.planner-goals h2 {
+  margin-top: 0;
+}
+
+.planner-goals ul {
+  list-style: none;
+  padding: 0;
+}
+
+.planner-goals li {
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Add DayPlanner component and styles under `src`
- Show planner on first launch of each day and reopen via postMessage
- Expose Admin Console button in settings to reset daily planner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af0cf75af88322925d55fafcdb1f48