### PR TITLE
Preserve left pane when launching docked apps

### DIFF
--- a/src/dock-layout.css
+++ b/src/dock-layout.css
@@ -4,14 +4,15 @@
   height: 100%;
   display: flex;
   flex-direction: row;
-  background: #111;
+  /* Let the body wallpaper show through when docked */
+  background: transparent;
   color: #eee;
 }
 
 .pane {
   height: 100%;
   overflow: auto;
-  padding: 10px;
+  padding: 0;
 }
 
 .divider {


### PR DESCRIPTION
## Summary
- Track dock state separately so opening a docked app no longer resets the left page
- Allow navigation while docked and close the dock through Back or home events
- Render DockLayout only while docked, keeping existing left content visible
- Make DockLayout transparent so the wallpaper remains visible when split
- Remove DockLayout pane padding so the left bar stays flush when split

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9904e754c832291780d18f6c3d81b