### PR TITLE
Add loading screen to mask default wallpaper

### DIFF
--- a/src/LoadingScreen.jsx
+++ b/src/LoadingScreen.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './loading-screen.css';
+
+export default function LoadingScreen() {
+  return (
+    <div className="loading-overlay">
+      <div className="loading-bar">
+        <div className="loading-bar-progress" />
+      </div>
+    </div>
+  );
+}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -9,6 +9,7 @@ import { supabaseClient } from './supabaseClient';
 import ActivityTimer from './ActivityTimer.jsx';
 import ExitVideo from './ExitVideo.jsx';
 import ImageGallery from './ImageGallery.jsx';
+import LoadingScreen from './LoadingScreen.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
@@ -21,6 +22,7 @@ export default function PageRouter() {
   const [menuBg, setMenuBg] = useState(
     () => localStorage.getItem('menuBg') || defaultMenuBg
   );
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -57,6 +59,7 @@ export default function PageRouter() {
   }, [user]);
 
   const navigate = useCallback((newPage) => {
+    setIsLoading(true);
     if (newPage === '5th') {
       history.current = ['5th'];
     } else {
@@ -112,6 +115,11 @@ export default function PageRouter() {
     }
   }, [page]);
 
+  useEffect(() => {
+    const timeout = setTimeout(() => setIsLoading(false), 300);
+    return () => clearTimeout(timeout);
+  }, [page, menuBg]);
+
   if (!user) {
     return <Auth />;
   }
@@ -153,6 +161,7 @@ export default function PageRouter() {
 
   return (
     <>
+      {isLoading && <LoadingScreen />}
       <ActivityTimer />
       {content}
     </>

--- a/src/loading-screen.css
+++ b/src/loading-screen.css
@@ -1,0 +1,32 @@
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.loading-bar {
+  width: 50%;
+  max-width: 300px;
+  height: 4px;
+  background: #333;
+}
+
+.loading-bar-progress {
+  width: 0;
+  height: 100%;
+  background: #fff;
+  animation: loading-fill 0.3s linear forwards;
+}
+
+@keyframes loading-fill {
+  to {
+    width: 100%;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,7 @@
 :root {
-  --main-bg-url: url('./assets/backgrounds/background_EI.jpg');
-  --char-bg-url: url('./assets/backgrounds/Viego_0.jpg');
-  --menu-bg-url: url('./assets/backgrounds/background_EI.jpg');
+  --main-bg-url: none;
+  --char-bg-url: none;
+  --menu-bg-url: none;
 }
 
 body {
@@ -9,6 +9,7 @@ body {
   font-family: sans-serif;
   background: var(--main-bg-url) no-repeat center center fixed;
   background-size: cover;
+  background-color: black;
   color: #e6e7eb;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,7 @@
 body {
   margin: 0;
   font-family: sans-serif;
-  /* Replace solid background with custom image */
-  background: url('./assets/backgrounds/background_EI.jpg') no-repeat center center fixed;
-  background-size: cover;
+  background: black;
   color: #e6e7eb;
 }
 


### PR DESCRIPTION
## Summary
- add a simple loading overlay component with progress bar
- cover initial and navigation flashes of the default wallpaper
- default background is now black until user preferences load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af56f335288322a1d8d79ab3a28004