### PR TITLE
Fix unclickable layer buttons on Character tab

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -57,6 +57,7 @@ body.character-page {
   display: flex;
   flex-direction: row;
   gap: 15px;
+  z-index: 1000;
 }
 
 .layer-button {

--- a/styles.css
+++ b/styles.css
@@ -42,6 +42,7 @@ body {
   flex-direction: row;
   gap: 15px;
   margin-top: 20px;
+  z-index: 1000;
 }
 
 .layer-button {


### PR DESCRIPTION
## Summary
- Ensure layer buttons sit above Character page content
- Allow clicking Form/Semi-Formless/Formless options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c6050ddc8322863c6f0e0e891c04