### PR TITLE
Add onMoveEvent callback and tests

### DIFF
--- a/Calendar.test.js
+++ b/Calendar.test.js
@@ -84,4 +84,45 @@ describe('Calendar', () => {
     });
     expect(RbcCalendar.latestProps.events[0].kind).toBe('done');
   });
+
+  test('dragging or resizing does not throw without onMoveEvent', () => {
+    const start = new Date();
+    const end = new Date(start.getTime() + 30 * 60000);
+    localStorage.setItem(
+      'calendarEvents',
+      JSON.stringify([
+        {
+          title: 'Test',
+          start: start.toISOString(),
+          end: end.toISOString(),
+          kind: 'planned',
+        },
+      ])
+    );
+
+    render(<Calendar onBack={() => {}} />);
+    const original = RbcCalendar.latestProps.events[0];
+    const newStart = new Date(start.getTime() + 60 * 60000);
+    const newEnd = new Date(end.getTime() + 60 * 60000);
+
+    expect(() => {
+      act(() => {
+        RbcCalendar.latestProps.onEventDrop({
+          event: original,
+          start: newStart,
+          end: newEnd,
+        });
+      });
+    }).not.toThrow();
+
+    expect(() => {
+      act(() => {
+        RbcCalendar.latestProps.onEventResize({
+          event: RbcCalendar.latestProps.events[0],
+          start: newStart,
+          end: newEnd,
+        });
+      });
+    }).not.toThrow();
+  });
 });

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -39,6 +39,13 @@ function CalendarEvent({ event, onDelete, onMarkDone }) {
   );
 }
 
+/**
+ * Calendar component used throughout the app.
+ *
+ * @param {Object} props
+ * @param {Function} [props.onMoveEvent] - Callback fired when an event is moved
+ * or resized. Receives the original event followed by the updated event.
+ */
 export default function Calendar({
   onBack,
   backLabel = 'Back',
@@ -47,6 +54,7 @@ export default function Calendar({
   onExternalDrop,
   backDisabled = false,
   onDeleteEvent,
+  onMoveEvent,
 }) {
   const roundSlot = (date) => {
     const d = new Date(date);

--- a/src/DayPlanner.jsx
+++ b/src/DayPlanner.jsx
@@ -82,6 +82,26 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
     });
   };
 
+  const handleMove = (prevEvent, nextEvent) => {
+    const wasToday = isToday(prevEvent.start);
+    const isNowToday = isToday(nextEvent.start);
+    if (wasToday && !isNowToday) {
+      setCounts((prev) => {
+        const next = { ...prev };
+        if (next[prevEvent.title]) {
+          next[prevEvent.title] -= 1;
+          if (next[prevEvent.title] <= 0) delete next[prevEvent.title];
+        }
+        return next;
+      });
+    } else if (!wasToday && isNowToday) {
+      setCounts((prev) => ({
+        ...prev,
+        [nextEvent.title]: (prev[nextEvent.title] || 0) + 1,
+      }));
+    }
+  };
+
   const canStart = activities.every(
     (a) => (counts[a.title] || 0) >= (a.timesPerDay || 0)
   );
@@ -101,6 +121,7 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
             externalActivity={dragging}
             onExternalDrop={handleDrop}
             onDeleteEvent={handleDelete}
+            onMoveEvent={handleMove}
             backDisabled={!canStart}
           />
         </div>


### PR DESCRIPTION
## Summary
- expose `onMoveEvent` prop on Calendar to notify when events move or resize
- update DayPlanner to track counts when events move across days
- test drag and resize flows to avoid ReferenceError

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6e60feb188322a9c829170d808aed