### PR TITLE
Add placeholder Watchdog app

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -15,6 +15,7 @@ import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './src/ToolsBlog.jsx';
 import MomentoMori from './MomentoMori.jsx';
+import Watchdog from './Watchdog.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -67,6 +68,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showMomentoMori, setShowMomentoMori] = useState(false);
   // Avoid naming clash with src/App.jsx by giving the blog state a unique name
   const [showToolsBlog, setShowToolsBlog] = useState(false);
+  const [showWatchdog, setShowWatchdog] = useState(false);
 const [showAkashicRecords, setShowAkashicRecords] = useState(false);
 const [showProfile, setShowProfile] = useState(false);
 const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
@@ -96,6 +98,7 @@ const anyAppOpen =
   showMoodtracker ||
   showAnima ||
   showMomentoMori ||
+  showWatchdog ||
   showToolsBlog ||
   showAkashicRecords ||
   showProfile ||
@@ -115,6 +118,7 @@ const closeOpenApp = () => {
   setShowMoodtracker(false);
   setShowAnima(false);
   setShowMomentoMori(false);
+  setShowWatchdog(false);
   setShowToolsBlog(false);
   setShowAkashicRecords(false);
   setShowProfile(false);
@@ -358,10 +362,12 @@ useEffect(() => {
               <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : showMoodtracker ? (
               <Moodtracker onBack={() => setShowMoodtracker(false)} />
-            ) : showToolsBlog ? (
-              <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : showMomentoMori ? (
               <MomentoMori onBack={() => setShowMomentoMori(false)} />
+            ) : showWatchdog ? (
+              <Watchdog onBack={() => setShowWatchdog(false)} />
+            ) : showToolsBlog ? (
+              <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : (
@@ -413,6 +419,10 @@ useEffect(() => {
                 <div className="app-card" onClick={() => setShowMomentoMori(true)}>
                   <div className="star-icon">☠️</div>
                   <span>Momento Mori</span>
+                </div>
+                <div className="app-card" onClick={() => setShowWatchdog(true)}>
+                  <div className="star-icon">🐶</div>
+                  <span>Watchdog</span>
                 </div>
                 <div className="app-card" onClick={() => setShowToolsBlog(true)}>
                   <div className="star-icon">📝</div>

--- a/Watchdog.jsx
+++ b/Watchdog.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './placeholder-app.css';
+
+export default function Watchdog({ onBack }) {
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <h2>Watchdog</h2>
+      <p>Coming soon...</p>
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './ToolsBlog.jsx';
 import MomentoMori from '../MomentoMori.jsx';
+import Watchdog from './Watchdog.jsx';
 import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
@@ -80,6 +81,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showIdeaBoard, setShowIdeaBoard] = useState(false);
   const [showImplementationIdeas, setShowImplementationIdeas] = useState(false);
   const [showOrb, setShowOrb] = useState(false);
+  const [showWatchdog, setShowWatchdog] = useState(false);
   const [showAkashicRecords, setShowAkashicRecords] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -114,6 +116,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       ideaBoard: 'Form',
       implementationIdeas: 'Form',
       orb: 'Form',
+      watchdog: 'Form',
     };
 
     const stored = localStorage.getItem('appLayers');
@@ -165,6 +168,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showIdeaBoard ||
     showImplementationIdeas ||
     showOrb ||
+    showWatchdog ||
     showToolsBlog ||
     showAkashicRecords ||
     showProfile ||
@@ -193,6 +197,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowIdeaBoard(false);
     setShowImplementationIdeas(false);
     setShowOrb(false);
+    setShowWatchdog(false);
     setShowToolsBlog(false);
     setShowAkashicRecords(false);
     setShowProfile(false);
@@ -529,6 +534,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <ImplementationIdeas onBack={() => setShowImplementationIdeas(false)} />
             ) : showOrb ? (
               <Orb onBack={() => setShowOrb(false)} />
+            ) : showWatchdog ? (
+              <Watchdog onBack={() => setShowWatchdog(false)} />
             ) : activeLayer === 'Form' && showToolsBlog ? (
               <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : (
@@ -801,6 +808,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">🧿</div>
                     <span>Orb</span>
+                  </div>
+                )}
+                {appLayers.watchdog === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowWatchdog(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'watchdog')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'watchdog')}
+                  >
+                    <div className="star-icon">🐶</div>
+                    <span>Watchdog</span>
                   </div>
                 )}
               </div>

--- a/src/Watchdog.jsx
+++ b/src/Watchdog.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './placeholder-app.css';
+
+export default function Watchdog({ onBack }) {
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>Back</button>
+      <h2>Watchdog</h2>
+      <p>Coming soon...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add minimal Watchdog component
- expose Watchdog app in Tools tab with routing and menu card

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c46e9d5c83228ba550d3d83c4318