### PR TITLE
Avoid React warning for empty asset sources in tests

### DIFF
--- a/src/__mocks__/fileMock.js
+++ b/src/__mocks__/fileMock.js
@@ -1,1 +1,5 @@
-module.exports = '';
+// Provide a non-empty placeholder string for static asset imports in tests.
+// An empty string triggers React warnings when used as the `src` attribute
+// on elements like `<img>` or `<source>`. Returning a stub string avoids
+// those warnings without affecting test behavior.
+module.exports = 'test-file-stub';


### PR DESCRIPTION
## Summary
- stop returning an empty string for mocked static assets
- document why asset stubs use a non-empty placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a79fb2c48322b3cc8751f9ef58a6