### PR TITLE
Fix planner completion handling and UI

### DIFF
--- a/Calendar.test.js
+++ b/Calendar.test.js
@@ -141,9 +141,10 @@ describe('Calendar', () => {
       });
     });
 
-    const doneBtn = await screen.findByRole('button', { name: 'Done' });
+    const doneBtns = await screen.findAllByRole('button', { name: 'Done' });
+    expect(doneBtns).toHaveLength(1);
     act(() => {
-      doneBtn.click();
+      doneBtns[0].click();
     });
 
     await waitFor(() => {

--- a/DayPlanner.test.js
+++ b/DayPlanner.test.js
@@ -146,7 +146,7 @@ describe('DayPlanner', () => {
     expect(startBtn).toBeDisabled();
   });
 
-  test('marking event done decreases planned count', async () => {
+  test('marking event done keeps planned count', async () => {
     localStorage.setItem(
       'activities',
       JSON.stringify([
@@ -172,8 +172,8 @@ describe('DayPlanner', () => {
     });
     await screen.findByText('2/2');
     act(() => {
-      props.onDeleteEvent({ title: 'Neck Training', start: now, kind: 'planned' });
+      props.onDeleteEvent({ title: 'Neck Training', start: now, kind: 'done' });
     });
-    expect(await screen.findByText('1/2')).toBeInTheDocument();
+    expect(await screen.findByText('2/2')).toBeInTheDocument();
   });
 });

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -222,7 +222,6 @@ export default function Calendar({
     const start = roundSlot(new Date());
     const end = new Date(start.getTime() + duration);
     const done = { ...event, start, end, kind: 'done', color: '#34a853' };
-    if (onDeleteEvent) onDeleteEvent(event);
     setEvents((prev) =>
       prev
         .filter(

--- a/src/DayPlanner.jsx
+++ b/src/DayPlanner.jsx
@@ -55,7 +55,7 @@ export default function DayPlanner({ onComplete, backLabel = 'Start Day' }) {
     const events = JSON.parse(localStorage.getItem('calendarEvents') || '[]');
     const c = {};
     events
-      .filter((e) => e.kind === 'planned' && isToday(e.start))
+      .filter((e) => ['planned', 'done'].includes(e.kind) && isToday(e.start))
       .forEach((e) => {
         c[e.title] = (c[e.title] || 0) + 1;
       });

--- a/src/DayPlanner.test.js
+++ b/src/DayPlanner.test.js
@@ -146,7 +146,7 @@ describe('DayPlanner', () => {
     expect(startBtn).toBeDisabled();
   });
 
-  test('marking event done decreases planned count', async () => {
+  test('marking event done keeps planned count', async () => {
     localStorage.setItem(
       'activities',
       JSON.stringify([
@@ -172,8 +172,8 @@ describe('DayPlanner', () => {
     });
     await screen.findByText('2/2');
     act(() => {
-      props.onDeleteEvent({ title: 'Neck Training', start: now, kind: 'planned' });
+      props.onDeleteEvent({ title: 'Neck Training', start: now, kind: 'done' });
     });
-    expect(await screen.findByText('1/2')).toBeInTheDocument();
+    expect(await screen.findByText('2/2')).toBeInTheDocument();
   });
 });

--- a/src/EventModal.jsx
+++ b/src/EventModal.jsx
@@ -102,18 +102,19 @@ export default function EventModal({
               Delete
             </button>
           )}
-          {onDone && (
+          {onDone ? (
             <button className="done-button" onClick={() => { onDone(); onClose(); }}>
+              Done
+            </button>
+          ) : (
+            <button
+              className="save-button done-button"
+              onClick={() => { handleDone(); onClose(); }}
+            >
               Done
             </button>
           )}
           <button className="save-button" onClick={onClose}>Cancel</button>
-          <button
-            className="save-button done-button"
-            onClick={() => { handleDone(); onClose(); }}
-          >
-            Done
-          </button>
           <button className="save-button" onClick={() => { handleSave(); onClose(); }}>
             Save
           </button>

--- a/src/calendar-app.css
+++ b/src/calendar-app.css
@@ -120,7 +120,8 @@
 .calendar-event-content .event-done-button {
   position: absolute;
   top: 2px;
-  left: 2px;
+  right: 18px;
+  left: auto;
   width: 20px;
   height: 20px;
   padding: 0;


### PR DESCRIPTION
## Summary
- remove duplicate Done button in event modal and move checkmark to right of events
- ensure completed tasks still satisfy daily planner requirements
- update tests for new completion logic and single Done button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7051ffe6c8322b9f0ae7e2b6c7b70