### PR TITLE
feat: make activities customizable with tags and daily goals

### DIFF
--- a/activity-app.css
+++ b/activity-app.css
@@ -90,6 +90,7 @@
   align-items: center;
   gap: 6px;
   text-align: center;
+  position: relative;
 }
 
 .activity-box:hover {
@@ -106,4 +107,45 @@
 .activity-desc {
   font-size: 0.85em;
   color: #bbb;
+}
+
+.add-button {
+  margin-bottom: 10px;
+}
+
+.delete-button {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+}
+
+.delete-button:hover {
+  color: #fff;
+}
+
+.activity-tags {
+  font-size: 0.75em;
+  color: #888;
+  display: flex;
+  gap: 4px;
+}
+
+.daily-progress {
+  display: flex;
+  gap: 4px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #333;
+}
+
+.dot.done {
+  background: #4caf50;
 }

--- a/src/ActivityApp.jsx
+++ b/src/ActivityApp.jsx
@@ -1,13 +1,54 @@
 import React, { useState, useEffect } from 'react';
 import './placeholder-app.css';
 import './activity-app.css';
+import AddActivityModal from './AddActivityModal.jsx';
 
-const ACTIVITIES = [
-  { title: 'Meditation - Vipassana', icon: '🧘', base: 30, description: 'Focus on breath' },
-  { title: 'Meditation - Ramana', icon: '🧘', base: 30, description: 'Self inquiry' },
-  { title: 'Yoga', icon: '🧘‍♂️', base: 45, description: 'Stretch and breathe' },
-  { title: 'Workout', icon: '🏋️', base: 45, description: 'Strength training' },
-  { title: 'Reading', icon: '📚', base: 20, description: 'Read a book' },
+const DEFAULT_ACTIVITIES = [
+  {
+    title: 'Meditation - Vipassana',
+    icon: '🧘',
+    base: 30,
+    description: 'Focus on breath',
+    dimension: 'Formless',
+    aspect: 'II',
+    timesPerDay: 1,
+  },
+  {
+    title: 'Meditation - Ramana',
+    icon: '🧘',
+    base: 30,
+    description: 'Self inquiry',
+    dimension: 'Formless',
+    aspect: 'II',
+    timesPerDay: 1,
+  },
+  {
+    title: 'Yoga',
+    icon: '🧘‍♂️',
+    base: 45,
+    description: 'Stretch and breathe',
+    dimension: 'Form',
+    aspect: 'IE',
+    timesPerDay: 1,
+  },
+  {
+    title: 'Workout',
+    icon: '🏋️',
+    base: 45,
+    description: 'Strength training',
+    dimension: 'Form',
+    aspect: 'EE',
+    timesPerDay: 1,
+  },
+  {
+    title: 'Reading',
+    icon: '📚',
+    base: 20,
+    description: 'Read a book',
+    dimension: 'Form',
+    aspect: 'II',
+    timesPerDay: 1,
+  },
 ];
 
 const computeReward = (mins) => {
@@ -58,6 +99,20 @@ function ActivityModal({ activity, onStart, onClose }) {
 }
 
 export default function ActivityApp({ onBack }) {
+  const [activities, setActivities] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('activities')) || DEFAULT_ACTIVITIES;
+    } catch {
+      return DEFAULT_ACTIVITIES;
+    }
+  });
+  const [counts, setCounts] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('activityCounts')) || {};
+    } catch {
+      return {};
+    }
+  });
   const [xp, setXp] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem('activityXP')) || {};
@@ -77,6 +132,18 @@ export default function ActivityApp({ onBack }) {
     return Math.max(0, Math.floor((new Date(active.end) - Date.now()) / 1000));
   });
   const [modalAct, setModalAct] = useState(null);
