### PR TITLE
feat(day-planner): open calendar in day view

### DIFF
--- a/DayPlanner.jsx
+++ b/DayPlanner.jsx
@@ -26,7 +26,7 @@ export default function DayPlanner({ onComplete }) {
     <div className="day-planner-overlay">
       <div className="day-planner">
         <div className="planner-calendar">
-          <Calendar onBack={onComplete} backLabel="Start Day" />
+          <Calendar onBack={onComplete} backLabel="Start Day" defaultView="day" />
         </div>
         <div className="planner-goals">
           <h2>Big Goals</h2>

--- a/DayPlanner.test.js
+++ b/DayPlanner.test.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-jest.mock('./src/Calendar.jsx', () => ({ onBack, backLabel }) => (
-  <div data-testid="calendar-mock">
-    <button onClick={onBack}>{backLabel}</button>
-  </div>
-));
-
+jest.mock('./src/Calendar.jsx', () => {
+  return jest.fn(({ onBack, backLabel }) => (
+    <div data-testid="calendar-mock">
+      <button onClick={onBack}>{backLabel}</button>
+    </div>
+  ));
+});
+import mockCalendar from './src/Calendar.jsx';
 import DayPlanner from './src/DayPlanner.jsx';
 
 describe('DayPlanner', () => {
@@ -28,7 +30,8 @@ describe('DayPlanner', () => {
   });
 
   test('shows stored goals and calendar back button label', async () => {
-    render(<DayPlanner onComplete={() => {}} backLabel="Return" />);
+    const onComplete = jest.fn();
+    render(<DayPlanner onComplete={onComplete} backLabel="Return" />);
 
     expect(await screen.findByText('Ascend')).toBeInTheDocument();
     expect(screen.getByText('Win big')).toBeInTheDocument();
@@ -37,5 +40,14 @@ describe('DayPlanner', () => {
     expect(
       screen.getByRole('button', { name: 'Return' })
     ).toBeInTheDocument();
+
+    expect(mockCalendar).toHaveBeenCalled();
+    expect(mockCalendar.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        onBack: onComplete,
+        backLabel: 'Return',
+        defaultView: 'day',
+      })
+    );
   });
 });

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -28,7 +28,7 @@ function CalendarEvent({ event, onDelete }) {
   );
 }
 
-export default function Calendar({ onBack, backLabel = 'Back' }) {
+export default function Calendar({ onBack, backLabel = 'Back', defaultView = 'month' }) {
   const roundSlot = (date) => {
     const d = new Date(date);
     d.setMinutes(Math.floor(d.getMinutes() / 30) * 30, 0, 0);
@@ -287,7 +287,7 @@ export default function Calendar({ onBack, backLabel = 'Back' }) {
           events={[...events, ...blocks]}
           startAccessor="start"
           endAccessor="end"
-          defaultView="month"
+          defaultView={defaultView}
           views={["month", "week", "day"]}
           style={{ height: "100%" }}
           onSelectSlot={handleSelectSlot}

--- a/src/DayPlanner.jsx
+++ b/src/DayPlanner.jsx
@@ -26,7 +26,7 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
     <div className="day-planner-overlay">
       <div className="day-planner">
         <div className="planner-calendar">
-          <Calendar onBack={onComplete} backLabel={backLabel} />
+          <Calendar onBack={onComplete} backLabel={backLabel} defaultView="day" />
         </div>
         <div className="planner-goals">
           <h2>Big Goals</h2>

--- a/src/DayPlanner.test.js
+++ b/src/DayPlanner.test.js
@@ -2,12 +2,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-jest.mock('./Calendar.jsx', () => ({ onBack, backLabel }) => (
-  <div data-testid="calendar-mock">
-    <button onClick={onBack}>{backLabel}</button>
-  </div>
-));
-
+jest.mock('./Calendar.jsx', () => {
+  return jest.fn(({ onBack, backLabel }) => (
+    <div data-testid="calendar-mock">
+      <button onClick={onBack}>{backLabel}</button>
+    </div>
+  ));
+});
+import mockCalendar from './Calendar.jsx';
 import DayPlanner from './DayPlanner.jsx';
 
 describe('DayPlanner', () => {
@@ -28,7 +30,8 @@ describe('DayPlanner', () => {
   });
 
   test('shows stored goals and calendar back button label', async () => {
-    render(<DayPlanner onComplete={() => {}} backLabel="Return" />);
+    const onComplete = jest.fn();
+    render(<DayPlanner onComplete={onComplete} backLabel="Return" />);
 
     expect(await screen.findByText('Ascend')).toBeInTheDocument();
     expect(screen.getByText('Win big')).toBeInTheDocument();
@@ -37,5 +40,14 @@ describe('DayPlanner', () => {
     expect(
       screen.getByRole('button', { name: 'Return' })
     ).toBeInTheDocument();
+
+    expect(mockCalendar).toHaveBeenCalled();
+    expect(mockCalendar.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        onBack: onComplete,
+        backLabel: 'Return',
+        defaultView: 'day',
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- allow Calendar component to accept configurable default view
- open Day Planner calendar directly in day view
- test that Day Planner passes the correct calendar view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b32e6a7cc083229ddf498a8cadbd11