### PR TITLE
feat: add watchdog activation toggle

### DIFF
--- a/src/Watchdog.jsx
+++ b/src/Watchdog.jsx
@@ -16,6 +16,7 @@ export default function Watchdog({ onBack }) {
     return saved ? JSON.parse(saved) : defaultSettings;
   });
   const [newApp, setNewApp] = useState('');
+  const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
     localStorage.setItem('watchdogSettings', JSON.stringify(settings));
@@ -48,6 +49,10 @@ export default function Watchdog({ onBack }) {
         Back
       </button>
       <h2>Watchdog Settings</h2>
+      <p>Watchdog is {enabled ? 'ON' : 'OFF'}</p>
+      <button onClick={() => setEnabled(!enabled)}>
+        Turn {enabled ? 'Off' : 'On'}
+      </button>
 
       <label>
         <input


### PR DESCRIPTION
## Summary
- add activation toggle to Watchdog settings so users can turn the app on/off

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f13a76e88322b9bbefe35e7ffc55