### PR TITLE
Add basic resizable dock layout

### DIFF
--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -166,7 +166,7 @@ export default function PageRouter() {
       content = <ImageGallery onBack={() => navigate('5th')} />;
       break;
     case 'dock':
-      content = <DockLayout />;
+      content = <DockLayout onExit={() => navigate('5th')} />;
       break;
     default:
       content = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;

--- a/src/dock-layout.css
+++ b/src/dock-layout.css
@@ -1,0 +1,29 @@
+.dock-layout {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  background: #111;
+  color: #eee;
+}
+
+.pane {
+  height: 100%;
+  overflow: auto;
+  padding: 10px;
+}
+
+.divider {
+  width: 5px;
+  cursor: col-resize;
+  background: #444;
+}
+
+.exit-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+}
+


### PR DESCRIPTION
## Summary
- Replace broken dock page with simple two-pane layout
- Add styles and back button for dock layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73946105083229a9d6f94650eba58