### PR TITLE
Replace checkmark span with button in CalendarEvent

### DIFF
--- a/Calendar.test.js
+++ b/Calendar.test.js
@@ -54,7 +54,7 @@ describe('Calendar', () => {
     });
   });
 
-  test('adds done event when marked complete', async () => {
+  test('renders mark done button and marks event complete on click', async () => {
     const start = new Date();
     const end = new Date(start.getTime() + 30 * 60000);
     localStorage.setItem(
@@ -74,7 +74,8 @@ describe('Calendar', () => {
     const EventComp = RbcCalendar.latestProps.components.event;
     render(EventComp({ event: RbcCalendar.latestProps.events[0] }));
 
-    const doneBtn = screen.getByText('✓');
+    const doneBtn = screen.getByRole('button', { name: /mark done/i });
+    expect(doneBtn).toBeInTheDocument();
     act(() => {
       doneBtn.click();
     });

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -16,15 +16,17 @@ function CalendarEvent({ event, onDelete, onMarkDone }) {
     <div className="calendar-event-content">
       {event.title}
       {event.kind !== "done" && (
-        <span
-          className="event-done-icon"
+        <button
+          type="button"
+          className="event-done-button"
+          aria-label="Mark done"
           onClick={(e) => {
             e.stopPropagation();
             onMarkDone(event);
           }}
         >
           ✓
-        </span>
+        </button>
       )}
       <span
         className="event-delete-icon"

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -117,12 +117,26 @@
   position: relative;
 }
 
-.calendar-event-content .event-done-icon {
+.calendar-event-content .event-done-button {
   position: absolute;
   top: 0;
   left: 2px;
+  width: 16px;
+  height: 16px;
+  padding: 0;
   font-size: 12px;
+  line-height: 1;
+  background-color: rgba(255, 255, 255, 0.7);
+  color: #000;
+  border: none;
+  border-radius: 2px;
   cursor: pointer;
+}
+
+.calendar-event-content .event-done-button:hover,
+.calendar-event-content .event-done-button:focus {
+  background-color: rgba(255, 255, 255, 0.9);
+  outline: none;
 }
 
 .calendar-event-content .event-delete-icon {


### PR DESCRIPTION
## Summary
- Improve CalendarEvent accessibility by replacing checkmark span with an aria-labeled button
- Style new mark-done button for visibility
- Test button presence and functionality

## Testing
- `npm test Calendar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6e60173f88322a64ee404511aeed9