### PR TITLE
style: reposition navigation controls

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -49,6 +49,28 @@ body.character-page {
   padding: 20px 0;
 }
 
+.layer-buttons {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: row;
+  gap: 15px;
+}
+
+.layer-button {
+  width: 50px;
+  height: 50px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.layer-button.active {
+  animation: pulse 1s infinite alternate;
+  transform: scale(1.1);
+}
+
 .tab {
   display: flex;
   align-items: center;
@@ -74,6 +96,14 @@ body.character-page {
   background-color: #222;
   color: #fff;
   background-color: #e0e0e0
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 95px;
+  display: flex;
+  gap: 15px;
 }
 
 .layer-tabs {

--- a/styles.css
+++ b/styles.css
@@ -32,9 +32,14 @@ body {
   padding: 20px 0;
 }
 
+
 .layer-buttons {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 15px;
 }
 
@@ -80,7 +85,7 @@ body {
 .bottom-nav {
   position: fixed;
   bottom: 20px;
-  left: 20px;
+  left: 95px;
   display: flex;
   gap: 15px;
 }


### PR DESCRIPTION
## Summary
- move layer buttons to the top center of the screen
- anchor bottom navigation to the bottom-left with a 95px margin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05ff7a3388322b69d0b7ed3458d51