### PR TITLE
fix: gate planner start by today's events

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -126,6 +126,7 @@ export default function Calendar({
 
   useEffect(() => {
     localStorage.setItem("calendarEvents", JSON.stringify(events));
+    window.dispatchEvent(new Event('calendar-updated'));
   }, [events]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- restrict daily planner start gating to activities scheduled for the current day
- broadcast calendar updates so planner counts refresh when events are added or removed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4aa2598dc83228ac9bd0cfa83085d