### PR TITLE
Compare calendar events by key when marking done

### DIFF
--- a/Calendar.test.js
+++ b/Calendar.test.js
@@ -84,4 +84,36 @@ describe('Calendar', () => {
     });
     expect(RbcCalendar.latestProps.events[0].kind).toBe('done');
   });
+
+  test('removes original event when marking done with new object instance', async () => {
+    const start = new Date();
+    const end = new Date(start.getTime() + 30 * 60000);
+    localStorage.setItem(
+      'calendarEvents',
+      JSON.stringify([
+        {
+          title: 'Neck Training',
+          start: start.toISOString(),
+          end: end.toISOString(),
+          kind: 'planned',
+        },
+      ])
+    );
+
+    render(<Calendar onBack={() => {}} />);
+
+    const EventComp = RbcCalendar.latestProps.components.event;
+    const copy = { ...RbcCalendar.latestProps.events[0] };
+    render(EventComp({ event: copy }));
+
+    const doneBtn = screen.getByText('✓');
+    act(() => {
+      doneBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(RbcCalendar.latestProps.events).toHaveLength(1);
+    });
+    expect(RbcCalendar.latestProps.events[0].kind).toBe('done');
+  });
 });

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -206,7 +206,9 @@ export default function Calendar({
     const start = roundSlot(new Date());
     const end = new Date(start.getTime() + duration);
     const done = { ...event, start, end, kind: 'done', color: '#34a853' };
-    setEvents((prev) => prev.filter((ev) => ev !== event).concat(done));
+    const getKey = (e) =>
+      [e.title, new Date(e.start).getTime(), new Date(e.end).getTime()].join('|');
+    setEvents((prev) => prev.filter((ev) => getKey(ev) !== getKey(event)).concat(done));
   };
 
   const eventPropGetter = (event) => {


### PR DESCRIPTION
## Summary
- ensure Calendar's handleMarkDone removes events by comparing unique keys (title + start/end) instead of object reference
- add regression test ensuring marking done with a cloned event removes the original

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e60c6f188322ac9f9358e82a316e