### PR TITLE
feat: plan activities through daily planner

### DIFF
--- a/DayPlanner.test.js
+++ b/DayPlanner.test.js
@@ -3,9 +3,11 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('./src/Calendar.jsx', () => {
-  return jest.fn(({ onBack, backLabel }) => (
+  return jest.fn(({ onBack, backLabel, backDisabled }) => (
     <div data-testid="calendar-mock">
-      <button onClick={onBack}>{backLabel}</button>
+      <button onClick={onBack} disabled={backDisabled}>
+        {backLabel}
+      </button>
     </div>
   ));
 });
@@ -44,10 +46,35 @@ describe('DayPlanner', () => {
     expect(mockCalendar).toHaveBeenCalled();
     expect(mockCalendar.mock.calls[0][0]).toEqual(
       expect.objectContaining({
-        onBack: onComplete,
+        onBack: expect.any(Function),
         backLabel: 'Return',
         defaultView: 'day',
+        backDisabled: false,
       })
     );
+  });
+
+  test('shows planner activities and disables start until scheduled', () => {
+    localStorage.setItem(
+      'activities',
+      JSON.stringify([
+        {
+          title: 'Neck Training',
+          icon: '🦒',
+          base: 10,
+          description: '',
+          dimension: 'Form',
+          aspect: 'II',
+          timesPerDay: 2,
+          planner: true,
+        },
+      ])
+    );
+    const onComplete = jest.fn();
+    render(<DayPlanner onComplete={onComplete} backLabel="Start" />);
+    expect(screen.getByText('Activities')).toBeInTheDocument();
+    expect(screen.getByText('Neck Training')).toBeInTheDocument();
+    const startBtn = screen.getByRole('button', { name: 'Start' });
+    expect(startBtn).toBeDisabled();
   });
 });

--- a/activity-app.css
+++ b/activity-app.css
@@ -90,6 +90,7 @@
   align-items: center;
   gap: 6px;
   text-align: center;
+  position: relative;
 }
 
 .activity-box:hover {
@@ -106,4 +107,59 @@
 .activity-desc {
   font-size: 0.85em;
   color: #bbb;
+}
+
+.add-button {
+  margin-bottom: 10px;
+}
+
+.delete-button {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+}
+
+.delete-button:hover {
+  color: #fff;
+}
+
+.activity-tags {
+  font-size: 0.75em;
+  color: #888;
+  display: flex;
+  gap: 4px;
+}
+
+.daily-progress {
+  display: flex;
+  gap: 4px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #333;
+}
+
+.dot.done {
+  background: #4caf50;
+}
+
+.planner-button {
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+}
+
+.planner-button.active {
+  color: #4caf50;
 }

--- a/day-planner.css
+++ b/day-planner.css
@@ -46,3 +46,27 @@
 .planner-goals li {
   margin-bottom: 0.5rem;
 }
+
+.planner-activities {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.planner-activity {
+  background: #333;
+  padding: 0.5rem;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: grab;
+}
+
+.planner-count {
+  background: #555;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8em;
+}

--- a/src/ActivityApp.jsx
+++ b/src/ActivityApp.jsx
@@ -1,13 +1,59 @@
 import React, { useState, useEffect } from 'react';
 import './placeholder-app.css';
 import './activity-app.css';
+import AddActivityModal from './AddActivityModal.jsx';
 
-const ACTIVITIES = [
-  { title: 'Meditation - Vipassana', icon: '🧘', base: 30, description: 'Focus on breath' },
-  { title: 'Meditation - Ramana', icon: '🧘', base: 30, description: 'Self inquiry' },
-  { title: 'Yoga', icon: '🧘‍♂️', base: 45, description: 'Stretch and breathe' },
-  { title: 'Workout', icon: '🏋️', base: 45, description: 'Strength training' },
-  { title: 'Reading', icon: '📚', base: 20, description: 'Read a book' },
+const DEFAULT_ACTIVITIES = [
+  {
+    title: 'Meditation - Vipassana',
+    icon: '🧘',
+    base: 30,
+    description: 'Focus on breath',
+    dimension: 'Formless',
+    aspect: 'II',
+    timesPerDay: 1,
+    planner: false,
+  },
+  {
+    title: 'Meditation - Ramana',
+    icon: '🧘',
+    base: 30,
+    description: 'Self inquiry',
+    dimension: 'Formless',
+    aspect: 'II',
+    timesPerDay: 1,
+    planner: false,
+  },
+  {
+    title: 'Yoga',
+    icon: '🧘‍♂️',
+    base: 45,
+    description: 'Stretch and breathe',
+    dimension: 'Form',
+    aspect: 'IE',
+    timesPerDay: 1,
+    planner: false,
+  },
+  {
+    title: 'Workout',
+    icon: '🏋️',
+    base: 45,
+    description: 'Strength training',
+    dimension: 'Form',
+    aspect: 'EE',
+    timesPerDay: 1,
+    planner: false,
+  },
+  {
+    title: 'Reading',
+    icon: '📚',
+    base: 20,
+    description: 'Read a book',
+    dimension: 'Form',
+    aspect: 'II',
+    timesPerDay: 1,
+    planner: false,
+  },
 ];
 
 const computeReward = (mins) => {
@@ -58,6 +104,20 @@ function ActivityModal({ activity, onStart, onClose }) {
 }
 
 export default function ActivityApp({ onBack }) {
+  const [activities, setActivities] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('activities')) || DEFAULT_ACTIVITIES;
+    } catch {
+      return DEFAULT_ACTIVITIES;
+    }
+  });
+  const [counts, setCounts] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('activityCounts')) || {};
+    } catch {
+      return {};
+    }
+  });
   const [xp, setXp] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem('activityXP')) || {};
