### PR TITLE
Ensure Watchdog card appears for existing users

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -15,6 +15,7 @@ import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './src/ToolsBlog.jsx';
 import MomentoMori from './MomentoMori.jsx';
+import Watchdog from './Watchdog.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -67,6 +68,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showMomentoMori, setShowMomentoMori] = useState(false);
   // Avoid naming clash with src/App.jsx by giving the blog state a unique name
   const [showToolsBlog, setShowToolsBlog] = useState(false);
+  const [showWatchdog, setShowWatchdog] = useState(false);
 const [showAkashicRecords, setShowAkashicRecords] = useState(false);
 const [showProfile, setShowProfile] = useState(false);
 const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
@@ -96,6 +98,7 @@ const anyAppOpen =
   showMoodtracker ||
   showAnima ||
   showMomentoMori ||
+  showWatchdog ||
   showToolsBlog ||
   showAkashicRecords ||
   showProfile ||
@@ -115,6 +118,7 @@ const closeOpenApp = () => {
   setShowMoodtracker(false);
   setShowAnima(false);
   setShowMomentoMori(false);
+  setShowWatchdog(false);
   setShowToolsBlog(false);
   setShowAkashicRecords(false);
   setShowProfile(false);
@@ -358,10 +362,12 @@ useEffect(() => {
               <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : showMoodtracker ? (
               <Moodtracker onBack={() => setShowMoodtracker(false)} />
-            ) : showToolsBlog ? (
-              <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : showMomentoMori ? (
               <MomentoMori onBack={() => setShowMomentoMori(false)} />
+            ) : showWatchdog ? (
+              <Watchdog onBack={() => setShowWatchdog(false)} />
+            ) : showToolsBlog ? (
+              <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : (
@@ -413,6 +419,10 @@ useEffect(() => {
                 <div className="app-card" onClick={() => setShowMomentoMori(true)}>
                   <div className="star-icon">☠️</div>
                   <span>Momento Mori</span>
+                </div>
+                <div className="app-card" onClick={() => setShowWatchdog(true)}>
+                  <div className="star-icon">🐶</div>
+                  <span>Watchdog</span>
                 </div>
                 <div className="app-card" onClick={() => setShowToolsBlog(true)}>
                   <div className="star-icon">📝</div>

--- a/Watchdog.jsx
+++ b/Watchdog.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import './placeholder-app.css';
+
+const defaultSettings = {
+  hardMode: false,
+  blockNetwork: false,
+  autoStart: false,
+  tamperGuard: false,
+  checkInterval: 600,
+  blockedApps: ['brave.exe', 'chrome.exe', 'steam.exe'],
+};
+
+export default function Watchdog({ onBack }) {
+  const [settings, setSettings] = useState(() => {
+    const saved = localStorage.getItem('watchdogSettings');
+    return saved ? JSON.parse(saved) : defaultSettings;
+  });
+  const [newApp, setNewApp] = useState('');
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem('watchdogSettings', JSON.stringify(settings));
+  }, [settings]);
+
+  const toggleSetting = (key) => {
+    setSettings((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const addBlockedApp = () => {
+    const app = newApp.trim();
+    if (!app) return;
+    setSettings((prev) => ({
+      ...prev,
+      blockedApps: [...prev.blockedApps, app],
+    }));
+    setNewApp('');
+  };
+
+  const removeBlockedApp = (app) => {
+    setSettings((prev) => ({
+      ...prev,
+      blockedApps: prev.blockedApps.filter((a) => a !== app),
+    }));
+  };
+
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
+      <h2>Watchdog Settings</h2>
+      <p>Watchdog is {enabled ? 'ON' : 'OFF'}</p>
+      <button onClick={() => setEnabled(!enabled)}>
+        Turn {enabled ? 'Off' : 'On'}
+      </button>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.hardMode}
+          onChange={() => toggleSetting('hardMode')}
+        />
+        Hard mode (kill blocked apps)
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.blockNetwork}
+          onChange={() => toggleSetting('blockNetwork')}
+        />
+        Block network for browsers
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.autoStart}
+          onChange={() => toggleSetting('autoStart')}
+        />
+        Auto-start with system
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.tamperGuard}
+          onChange={() => toggleSetting('tamperGuard')}
+        />
+        Enable tamper guard
+      </label>
+
+      <label>
+        Foreground check interval (ms)
+        <input
+          type="number"
+          value={settings.checkInterval}
+          onChange={(e) =>
+            setSettings((prev) => ({
+              ...prev,
+              checkInterval: Number(e.target.value) || 0,
+            }))
+          }
+        />
+      </label>
+
+      <div className="blocked-apps">
+        <h3>Blocked Processes</h3>
+        <ul>
+          {settings.blockedApps.map((app) => (
+            <li key={app}>
+              <span>{app}</span>
+              <button onClick={() => removeBlockedApp(app)}>✕</button>
+            </li>
+          ))}
+        </ul>
+        <div className="blocked-apps-input">
+          <input
+            type="text"
+            placeholder="e.g. chrome.exe"
+            value={newApp}
+            onChange={(e) => setNewApp(e.target.value)}
+          />
+          <button onClick={addBlockedApp}>Add</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/placeholder-app.css
+++ b/placeholder-app.css
@@ -4,3 +4,48 @@
   gap: 10px;
   align-items: center;
 }
+
+.placeholder-app label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.placeholder-app label input[type="number"] {
+  width: 80px;
+}
+
+.blocked-apps {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 300px;
+}
+
+.blocked-apps ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.blocked-apps li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.blocked-apps-input {
+  display: flex;
+  gap: 4px;
+}
+
+.blocked-apps-input input[type="text"] {
+  flex: 1;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './ToolsBlog.jsx';
 import MomentoMori from '../MomentoMori.jsx';
+import Watchdog from './Watchdog.jsx';
 import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
@@ -80,6 +81,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showIdeaBoard, setShowIdeaBoard] = useState(false);
   const [showImplementationIdeas, setShowImplementationIdeas] = useState(false);
   const [showOrb, setShowOrb] = useState(false);
+  const [showWatchdog, setShowWatchdog] = useState(false);
   const [showAkashicRecords, setShowAkashicRecords] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -114,15 +116,26 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       ideaBoard: 'Form',
       implementationIdeas: 'Form',
       orb: 'Form',
+      watchdog: 'Form',
     };
 
     const stored = localStorage.getItem('appLayers');
-    if (!stored) return defaults;
+    if (!stored) {
+      localStorage.setItem('appLayers', JSON.stringify(defaults));
+      return defaults;
+    }
 
     try {
       const parsed = JSON.parse(stored);
-      return { ...defaults, ...parsed };
+      const merged = { ...defaults, ...parsed };
+
+      if (Object.keys(defaults).some((key) => !(key in parsed))) {
+        localStorage.setItem('appLayers', JSON.stringify(merged));
+      }
+
+      return merged;
     } catch {
+      localStorage.setItem('appLayers', JSON.stringify(defaults));
       return defaults;
     }
   };
@@ -165,6 +178,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showIdeaBoard ||
     showImplementationIdeas ||
     showOrb ||
+    showWatchdog ||
     showToolsBlog ||
     showAkashicRecords ||
     showProfile ||
@@ -193,6 +207,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowIdeaBoard(false);
     setShowImplementationIdeas(false);
     setShowOrb(false);
+    setShowWatchdog(false);
     setShowToolsBlog(false);
     setShowAkashicRecords(false);
     setShowProfile(false);
@@ -529,6 +544,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <ImplementationIdeas onBack={() => setShowImplementationIdeas(false)} />
             ) : showOrb ? (
               <Orb onBack={() => setShowOrb(false)} />
+            ) : showWatchdog ? (
+              <Watchdog onBack={() => setShowWatchdog(false)} />
             ) : activeLayer === 'Form' && showToolsBlog ? (
               <ToolsBlog onBack={() => setShowToolsBlog(false)} />
             ) : (
@@ -801,6 +818,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">🧿</div>
                     <span>Orb</span>
+                  </div>
+                )}
+                {appLayers.watchdog === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowWatchdog(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'watchdog')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'watchdog')}
+                  >
+                    <div className="star-icon">🐶</div>
+                    <span>Watchdog</span>
                   </div>
                 )}
               </div>

