### PR TITLE
Add formless character layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
 import CharacterEvolve from './CharacterEvolve.jsx';
 import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
+import FormlessCharacter from './FormlessCharacter.jsx';
 import SettingsModal from './SettingsModal.jsx';
 import AkashicRecords from './AkashicRecords.jsx';
 import { supabaseClient } from './supabaseClient';
@@ -501,6 +502,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
         {activeTab === 'Character' && (
           activeLayer === 'Semi-Formless' ? (
             <SemiFormlessCharacter />
+          ) : activeLayer === 'Formless' ? (
+            <FormlessCharacter />
           ) : (
             <StatsQuadrant />
           )

--- a/src/FormlessCharacter.jsx
+++ b/src/FormlessCharacter.jsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import './formless-character.css';
+import { DEFAULT_COLORS, loadPalette, savePalette } from './colorConfig.js';
+
+export default function FormlessCharacter({ onBack }) {
+  const [colors, setColors] = useState(DEFAULT_COLORS);
+  const [editing, setEditing] = useState(false);
+
+  useEffect(() => {
+    loadPalette().then(setColors);
+  }, []);
+
+  useEffect(() => {
+    savePalette(colors);
+  }, [colors]);
+
+  const rows = [
+    {
+      formless: { colorIndex: 6 },
+      semi: { colorIndex: 5 },
+      form: { colorIndex: 4 },
+    },
+    {
+      formless: { colorIndex: 6 },
+      semi: { colorIndex: 2 },
+      form: { colorIndex: 3 },
+    },
+    {
+      formless: { colorIndex: 6 },
+      semi: { colorIndex: 0 },
+      form: { colorIndex: 1 },
+    },
+  ];
+
+  return (
+    <div className="formless-character">
+      {onBack && (
+        <button className="back-button" onClick={onBack}>
+          Back
+        </button>
+      )}
+      <div className="diagram">
+        <div className="column-labels">
+          <span>Formless</span>
+          <span>Semi-formless</span>
+          <span>Form</span>
+        </div>
+        {rows.map((r, idx) => (
+          <div key={idx} className="row">
+            <div
+              className="node circle"
+              style={{ backgroundColor: colors[r.formless.colorIndex] }}
+            />
+            <div className="arrow">▶</div>
+            <div
+              className="node circle"
+              style={{ backgroundColor: colors[r.semi.colorIndex] }}
+            />
+            <div className="arrow">▶</div>
+            <div
+              className="node circle"
+              style={{ backgroundColor: colors[r.form.colorIndex] }}
+            />
+          </div>
+        ))}
+      </div>
+      <button
+        className="color-edit-toggle"
+        onClick={() => setEditing((e) => !e)}
+      >
+        {editing ? 'Done' : 'Edit Colors'}
+      </button>
+      {editing && (
+        <div className="color-edit-list">
+          {colors.map((c, idx) => (
+            <input
+              key={idx}
+              type="color"
+              value={c}
+              onChange={(e) => {
+                const nc = [...colors];
+                nc[idx] = e.target.value;
+                setColors(nc);
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -30,6 +30,7 @@ import TodoGoals from './TodoGoals.jsx';
 import ActivityApp from './ActivityApp.jsx';
 import CharacterEvolve from './CharacterEvolve.jsx';
 import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
+import FormlessCharacter from './FormlessCharacter.jsx';
 import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
 import Orb from './Orb.jsx';
@@ -221,6 +222,7 @@ export default function PageRouter() {
       activity: <ActivityApp onBack={goBack} />,
       characterEvolve: <CharacterEvolve onBack={goBack} />,
       semiCharacter: <SemiFormlessCharacter onBack={goBack} />,
+      formlessCharacter: <FormlessCharacter onBack={goBack} />,
       ideaBoard: <IdeaBoard onBack={goBack} />,
       implementationIdeas: <ImplementationIdeas onBack={goBack} />,
       orb: <Orb onBack={goBack} />,

--- a/src/formless-character.css
+++ b/src/formless-character.css
@@ -1,0 +1,51 @@
+.formless-character {
+  padding: 20px;
+  color: #fff;
+}
+
+.formless-character .diagram {
+  width: 500px;
+  margin: 0 auto 20px;
+}
+
+.formless-character .column-labels {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+.formless-character .row {
+  display: grid;
+  grid-template-columns: 1fr 40px 1fr 40px 1fr;
+  align-items: center;
+  justify-items: center;
+  margin: 20px 0;
+}
+
+.formless-character .node {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #000;
+  text-align: center;
+}
+
+.formless-character .node.circle {
+  border-radius: 50%;
+}
+
+.formless-character .arrow {
+  color: #fff;
+  font-size: 24px;
+}
+
+.formless-character .color-edit-toggle {
+  margin-bottom: 10px;
+}
+
+.formless-character .color-edit-list input {
+  margin-right: 5px;
+}


### PR DESCRIPTION
## Summary
- add FormlessCharacter component with column layout and color palette editing
- integrate formless character view into character tab and router

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ccb984a483229515a9fe590f265d