@@ -77,6 +137,18 @@ export default function ActivityApp({ onBack }) {
     return Math.max(0, Math.floor((new Date(active.end) - Date.now()) / 1000));
   });
   const [modalAct, setModalAct] = useState(null);
+  const [showAdd, setShowAdd] = useState(false);
+
+  const saveActivities = (next) => {
+    setActivities(next);
+    localStorage.setItem('activities', JSON.stringify(next));
+    window.dispatchEvent(new CustomEvent('activities-updated', { detail: next }));
+  };
+
+  const saveCounts = (next) => {
+    setCounts(next);
+    localStorage.setItem('activityCounts', JSON.stringify(next));
+  };
 
   const saveXp = (next) => {
     setXp(next);
@@ -137,9 +209,32 @@ export default function ActivityApp({ onBack }) {
 
     const nextXp = { ...xp, [activity.title]: (xp[activity.title] || 0) + mins };
     saveXp(nextXp);
+    const today = new Date().toISOString().slice(0, 10);
+    const nextCounts = { ...counts };
+    if (!nextCounts[activity.title]) nextCounts[activity.title] = {};
+    nextCounts[activity.title][today] = (nextCounts[activity.title][today] || 0) + 1;
+    saveCounts(nextCounts);
     setModalAct(null);
     setActive({ title: activity.title, end: end.toISOString() });
     setTimeLeft(mins * 60);
+  };
+
+  const addActivity = (activity) => {
+    const next = [...activities, activity];
+    saveActivities(next);
+    setShowAdd(false);
+  };
+
+  const removeActivity = (title) => {
+    const next = activities.filter((a) => a.title !== title);
+    saveActivities(next);
+  };
+
+  const togglePlanner = (title) => {
+    const next = activities.map((a) =>
+      a.title === title ? { ...a, planner: !a.planner } : a
+    );
+    saveActivities(next);
   };
 
   return (
@@ -153,21 +248,54 @@ export default function ActivityApp({ onBack }) {
         </div>
       )}
       <h2>Activities</h2>
+      <button className="add-button" onClick={() => setShowAdd(true)}>
+        Add Activity
+      </button>
       <ul className="activity-grid">
-        {ACTIVITIES.map((act) => {
+        {activities.map((act) => {
           const spent = xp[act.title] || 0;
           const pct = Math.min(spent / 180, 1);
+          const today = new Date().toISOString().slice(0, 10);
+          const done = counts[act.title]?.[today] || 0;
           return (
             <li
               key={act.title}
               className="activity-box"
               onClick={() => setModalAct(act)}
             >
+              <button
+                className={act.planner ? 'planner-button active' : 'planner-button'}
+                title="Toggle Daily Planner"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  togglePlanner(act.title);
+                }}
+              >
+                📅
+              </button>
+              <button
+                className="delete-button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeActivity(act.title);
+                }}
+              >
+                ×
+              </button>
               <div className="box-header">
                 <span className="activity-icon">{act.icon}</span>
                 <span>{act.title}</span>
               </div>
               <div className="activity-desc">{act.description}</div>
+              <div className="activity-tags">
+                <span>{act.dimension}</span>
+                <span>{act.aspect}</span>
+              </div>
+              <div className="daily-progress">
+                {[...Array(act.timesPerDay || 0)].map((_, i) => (
+                  <span key={i} className={i < done ? 'dot done' : 'dot'} />
+                ))}
+              </div>
               <div className="xp-bar">
                 <div
                   className="xp-fill"
@@ -183,6 +311,12 @@ export default function ActivityApp({ onBack }) {
           activity={modalAct}
           onStart={(mins) => startActivity(modalAct, mins)}
           onClose={() => setModalAct(null)}
+        />
+      )}
+      {showAdd && (
+        <AddActivityModal
+          onSave={addActivity}
+          onClose={() => setShowAdd(false)}
         />
       )}
     </div>

--- a/src/AddActivityModal.jsx
+++ b/src/AddActivityModal.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+
+const DIMENSIONS = ['Form', 'SemiFormless', 'Formless'];
+const ASPECTS = ['II', 'IE', 'EI', 'EE'];
+
+export default function AddActivityModal({ onSave, onClose }) {
+  const [title, setTitle] = useState('');
+  const [icon, setIcon] = useState('🏷️');
+  const [description, setDescription] = useState('');
+  const [base, setBase] = useState(30);
+  const [dimension, setDimension] = useState(DIMENSIONS[0]);
+  const [aspect, setAspect] = useState(ASPECTS[0]);
+  const [times, setTimes] = useState(1);
+  const [planner, setPlanner] = useState(false);
+
+  const handleSave = () => {
+    onSave({
+      title,
+      icon,
+      base,
+      description,
+      dimension,
+      aspect,
+      timesPerDay: times,
+      planner,
+    });
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h3>Add Activity</h3>
+        <label className="note-label">
+          Title
+          <input className="note-title" value={title} onChange={(e) => setTitle(e.target.value)} />
+        </label>
+        <label className="note-label">
+          Icon
+          <input className="note-title" value={icon} onChange={(e) => setIcon(e.target.value)} />
+        </label>
+        <label className="note-label">
+          Description
+          <input className="note-title" value={description} onChange={(e) => setDescription(e.target.value)} />
+        </label>
+        <label className="note-label">
+          Base Minutes
+          <input
+            type="number"
+            className="note-title"
+            value={base}
+            min="1"
+            onChange={(e) => setBase(Number(e.target.value))}
+          />
+        </label>
+        <label className="note-label">
+          Dimension
+          <select className="note-title" value={dimension} onChange={(e) => setDimension(e.target.value)}>
+            {DIMENSIONS.map((d) => (
+              <option key={d}>{d}</option>
+            ))}
+          </select>
+        </label>
+        <label className="note-label">
+          Aspect
+          <select className="note-title" value={aspect} onChange={(e) => setAspect(e.target.value)}>
+            {ASPECTS.map((a) => (
+              <option key={a}>{a}</option>
+            ))}
+          </select>
+        </label>
+        <label className="note-label">
+          Times per Day
+          <input
+            type="number"
+            className="note-title"
+            min="1"
+            value={times}
+            onChange={(e) => setTimes(Number(e.target.value))}
+          />
+        </label>
+        <label className="note-label">
+          <input
+            type="checkbox"
+            checked={planner}
+            onChange={(e) => setPlanner(e.target.checked)}
+          />
+          Add to Daily Planner
+        </label>
+        <div className="actions">
+          <button className="save-button" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="save-button" onClick={handleSave}>
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -28,7 +28,14 @@ function CalendarEvent({ event, onDelete }) {
   );
 }
 
-export default function Calendar({ onBack, backLabel = 'Back', defaultView = 'month' }) {
+export default function Calendar({
+  onBack,
+  backLabel = 'Back',
+  defaultView = 'month',
+  externalActivity = null,
+  onExternalDrop,
+  backDisabled = false,
+}) {
   const roundSlot = (date) => {
     const d = new Date(date);
     d.setMinutes(Math.floor(d.getMinutes() / 30) * 30, 0, 0);
@@ -276,7 +283,7 @@ export default function Calendar({ onBack, backLabel = 'Back', defaultView = 'mo
 
   return (
     <div className="calendar-app">
-      <button className="back-button" onClick={onBack}>
+      <button className="back-button" onClick={onBack} disabled={backDisabled}>
         {backLabel}
       </button>
       <div className="calendar-container" ref={containerRef}>
@@ -295,6 +302,25 @@ export default function Calendar({ onBack, backLabel = 'Back', defaultView = 'mo
           onEventDrop={moveEvent}
           onEventResize={resizeEvent}
           eventPropGetter={eventPropGetter}
+          dragFromOutsideItem={() => externalActivity}
+          onDropFromOutside={({ start }) => {
+            if (!externalActivity) return;
+            const duration = externalActivity.base || 30;
+            const ev = {
+              title: externalActivity.title,
+              start: new Date(start),
+              end: new Date(new Date(start).getTime() + duration * 60000),
+              kind: 'planned',
+              color: '#4285f4',
+            };
+            setEvents((prev) => [...prev, ev]);
+            if (onExternalDrop) onExternalDrop(ev);
+          }}
+          onDragOver={(e) => {
+            if (externalActivity) {
+              e.preventDefault();
+            }
+          }}
           components={{
             event: (props) => (
               <CalendarEvent {...props} onDelete={handleDelete} />

--- a/src/DayPlanner.test.js
+++ b/src/DayPlanner.test.js
@@ -3,9 +3,11 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('./Calendar.jsx', () => {
-  return jest.fn(({ onBack, backLabel }) => (
+  return jest.fn(({ onBack, backLabel, backDisabled }) => (
     <div data-testid="calendar-mock">
-      <button onClick={onBack}>{backLabel}</button>
+      <button onClick={onBack} disabled={backDisabled}>
+        {backLabel}
+      </button>
     </div>
   ));
 });
@@ -44,10 +46,35 @@ describe('DayPlanner', () => {
     expect(mockCalendar).toHaveBeenCalled();
     expect(mockCalendar.mock.calls[0][0]).toEqual(
       expect.objectContaining({
-        onBack: onComplete,
+        onBack: expect.any(Function),
         backLabel: 'Return',
         defaultView: 'day',
+        backDisabled: false,
       })
     );
+  });
+
+  test('shows planner activities and disables start until scheduled', () => {
+    localStorage.setItem(
+      'activities',
+      JSON.stringify([
+        {
+          title: 'Neck Training',
+          icon: '🦒',
+          base: 10,
+          description: '',
+          dimension: 'Form',
+          aspect: 'II',
+          timesPerDay: 2,
+          planner: true,
+        },
+      ])
+    );
+    const onComplete = jest.fn();
+    render(<DayPlanner onComplete={onComplete} backLabel="Start" />);
+    expect(screen.getByText('Activities')).toBeInTheDocument();
+    expect(screen.getByText('Neck Training')).toBeInTheDocument();
+    const startBtn = screen.getByRole('button', { name: 'Start' });
+    expect(startBtn).toBeDisabled();
   });
 });

--- a/src/activity-app.css
+++ b/src/activity-app.css
@@ -90,6 +90,7 @@
   align-items: center;
   gap: 6px;
   text-align: center;
+  position: relative;
 }
 
 .activity-box:hover {
@@ -106,4 +107,59 @@
 .activity-desc {
   font-size: 0.85em;
   color: #bbb;
+}
+
+.add-button {
+  margin-bottom: 10px;
+}
+
+.delete-button {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+}
+
+.delete-button:hover {
+  color: #fff;
+}
+
+.activity-tags {
+  font-size: 0.75em;
+  color: #888;
+  display: flex;
+  gap: 4px;
+}
+
+.daily-progress {
+  display: flex;
+  gap: 4px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #333;
+}
+
+.dot.done {
+  background: #4caf50;
+}
+
+.planner-button {
+  position: absolute;
+  top: 4px;
+  left: 6px;
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+}
+
+.planner-button.active {
+  color: #4caf50;
 }

--- a/src/day-planner.css
+++ b/src/day-planner.css
@@ -46,3 +46,27 @@
 .planner-goals li {
   margin-bottom: 0.5rem;
 }
+
+.planner-activities {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.planner-activity {
+  background: #333;
+  padding: 0.5rem;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: grab;
+}
+
+.planner-count {
+  background: #555;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8em;
+}


### PR DESCRIPTION
## Summary
- allow marking activities for inclusion in daily planner and toggling from activity list
- render planner-tagged activities in DayPlanner with drag-to-schedule banners and start gating
- support external drag-and-drop events into calendar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b478c0dd648322862ea8aebb514ad6