--- a/src/Watchdog.jsx
+++ b/src/Watchdog.jsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import './placeholder-app.css';
+
+const defaultSettings = {
+  hardMode: false,
+  blockNetwork: false,
+  autoStart: false,
+  tamperGuard: false,
+  checkInterval: 600,
+  blockedApps: ['brave.exe', 'chrome.exe', 'steam.exe'],
+};
+
+export default function Watchdog({ onBack }) {
+  const [settings, setSettings] = useState(() => {
+    const saved = localStorage.getItem('watchdogSettings');
+    return saved ? JSON.parse(saved) : defaultSettings;
+  });
+  const [newApp, setNewApp] = useState('');
+
+  useEffect(() => {
+    localStorage.setItem('watchdogSettings', JSON.stringify(settings));
+  }, [settings]);
+
+  const toggleSetting = (key) => {
+    setSettings((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const addBlockedApp = () => {
+    const app = newApp.trim();
+    if (!app) return;
+    setSettings((prev) => ({
+      ...prev,
+      blockedApps: [...prev.blockedApps, app],
+    }));
+    setNewApp('');
+  };
+
+  const removeBlockedApp = (app) => {
+    setSettings((prev) => ({
+      ...prev,
+      blockedApps: prev.blockedApps.filter((a) => a !== app),
+    }));
+  };
+
+  return (
+    <div className="placeholder-app">
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
+      <h2>Watchdog Settings</h2>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.hardMode}
+          onChange={() => toggleSetting('hardMode')}
+        />
+        Hard mode (kill blocked apps)
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.blockNetwork}
+          onChange={() => toggleSetting('blockNetwork')}
+        />
+        Block network for browsers
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.autoStart}
+          onChange={() => toggleSetting('autoStart')}
+        />
+        Auto-start with system
+      </label>
+
+      <label>
+        <input
+          type="checkbox"
+          checked={settings.tamperGuard}
+          onChange={() => toggleSetting('tamperGuard')}
+        />
+        Enable tamper guard
+      </label>
+
+      <label>
+        Foreground check interval (ms)
+        <input
+          type="number"
+          value={settings.checkInterval}
+          onChange={(e) =>
+            setSettings((prev) => ({
+              ...prev,
+              checkInterval: Number(e.target.value) || 0,
+            }))
+          }
+        />
+      </label>
+
+      <div className="blocked-apps">
+        <h3>Blocked Processes</h3>
+        <ul>
+          {settings.blockedApps.map((app) => (
+            <li key={app}>
+              <span>{app}</span>
+              <button onClick={() => removeBlockedApp(app)}>✕</button>
+            </li>
+          ))}
+        </ul>
+        <div className="blocked-apps-input">
+          <input
+            type="text"
+            placeholder="e.g. chrome.exe"
+            value={newApp}
+            onChange={(e) => setNewApp(e.target.value)}
+          />
+          <button onClick={addBlockedApp}>Add</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/placeholder-app.css
+++ b/src/placeholder-app.css
@@ -4,3 +4,48 @@
   gap: 10px;
   align-items: center;
 }
+
+.placeholder-app label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.placeholder-app label input[type="number"] {
+  width: 80px;
+}
+
+.blocked-apps {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 300px;
+}
+
+.blocked-apps ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.blocked-apps li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.blocked-apps-input {
+  display: flex;
+  gap: 4px;
+}
+
+.blocked-apps-input input[type="text"] {
+  flex: 1;
+}


### PR DESCRIPTION
## Summary
- Seed missing app-layer keys like `watchdog` into localStorage during app init
- Persist merged defaults so new Tools cards render without clearing storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c46e9d5c83228ba550d3d83c4318