### PR TITLE
fix: update planner counts when rescheduling events

### DIFF
--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -36,6 +36,7 @@ export default function Calendar({
   onExternalDrop,
   backDisabled = false,
   onDeleteEvent,
+  onMoveEvent,
 }) {
   const roundSlot = (date) => {
     const d = new Date(date);
@@ -276,8 +277,10 @@ export default function Calendar({
     const idx = events.indexOf(event);
     if (idx !== -1) {
       const updated = [...events];
-      updated[idx] = { ...event, start, end };
+      const next = { ...event, start, end };
+      updated[idx] = next;
       setEvents(updated);
+      if (onMoveEvent) onMoveEvent(event, next);
     }
   };
 

--- a/src/DayPlanner.jsx
+++ b/src/DayPlanner.jsx
@@ -82,6 +82,23 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
     });
   };
 
+  const handleMove = (from, to) => {
+    const wasToday = isToday(from.start);
+    const isTodayNow = isToday(to.start);
+    if (wasToday === isTodayNow) return;
+    setCounts((prev) => {
+      const next = { ...prev };
+      if (wasToday && next[from.title]) {
+        next[from.title] -= 1;
+        if (next[from.title] <= 0) delete next[from.title];
+      }
+      if (isTodayNow) {
+        next[to.title] = (next[to.title] || 0) + 1;
+      }
+      return next;
+    });
+  };
+
   const canStart = activities.every(
     (a) => (counts[a.title] || 0) >= (a.timesPerDay || 0)
   );
@@ -101,6 +118,7 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
             externalActivity={dragging}
             onExternalDrop={handleDrop}
             onDeleteEvent={handleDelete}
+            onMoveEvent={handleMove}
             backDisabled={!canStart}
           />
         </div>

--- a/src/DayPlanner.test.js
+++ b/src/DayPlanner.test.js
@@ -53,6 +53,7 @@ describe('DayPlanner', () => {
         backLabel: 'Return',
         defaultView: 'day',
         backDisabled: false,
+        onMoveEvent: expect.any(Function),
       })
     );
   });
@@ -112,6 +113,42 @@ describe('DayPlanner', () => {
     );
     render(<DayPlanner onComplete={() => {}} backLabel="Start" />);
     expect(screen.getByText('0/2')).toBeInTheDocument();
+  });
+
+  test('updates counts when events are moved on or off today', () => {
+    localStorage.setItem(
+      'activities',
+      JSON.stringify([
+        {
+          title: 'Neck Training',
+          icon: '🦒',
+          base: 10,
+          description: '',
+          dimension: 'Form',
+          aspect: 'II',
+          timesPerDay: 1,
+          planner: true,
+        },
+      ])
+    );
+    render(<DayPlanner onComplete={() => {}} backLabel="Start" />);
+    const props = mockCalendar.mock.calls[mockCalendar.mock.calls.length - 1][0];
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const startBtn = screen.getByRole('button', { name: 'Start' });
+    act(() => {
+      props.onExternalDrop({ title: 'Neck Training', start: today });
+    });
+    expect(startBtn).toBeEnabled();
+    act(() => {
+      props.onMoveEvent({ title: 'Neck Training', start: today }, { title: 'Neck Training', start: tomorrow });
+    });
+    expect(startBtn).toBeDisabled();
+    act(() => {
+      props.onMoveEvent({ title: 'Neck Training', start: tomorrow }, { title: 'Neck Training', start: today });
+    });
+    expect(startBtn).toBeEnabled();
   });
 
   test('decrements count when planned event deleted', async () => {


### PR DESCRIPTION
## Summary
- adjust DayPlanner counts when events move between days
- expose onMoveEvent from Calendar to notify DayPlanner
- test rescheduling behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58ba18154832298da544638be4902