### PR TITLE
Keep left sidebar visible while scrolling

### DIFF
--- a/FifthMain.jsx
+++ b/FifthMain.jsx
@@ -133,7 +133,7 @@ export default function FifthMain({ onSelectQuadrant }) {
       <div className="side left" style={{ width: leftWidth }}>
         <div className="drag-handle" onMouseDown={startLeftDrag}></div>
       </div>
-      <div className="content-area"></div>
+      <div className="content-area" style={{ marginLeft: leftWidth }}></div>
       <div className="side right" style={{ width: rightWidth }}>
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>

--- a/main-page.css
+++ b/main-page.css
@@ -5,7 +5,7 @@ body {
 
 .main-page {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
   position: relative;
 }
 
@@ -16,6 +16,15 @@ body {
   height: 100%;
   min-width: 253px;
   max-width: 523px;
+}
+
+.side.left {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  height: 100vh;
+  z-index: 1;
 }
 
 .content-area {

--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -133,7 +133,7 @@ export default function FifthMain({ onSelectQuadrant }) {
       <div className="side left" style={{ width: leftWidth }}>
         <div className="drag-handle" onMouseDown={startLeftDrag}></div>
       </div>
-      <div className="content-area"></div>
+      <div className="content-area" style={{ marginLeft: leftWidth }}></div>
       <div className="side right" style={{ width: rightWidth }}>
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>

--- a/src/main-page.css
+++ b/src/main-page.css
@@ -5,7 +5,7 @@ body {
 
 .main-page {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
   position: relative;
 }
 
@@ -16,6 +16,15 @@ body {
   height: 100%;
   min-width: 253px;
   max-width: 523px;
+}
+
+.side.left {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  height: 100vh;
+  z-index: 1;
 }
 
 .content-area {


### PR DESCRIPTION
## Summary
- fix left sidebar with fixed positioning so it stays anchored to the viewport
- shift main content to account for the fixed sidebar and mirror changes in `src`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a2c6ba9083228a5b50551d92a08e