+  const [showAdd, setShowAdd] = useState(false);
+
+  const saveActivities = (next) => {
+    setActivities(next);
+    localStorage.setItem('activities', JSON.stringify(next));
+    window.dispatchEvent(new CustomEvent('activities-updated', { detail: next }));
+  };
+
+  const saveCounts = (next) => {
+    setCounts(next);
+    localStorage.setItem('activityCounts', JSON.stringify(next));
+  };
 
   const saveXp = (next) => {
     setXp(next);
@@ -137,9 +204,25 @@ export default function ActivityApp({ onBack }) {
 
     const nextXp = { ...xp, [activity.title]: (xp[activity.title] || 0) + mins };
     saveXp(nextXp);
+    const today = new Date().toISOString().slice(0, 10);
+    const nextCounts = { ...counts };
+    if (!nextCounts[activity.title]) nextCounts[activity.title] = {};
+    nextCounts[activity.title][today] = (nextCounts[activity.title][today] || 0) + 1;
+    saveCounts(nextCounts);
     setModalAct(null);
     setActive({ title: activity.title, end: end.toISOString() });
     setTimeLeft(mins * 60);
+  };
+
+  const addActivity = (activity) => {
+    const next = [...activities, activity];
+    saveActivities(next);
+    setShowAdd(false);
+  };
+
+  const removeActivity = (title) => {
+    const next = activities.filter((a) => a.title !== title);
+    saveActivities(next);
   };
 
   return (
@@ -153,21 +236,44 @@ export default function ActivityApp({ onBack }) {
         </div>
       )}
       <h2>Activities</h2>
+      <button className="add-button" onClick={() => setShowAdd(true)}>
+        Add Activity
+      </button>
       <ul className="activity-grid">
-        {ACTIVITIES.map((act) => {
+        {activities.map((act) => {
           const spent = xp[act.title] || 0;
           const pct = Math.min(spent / 180, 1);
+          const today = new Date().toISOString().slice(0, 10);
+          const done = counts[act.title]?.[today] || 0;
           return (
             <li
               key={act.title}
               className="activity-box"
               onClick={() => setModalAct(act)}
             >
+              <button
+                className="delete-button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeActivity(act.title);
+                }}
+              >
+                ×
+              </button>
               <div className="box-header">
                 <span className="activity-icon">{act.icon}</span>
                 <span>{act.title}</span>
               </div>
               <div className="activity-desc">{act.description}</div>
+              <div className="activity-tags">
+                <span>{act.dimension}</span>
+                <span>{act.aspect}</span>
+              </div>
+              <div className="daily-progress">
+                {[...Array(act.timesPerDay || 0)].map((_, i) => (
+                  <span key={i} className={i < done ? 'dot done' : 'dot'} />
+                ))}
+              </div>
               <div className="xp-bar">
                 <div
                   className="xp-fill"
@@ -183,6 +289,12 @@ export default function ActivityApp({ onBack }) {
           activity={modalAct}
           onStart={(mins) => startActivity(modalAct, mins)}
           onClose={() => setModalAct(null)}
+        />
+      )}
+      {showAdd && (
+        <AddActivityModal
+          onSave={addActivity}
+          onClose={() => setShowAdd(false)}
         />
       )}
     </div>

--- a/src/AddActivityModal.jsx
+++ b/src/AddActivityModal.jsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+
+const DIMENSIONS = ['Form', 'SemiFormless', 'Formless'];
+const ASPECTS = ['II', 'IE', 'EI', 'EE'];
+
+export default function AddActivityModal({ onSave, onClose }) {
+  const [title, setTitle] = useState('');
+  const [icon, setIcon] = useState('🏷️');
+  const [description, setDescription] = useState('');
+  const [base, setBase] = useState(30);
+  const [dimension, setDimension] = useState(DIMENSIONS[0]);
+  const [aspect, setAspect] = useState(ASPECTS[0]);
+  const [times, setTimes] = useState(1);
+
+  const handleSave = () => {
+    onSave({
+      title,
+      icon,
+      base,
+      description,
+      dimension,
+      aspect,
+      timesPerDay: times,
+    });
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h3>Add Activity</h3>
+        <label className="note-label">
+          Title
+          <input className="note-title" value={title} onChange={(e) => setTitle(e.target.value)} />
+        </label>
+        <label className="note-label">
+          Icon
+          <input className="note-title" value={icon} onChange={(e) => setIcon(e.target.value)} />
+        </label>
+        <label className="note-label">
+          Description
+          <input className="note-title" value={description} onChange={(e) => setDescription(e.target.value)} />
+        </label>
+        <label className="note-label">
+          Base Minutes
+          <input
+            type="number"
+            className="note-title"
+            value={base}
+            min="1"
+            onChange={(e) => setBase(Number(e.target.value))}
+          />
+        </label>
+        <label className="note-label">
+          Dimension
+          <select className="note-title" value={dimension} onChange={(e) => setDimension(e.target.value)}>
+            {DIMENSIONS.map((d) => (
+              <option key={d}>{d}</option>
+            ))}
+          </select>
+        </label>
+        <label className="note-label">
+          Aspect
+          <select className="note-title" value={aspect} onChange={(e) => setAspect(e.target.value)}>
+            {ASPECTS.map((a) => (
+              <option key={a}>{a}</option>
+            ))}
+          </select>
+        </label>
+        <label className="note-label">
+          Times per Day
+          <input
+            type="number"
+            className="note-title"
+            min="1"
+            value={times}
+            onChange={(e) => setTimes(Number(e.target.value))}
+          />
+        </label>
+        <div className="actions">
+          <button className="save-button" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="save-button" onClick={handleSave}>
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/activity-app.css
+++ b/src/activity-app.css
@@ -90,6 +90,7 @@
   align-items: center;
   gap: 6px;
   text-align: center;
+  position: relative;
 }
 
 .activity-box:hover {
@@ -106,4 +107,45 @@
 .activity-desc {
   font-size: 0.85em;
   color: #bbb;
+}
+
+.add-button {
+  margin-bottom: 10px;
+}
+
+.delete-button {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+}
+
+.delete-button:hover {
+  color: #fff;
+}
+
+.activity-tags {
+  font-size: 0.75em;
+  color: #888;
+  display: flex;
+  gap: 4px;
+}
+
+.daily-progress {
+  display: flex;
+  gap: 4px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #333;
+}
+
+.dot.done {
+  background: #4caf50;
 }


### PR DESCRIPTION
## Summary
- allow adding and removing activities with dimension/aspect tags and times-per-day goals
- store activities and completion counts in localStorage and show daily progress
- style activity grid with tags, progress dots, and delete controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b478c0dd648322862ea8aebb514ad6