### PR TITLE
feat: toggle day planner on existing activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mazed
+# mazed!
 
 The idea is to build the Mazed app for PC, it will be built in react electron, so it's useable through web, app. mobile, while being highly customizable and alive
 

--- a/src/ActivityApp.jsx
+++ b/src/ActivityApp.jsx
@@ -73,8 +73,13 @@ const getColor = (val) => {
   return '#4caf50';
 };
 
-function ActivityModal({ activity, onStart, onClose }) {
+function ActivityModal({ activity, onStart, onClose, onPlannerChange }) {
   const [duration, setDuration] = useState(activity.base);
+  const [planner, setPlanner] = useState(activity.planner);
+  useEffect(() => {
+    setPlanner(activity.planner);
+    setDuration(activity.base);
+  }, [activity]);
   const reward = computeReward(duration);
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -90,6 +95,17 @@ function ActivityModal({ activity, onStart, onClose }) {
             value={duration}
             onChange={(e) => setDuration(Number(e.target.value))}
           />
+        </label>
+        <label className="note-label">
+          <input
+            type="checkbox"
+            checked={planner}
+            onChange={(e) => {
+              setPlanner(e.target.checked);
+              onPlannerChange(e.target.checked);
+            }}
+          />
+          Add to Daily Planner
         </label>
         <div className="reward-label">Reward: {reward} R</div>
         <div className="actions">
@@ -230,11 +246,19 @@ export default function ActivityApp({ onBack }) {
     saveActivities(next);
   };
 
-  const togglePlanner = (title) => {
+  const setPlanner = (title, planner) => {
     const next = activities.map((a) =>
-      a.title === title ? { ...a, planner: !a.planner } : a
+      a.title === title ? { ...a, planner } : a
     );
     saveActivities(next);
+    if (modalAct && modalAct.title === title) {
+      setModalAct({ ...modalAct, planner });
+    }
+  };
+
+  const togglePlanner = (title) => {
+    const act = activities.find((a) => a.title === title);
+    setPlanner(title, !act?.planner);
   };
 
   return (
@@ -311,6 +335,7 @@ export default function ActivityApp({ onBack }) {
           activity={modalAct}
           onStart={(mins) => startActivity(modalAct, mins)}
           onClose={() => setModalAct(null)}
+          onPlannerChange={(val) => setPlanner(modalAct.title, val)}
         />
       )}
       {showAdd && (

--- a/src/ActivityApp.test.js
+++ b/src/ActivityApp.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ActivityApp from './ActivityApp.jsx';
+
+describe('ActivityApp planner toggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('allows toggling planner from activity modal', () => {
+    render(<ActivityApp onBack={() => {}} />);
+    fireEvent.click(screen.getByText('Meditation - Vipassana'));
+    const checkbox = screen.getByLabelText('Add to Daily Planner');
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+    const stored = JSON.parse(localStorage.getItem('activities'));
+    const act = stored.find((a) => a.title === 'Meditation - Vipassana');
+    expect(act.planner).toBe(true);
+  });
+});

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -126,6 +126,7 @@ export default function Calendar({
 
   useEffect(() => {
     localStorage.setItem("calendarEvents", JSON.stringify(events));
+    window.dispatchEvent(new Event('calendar-updated'));
   }, [events]);
 
   useEffect(() => {

--- a/src/DayPlanner.jsx
+++ b/src/DayPlanner.jsx
@@ -13,6 +13,26 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
   const [counts, setCounts] = useState({});
   const [dragging, setDragging] = useState(null);
 
+  const computeCounts = () => {
+    try {
+      const events = JSON.parse(localStorage.getItem('calendarEvents') || '[]');
+      const today = new Date().toDateString();
+      const c = {};
+      events
+        .filter(
+          (e) =>
+            e.kind === 'planned' &&
+            new Date(e.start).toDateString() === today
+        )
+        .forEach((e) => {
+          c[e.title] = (c[e.title] || 0) + 1;
+        });
+      setCounts(c);
+    } catch {
+      setCounts({});
+    }
+  };
+
   useEffect(() => {
     try {
       const stored = JSON.parse(localStorage.getItem('todoBigGoals') || '{}');
@@ -29,7 +49,8 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
     try {
       const data = JSON.parse(localStorage.getItem('activities') || '[]');
       setActivities(data.filter((a) => a.planner));
-    } catch {
+    } catch (err) {
+      console.error('Failed to load activities', err);
       setActivities([]);
     }
   };
@@ -42,21 +63,18 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
   }, []);
 
   useEffect(() => {
-    const events = JSON.parse(localStorage.getItem('calendarEvents') || '[]');
-    const c = {};
-    events
-      .filter((e) => e.kind === 'planned')
-      .forEach((e) => {
-        c[e.title] = (c[e.title] || 0) + 1;
-      });
-    setCounts(c);
+    computeCounts();
   }, [activities]);
 
-  const handleDrop = (ev) => {
-    setCounts((prev) => ({
-      ...prev,
-      [ev.title]: (prev[ev.title] || 0) + 1,
-    }));
+  useEffect(() => {
+    computeCounts();
+    const onUpdate = () => computeCounts();
+    window.addEventListener('calendar-updated', onUpdate);
+    return () => window.removeEventListener('calendar-updated', onUpdate);
+  }, []);
+
+  const handleDrop = () => {
+    computeCounts();
   };
 
   const canStart = activities.every(


### PR DESCRIPTION
## Summary
- allow adding or removing activities from the daily planner directly from the activity modal
- restrict daily planner start gating to activities scheduled for the current day
- broadcast calendar updates so planner counts refresh when events are added or removed
- add punctuation in README to retrigger extraction
- log activity loading failures to console

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4aa2598dc83228ac9bd0cfa83085d