### PR TITLE
fix: restore navigation layout

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -49,6 +49,24 @@ body.character-page {
   padding: 20px 0;
 }
 
+.layer-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.layer-button {
+  width: 50px;
+  height: 50px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.layer-button.active {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.1);
+}
+
 .tab {
   display: flex;
   align-items: center;
@@ -74,6 +92,14 @@ body.character-page {
   background-color: #222;
   color: #fff;
   background-color: #e0e0e0
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  display: flex;
+  gap: 15px;
 }
 
 .layer-tabs {


### PR DESCRIPTION
## Summary
- style layer buttons so form navigation sits vertically on the left
- position bottom navigation tabs at the bottom-left of the screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05ff7a3388322b69d0b7ed3458d51