### PR TITLE
Keep left sidebar visible while scrolling

### DIFF
--- a/main-page.css
+++ b/main-page.css
@@ -5,7 +5,7 @@ body {
 
 .main-page {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
   position: relative;
 }
 
@@ -16,6 +16,12 @@ body {
   height: 100%;
   min-width: 253px;
   max-width: 523px;
+}
+
+.side.left {
+  position: sticky;
+  top: 0;
+  height: 100vh;
 }
 
 .content-area {

--- a/src/main-page.css
+++ b/src/main-page.css
@@ -5,7 +5,7 @@ body {
 
 .main-page {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
   position: relative;
 }
 
@@ -16,6 +16,12 @@ body {
   height: 100%;
   min-width: 253px;
   max-width: 523px;
+}
+
+.side.left {
+  position: sticky;
+  top: 0;
+  height: 100vh;
 }
 
 .content-area {


### PR DESCRIPTION
## Summary
- make left sidebar sticky so it stays fixed on screen when scrolling
- use `min-height` so the sidebar remains fixed even in split screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a2c6ba9083228a5b50551d92a08e