### PR TITLE
Ensure Day Planner opens when expected

### DIFF
--- a/FifthMain.jsx
+++ b/FifthMain.jsx
@@ -58,8 +58,10 @@ export default function FifthMain({ onSelectQuadrant }) {
     document.addEventListener('mouseup', onMouseUp);
   };
 
+  const todayKey = () => new Date().toLocaleDateString('en-CA');
+
   useEffect(() => {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayKey();
     const last = localStorage.getItem('plannerDate');
     if (last !== today) {
       setShowPlanner(true);
@@ -77,7 +79,7 @@ export default function FifthMain({ onSelectQuadrant }) {
   }, []);
 
   const handlePlannerComplete = () => {
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayKey();
     localStorage.setItem('plannerDate', today);
     setShowPlanner(false);
   };

--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -3,6 +3,7 @@ import NoteModal from './NoteModal.jsx';
 import NotesListModal from './NotesListModal.jsx';
 import './main-page.css';
 import QuadrantMenu from './QuadrantMenu.jsx';
+import DayPlanner from './DayPlanner.jsx';
 
 export default function FifthMain({ onSelectQuadrant }) {
   const MIN_WIDTH = 253;
@@ -13,6 +14,7 @@ export default function FifthMain({ onSelectQuadrant }) {
   const [showModal, setShowModal] = useState(false);
   const [showList, setShowList] = useState(false);
   const [menuIndex, setMenuIndex] = useState(0);
+  const [showPlanner, setShowPlanner] = useState(false);
 
   const startLeftDrag = (e) => {
     e.preventDefault();
@@ -54,6 +56,32 @@ export default function FifthMain({ onSelectQuadrant }) {
 
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+  };
+
+  const todayKey = () => new Date().toLocaleDateString('en-CA');
+
+  useEffect(() => {
+    const today = todayKey();
+    const last = localStorage.getItem('plannerDate');
+    if (last !== today) {
+      setShowPlanner(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleMessage = (e) => {
+      if (e.data && e.data.type === 'OPEN_DAY_PLANNER') {
+        setShowPlanner(true);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  const handlePlannerComplete = () => {
+    const today = todayKey();
+    localStorage.setItem('plannerDate', today);
+    setShowPlanner(false);
   };
 
   useEffect(() => {
@@ -143,6 +171,7 @@ export default function FifthMain({ onSelectQuadrant }) {
       </div>
       {showModal && <NoteModal onClose={() => setShowModal(false)} />}
       {showList && <NotesListModal onClose={() => setShowList(false)} />}
+      {showPlanner && <DayPlanner onComplete={handlePlannerComplete} />}
     </div>
   );
 }

--- a/src/FifthMain.test.js
+++ b/src/FifthMain.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('./DayPlanner.jsx', () => () => <div data-testid="planner">Planner</div>);
+jest.mock('./QuadrantMenu.jsx', () => () => <div />);
+jest.mock('./NoteModal.jsx', () => () => <div />);
+jest.mock('./NotesListModal.jsx', () => () => <div />);
+
+import FifthMain from './FifthMain.jsx';
+
+describe('FifthMain DayPlanner integration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('shows planner when stored date is old', () => {
+    localStorage.setItem('plannerDate', '2000-01-01');
+    render(<FifthMain onSelectQuadrant={() => {}} />);
+    expect(screen.getByTestId('planner')).toBeInTheDocument();
+  });
+
+  test('opens planner in response to message', () => {
+    const today = new Date().toLocaleDateString('en-CA');
+    localStorage.setItem('plannerDate', today);
+    render(<FifthMain onSelectQuadrant={() => {}} />);
+    expect(screen.queryByTestId('planner')).not.toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', { data: { type: 'OPEN_DAY_PLANNER' } })
+      );
+    });
+    expect(screen.getByTestId('planner')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- display Day Planner when plannerDate is stale or admin sends OPEN_DAY_PLANNER message
- store planner completion using local dates to avoid timezone issues
- add tests for FifthMain Day Planner behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ebd833908322a4cc1b582c963377