### PR TITLE
Reposition navigation and layer tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,9 +44,9 @@ const tabs = [
 ];
 
 const layers = [
-  { label: 'Form', color: 'orange' },
-  { label: 'Semi-Formless', color: 'purple' },
-  { label: 'Formless', color: 'white' },
+  { label: 'Form', color: 'red' },
+  { label: 'Semi-Formless', color: 'blue' },
+  { label: 'Formless', color: 'green' },
 ];
 
 const defaultMainBg = './assets/backgrounds/background_EI.jpg';
@@ -427,20 +427,21 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     <QuestProvider>
       <ActivityLogger enabled={autoLog} />
       <div className="app-container">
-      <aside className="sidebar">
-        {tabs.map((tab, idx) => (
-          <div
-            key={tab.label}
-            className={`tab ${activeTab === tab.label ? 'active' : ''} ${sidebarIndex === idx ? 'selected' : ''}`}
-            onClick={() => {
-              setActiveTab(tab.label);
-              setSidebarIndex(idx);
-            }}
-          >
-            <span className="icon">{tab.icon}</span>
+        <aside className="sidebar">
+          <div className="layer-buttons">
+            {layers.map((layer) => (
+              <div
+                key={layer.label}
+                title={layer.label}
+                className={`layer-button ${activeLayer === layer.label ? 'active' : ''}`}
+                style={{ backgroundColor: layer.color }}
+                onClick={() => setActiveLayer(layer.label)}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => handleDropOnLayer(e, layer.label)}
+              />
+            ))}
           </div>
-        ))}
-        <div className="bottom-buttons">
+          <div className="bottom-buttons">
           <div
             className={`settings-button ${sidebarIndex === tabs.length ? 'selected' : ''}`}
             onClick={() => {
@@ -472,29 +473,9 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
             🏠
           </div>
         </div>
-      </aside>
-      <div className="content">
-        <div className="layer-tabs">
-          {layers.map((layer) => (
-            <div
-              key={layer.label}
-              className={`layer-tab ${activeLayer === layer.label ? 'active' : ''}`}
-              style={{
-                borderBottom:
-                  activeLayer === layer.label
-                    ? `3px solid ${layer.color}`
-                    : '3px solid transparent',
-                color: activeLayer === layer.label ? layer.color : '#e6e7eb',
-              }}
-              onClick={() => setActiveLayer(layer.label)}
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={(e) => handleDropOnLayer(e, layer.label)}
-            >
-              {layer.label}
-            </div>
-          ))}
-        </div>
-        <h1>{activeTab}</h1>
+        </aside>
+        <div className="content">
+          <h1>{activeTab}</h1>
         {activeTab === 'Character' && (
           activeLayer === 'Semi-Formless' ? (
             <SemiFormlessCharacter />
@@ -828,6 +809,20 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
         )}
         {activeTab === 'World' && <World />}
         {activeTab === 'Friends' && <FriendsList />}
+      </div>
+      <div className="bottom-nav">
+        {tabs.map((tab, idx) => (
+          <div
+            key={tab.label}
+            className={`tab ${activeTab === tab.label ? 'active' : ''} ${sidebarIndex === idx ? 'selected' : ''}`}
+            onClick={() => {
+              setActiveTab(tab.label);
+              setSidebarIndex(idx);
+            }}
+          >
+            <span className="icon">{tab.icon}</span>
+          </div>
+        ))}
       </div>
       {showProfile && (
         <ProfileModal

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,24 @@ body {
   padding: 20px 0;
 }
 
+.layer-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.layer-button {
+  width: 50px;
+  height: 50px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.layer-button.active {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.1);
+}
+
 .tab {
   display: flex;
   align-items: center;
@@ -57,6 +75,14 @@ body {
   background-color: #222;
   color: #fff;
   background-color: #e0e0e0
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  display: flex;
+  gap: 15px;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- Move Form/Semi-Formless/Formless tabs into a colored vertical stack on the sidebar
- Shift main page icons to a new bottom-left navigation bar
- Style new layer buttons and bottom nav layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b04ffcc2e483229a3b5568cbffc8b2