### PR TITLE
feat(calendar): mark tasks done

### DIFF
--- a/Calendar.test.js
+++ b/Calendar.test.js
@@ -53,4 +53,35 @@ describe('Calendar', () => {
       expect(RbcCalendar.latestProps.events).toHaveLength(0);
     });
   });
+
+  test('adds done event when marked complete', async () => {
+    const start = new Date();
+    const end = new Date(start.getTime() + 30 * 60000);
+    localStorage.setItem(
+      'calendarEvents',
+      JSON.stringify([
+        {
+          title: 'Neck Training',
+          start: start.toISOString(),
+          end: end.toISOString(),
+          kind: 'planned',
+        },
+      ])
+    );
+
+    render(<Calendar onBack={() => {}} />);
+
+    const EventComp = RbcCalendar.latestProps.components.event;
+    render(EventComp({ event: RbcCalendar.latestProps.events[0] }));
+
+    const doneBtn = screen.getByText('✓');
+    act(() => {
+      doneBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(RbcCalendar.latestProps.events).toHaveLength(1);
+    });
+    expect(RbcCalendar.latestProps.events[0].kind).toBe('done');
+  });
 });

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -117,6 +117,14 @@
   position: relative;
 }
 
+.calendar-event-content .event-done-icon {
+  position: absolute;
+  top: 0;
+  left: 2px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
 .calendar-event-content .event-delete-icon {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- add checkmark control to calendar events for quick completion marking
- display done tasks on calendar's right side in green
- persist completed events instead of discarding them on reload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6dbe6d4f88322beee5c60a5a6a3bf