### PR TITLE
Add dock mode overlay layout with toggle

### DIFF
--- a/src/DockLayout.jsx
+++ b/src/DockLayout.jsx
@@ -17,7 +17,7 @@ const componentMap = {
   shadowWork: { title: 'Shadow Work', component: ShadowWork },
 };
 
-export default function DockLayout() {
+export default function DockLayout({ onClose }) {
   const containerRef = useRef(null);
 
   useEffect(() => {
@@ -53,5 +53,19 @@ export default function DockLayout() {
     };
   }, []);
 
-  return <div style={{ height: '100%', width: '100%' }} ref={containerRef} />;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        zIndex: 1000,
+      }}
+    >
+      <button onClick={onClose}>Close dock</button>
+      <div style={{ height: '100%', width: '100%' }} ref={containerRef} />
+    </div>
+  );
 }

--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -5,7 +5,7 @@ import './main-page.css';
 import QuadrantMenu from './QuadrantMenu.jsx';
 import DayPlanner from './DayPlanner.jsx';
 
-export default function FifthMain({ onSelectQuadrant }) {
+export default function FifthMain({ onSelectQuadrant, onOpenDock = () => {} }) {
   const MIN_WIDTH = 253;
   const MAX_WIDTH = 523;
 
@@ -130,6 +130,7 @@ export default function FifthMain({ onSelectQuadrant }) {
 
   return (
     <div className="main-page">
+      <button onClick={onOpenDock}>Dock mode</button>
       <div className="side left" style={{ width: leftWidth }}>
         <div className="drag-handle" onMouseDown={startLeftDrag}></div>
       </div>

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -24,6 +24,7 @@ export default function PageRouter() {
     () => localStorage.getItem('menuBg') || defaultMenuBg
   );
   const [isLoading, setIsLoading] = useState(true);
+  const [dockEnabled, setDockEnabled] = useState(false);
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -155,7 +156,7 @@ export default function PageRouter() {
         <IImain
           menuBg={menuBg}
           onChangeMenuBg={setMenuBg}
-          onOpenDock={() => navigate('dock')}
+          onOpenDock={() => setDockEnabled(true)}
         />
       );
       break;
@@ -164,7 +165,7 @@ export default function PageRouter() {
         <IEmain
           menuBg={menuBg}
           onChangeMenuBg={setMenuBg}
-          onOpenDock={() => navigate('dock')}
+          onOpenDock={() => setDockEnabled(true)}
         />
       );
       break;
@@ -173,7 +174,7 @@ export default function PageRouter() {
         <EImain
           menuBg={menuBg}
           onChangeMenuBg={setMenuBg}
-          onOpenDock={() => navigate('dock')}
+          onOpenDock={() => setDockEnabled(true)}
         />
       );
       break;
@@ -182,18 +183,20 @@ export default function PageRouter() {
         <EEmain
           menuBg={menuBg}
           onChangeMenuBg={setMenuBg}
-          onOpenDock={() => navigate('dock')}
+          onOpenDock={() => setDockEnabled(true)}
         />
       );
       break;
     case 'gallery':
       content = <ImageGallery onBack={() => navigate('5th')} />;
       break;
-    case 'dock':
-      content = <DockLayout />;
-      break;
     default:
-      content = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;
+      content = (
+        <FifthMain
+          onSelectQuadrant={(label) => navigate(label)}
+          onOpenDock={() => setDockEnabled(true)}
+        />
+      );
   }
 
   return (
@@ -201,6 +204,7 @@ export default function PageRouter() {
       {isLoading && <LoadingScreen />}
       <ActivityTimer />
       {content}
+      {dockEnabled && <DockLayout onClose={() => setDockEnabled(false)} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add dock overlay support toggled from new "Dock mode" button
- overlay DockLayout has close control and covers full viewport
- wire PageRouter to manage dockEnabled state and show layout over app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b72efbab3483229b6bad3ac36a99ff