### PR TITLE
feat: add words and sounds to library

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -39,6 +39,16 @@ export default function Library({ onBack }) {
   const dragOffset = useRef({ x: 0, y: 0 });
   const dragMoveListener = useRef(null);
 
+  const [words, setWords] = useState([]);
+  const [wordInput, setWordInput] = useState('');
+  const [sounds, setSounds] = useState([]);
+  const [soundModal, setSoundModal] = useState(null);
+  const [soundTitle, setSoundTitle] = useState('');
+  const [soundThumb, setSoundThumb] = useState(null);
+  const [soundColor, setSoundColor] = useState('');
+  const [soundTag, setSoundTag] = useState('');
+  const [activeTab, setActiveTab] = useState('all');
+
   // Load saved images from localStorage on mount
   useEffect(() => {
     const saved = localStorage.getItem('mazedImages');
@@ -51,9 +61,39 @@ export default function Library({ onBack }) {
     }
   }, []);
 
+  // Load saved words and sounds from localStorage on mount
+  useEffect(() => {
+    const savedWords = localStorage.getItem('mazedWords');
+    if (savedWords) {
+      try {
+        setWords(JSON.parse(savedWords));
+      } catch (e) {
+        console.error('Failed to parse saved words', e);
+      }
+    }
+    const savedSounds = localStorage.getItem('mazedSounds');
+    if (savedSounds) {
+      try {
+        setSounds(JSON.parse(savedSounds));
+      } catch (e) {
+        console.error('Failed to parse saved sounds', e);
+      }
+    }
+  }, []);
+
   const saveImages = (imgs) => {
     setImages(imgs);
     localStorage.setItem('mazedImages', JSON.stringify(imgs));
+  };
+
+  const saveWords = (w) => {
+    setWords(w);
+    localStorage.setItem('mazedWords', JSON.stringify(w));
+  };
+
+  const saveSounds = (s) => {
+    setSounds(s);
+    localStorage.setItem('mazedSounds', JSON.stringify(s));
   };
 
   useEffect(() => {
@@ -355,9 +395,67 @@ export default function Library({ onBack }) {
         }
       }
     }
-    if (!droppedFile || !droppedFile.type.startsWith('image/')) return;
-    await uploadToServer(droppedFile);
-    processFile(droppedFile);
+    if (!droppedFile) return;
+
+    const ext = droppedFile.name.toLowerCase().split('.').pop();
+    const soundExts = ['mp3', 'mp4', 'wav', 'aiff', 'm4a'];
+    const isSound =
+      droppedFile.type.startsWith('audio/') ||
+      droppedFile.type.startsWith('video/') ||
+      soundExts.includes(ext);
+
+    if (droppedFile.type.startsWith('image/')) {
+      uploadToServer(droppedFile);
+      processFile(droppedFile);
+    } else if (isSound) {
+      uploadToServer(droppedFile);
+      const reader = new FileReader();
+      reader.onload = () => {
+        setSoundModal(reader.result);
+        setSoundTitle(droppedFile.name.replace(/\.[^/.]+$/, ''));
+        setSoundThumb(null);
+        setSoundColor('');
+        setSoundTag('');
+      };
+      reader.readAsDataURL(droppedFile);
+    }
+  };
+
+  const handleAddWord = (e) => {
+    e.preventDefault();
+    if (!wordInput.trim()) return;
+    const newWord = { id: Date.now(), text: wordInput.trim() };
+    const updated = [...words, newWord];
+    saveWords(updated);
+    setWordInput('');
+  };
+
+  const saveDroppedSound = () => {
+    if (!soundModal) return;
+    const create = (thumbData) => {
+      const newSound = {
+        id: Date.now(),
+        title: soundTitle || 'Untitled',
+        dataUrl: soundModal,
+        thumbnail: thumbData || null,
+        color: soundColor,
+        tag: soundTag,
+      };
+      const updated = [...sounds, newSound];
+      saveSounds(updated);
+      setSoundModal(null);
+      setSoundTitle('');
+      setSoundThumb(null);
+      setSoundColor('');
+      setSoundTag('');
+    };
+    if (soundThumb) {
+      const reader2 = new FileReader();
+      reader2.onload = () => create(reader2.result);
+      reader2.readAsDataURL(soundThumb);
+    } else {
+      create(null);
+    }
   };
 
   const renderImageCard = (img, index) => {
@@ -421,12 +519,22 @@ export default function Library({ onBack }) {
             : undefined}
         onDragOver={
           sortMode !== 'title' && sortMode !== 'date'
-            ? (e) => e.preventDefault()
+            ? (e) => {
+                if (e.dataTransfer.files?.length) {
+                  handleDragOver(e);
+                } else {
+                  e.preventDefault();
+                }
+              }
             : undefined
         }
         onDrop=
           {sortMode !== 'title' && sortMode !== 'date'
             ? (e) => {
+                if (e.dataTransfer.files?.length) {
+                  handleDrop(e);
+                  return;
+                }
                 e.preventDefault();
                 const from = dragIndex.current;
                 if (from == null || from === index) {
@@ -498,7 +606,7 @@ export default function Library({ onBack }) {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      {isDragging && <div className="drop-overlay">Upload Image</div>}
+      {isDragging && <div className="drop-overlay">Upload Media</div>}
       {uploading && <div className="upload-status">Uploading…</div>}
       <div className="library-manager">
         <div className="library-header">
@@ -557,20 +665,106 @@ export default function Library({ onBack }) {
             )}
           </div>
         </div>
-        {sortMode === 'color' ? (
-          <div className="color-groups">
-            {palette.map((c) => {
-              const group = images.filter((img) => img.color === c);
-              if (!group.length) return null;
-              return (
-                <div key={c} className="color-group">
-                  <h3 className="color-title" style={{ color: c }}>
-                    {hexToName(c)}
-                  </h3>
-                  <div
-                    className="image-grid"
-                    onDragOver={(e) => e.preventDefault()}
-                    onDrop={(e) => {
+        <div className="library-tabs">
+          <button
+            className={activeTab === 'all' ? 'active' : ''}
+            onClick={() => setActiveTab('all')}
+          >
+            All
+          </button>
+          <button
+            className={activeTab === 'images' ? 'active' : ''}
+            onClick={() => setActiveTab('images')}
+          >
+            Images
+          </button>
+          <button
+            className={activeTab === 'words' ? 'active' : ''}
+            onClick={() => setActiveTab('words')}
+          >
+            Words
+          </button>
+          <button
+            className={activeTab === 'sounds' ? 'active' : ''}
+            onClick={() => setActiveTab('sounds')}
+          >
+            Sounds
+          </button>
+        </div>
+        {(activeTab === 'all' || activeTab === 'images') && (
+          sortMode === 'color' ? (
+            <div className="color-groups">
+              {palette.map((c) => {
+                const group = images.filter((img) => img.color === c);
+                if (!group.length) return null;
+                return (
+                  <div key={c} className="color-group">
+                    <h3 className="color-title" style={{ color: c }}>
+                      {hexToName(c)}
+                    </h3>
+                    <div
+                      className="image-grid"
+                      onDragOver={(e) => {
+                        if (e.dataTransfer.files?.length) {
+                          handleDragOver(e);
+                        } else {
+                          e.preventDefault();
+                        }
+                      }}
+                      onDrop={(e) => {
+                        if (e.dataTransfer.files?.length) {
+                          handleDrop(e);
+                          return;
+                        }
+                        e.preventDefault();
+                        const from = dragIndex.current;
+                        if (from == null) {
+                          resetDrag();
+                          return;
+                        }
+                        const updated = [...images];
+                        const [moved] = updated.splice(from, 1);
+                        moved.color = c;
+                        moved.title = hexToName(c);
+                        updated.push(moved);
+                        saveImages(updated);
+                        dragIndex.current = null;
+                        resetDrag();
+                      }}
+                    >
+                      {group.map((img) =>
+                        renderImageCard(
+                          img,
+                          images.findIndex((i) => i.id === img.id)
+                        )
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div
+              ref={gridRef}
+              className="image-grid"
+              onDragOver={
+                sortMode !== 'title' && sortMode !== 'date'
+                  ? (e) => {
+                      if (e.dataTransfer.files?.length) {
+                        handleDragOver(e);
+                      } else {
+                        e.preventDefault();
+                      }
+                    }
+                  : undefined
+              }
+              onDrop={
+                sortMode !== 'title' && sortMode !== 'date'
+                  ? (e) => {
+                      if (e.dataTransfer.files?.length) {
+                        handleDrop(e);
+                        return;
+                      }
                       e.preventDefault();
                       const from = dragIndex.current;
                       if (from == null) {
@@ -579,54 +773,121 @@ export default function Library({ onBack }) {
                       }
                       const updated = [...images];
                       const [moved] = updated.splice(from, 1);
-                      moved.color = c;
-                      moved.title = hexToName(c);
                       updated.push(moved);
                       saveImages(updated);
                       dragIndex.current = null;
                       resetDrag();
-                    }}
-                  >
-                    {group.map((img) =>
-                      renderImageCard(
-                        img,
-                        images.findIndex((i) => i.id === img.id)
-                      )
-                    )}
+                    }
+                  : undefined
+              }
+            >
+              {images.map((img, index) => renderImageCard(img, index))}
+            </div>
+          )
+        )}
+        {(activeTab === 'all' || activeTab === 'words') && (
+          <div className="word-section">
+            {activeTab === 'words' && (
+              <form onSubmit={handleAddWord} className="word-form">
+                <input
+                  type="text"
+                  value={wordInput}
+                  onChange={(e) => setWordInput(e.target.value)}
+                  placeholder="Add word or sentence"
+                />
+                <button type="submit">Add</button>
+              </form>
+            )}
+            <ul className="word-list">
+              {words.map((w) => (
+                <li key={w.id}>{w.text}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {(activeTab === 'all' || activeTab === 'sounds') && (
+          <div className="sound-section">
+            <div className="sound-list">
+              {sounds.map((s) => (
+                <div key={s.id} className="sound-item">
+                  {s.thumbnail && (
+                    <img
+                      src={s.thumbnail}
+                      alt={s.title}
+                      className="sound-thumb"
+                    />
+                  )}
+                  <div className="sound-meta">
+                    <div className="sound-title">
+                      {s.color && (
+                        <span
+                          className="color-dot"
+                          style={{ background: s.color }}
+                        ></span>
+                      )}
+                      {s.title}
+                    </div>
+                    {s.tag && <span className="tag">{s.tag}</span>}
+                    <audio controls src={s.dataUrl}></audio>
                   </div>
                 </div>
-              );
-            })}
+              ))}
+            </div>
           </div>
-        ) : (
-          <div
-            ref={gridRef}
-            className="image-grid"
-            onDragOver={
-              sortMode !== 'title' && sortMode !== 'date'
-                ? (e) => e.preventDefault()
-                : undefined
-            }
-            onDrop={
-              sortMode !== 'title' && sortMode !== 'date'
-                ? (e) => {
-                    e.preventDefault();
-                    const from = dragIndex.current;
-                    if (from == null) {
-                      resetDrag();
-                      return;
+        )}
+        {soundModal && (
+          <div className="sound-modal" onClick={() => setSoundModal(null)}>
+            <div
+              className="sound-modal-content"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <audio controls src={soundModal}></audio>
+              <input
+                type="text"
+                value={soundTitle}
+                onChange={(e) => setSoundTitle(e.target.value)}
+                placeholder="Title"
+              />
+              <input
+                type="file"
+                accept="image/*"
+                onChange={(e) => setSoundThumb(e.target.files[0] || null)}
+              />
+              <div className="color-list">
+                {palette.map((c, idx) => (
+                  <button
+                    key={idx}
+                    className={`color-circle${
+                      soundColor === c ? ' selected' : ''
+                    }`}
+                    style={{ background: c }}
+                    onClick={() =>
+                      setSoundColor(soundColor === c ? '' : c)
                     }
-                    const updated = [...images];
-                    const [moved] = updated.splice(from, 1);
-                    updated.push(moved);
-                    saveImages(updated);
-                    dragIndex.current = null;
-                    resetDrag();
-                  }
-                : undefined
-            }
-          >
-            {images.map((img, index) => renderImageCard(img, index))}
+                  />
+                ))}
+              </div>
+              <input
+                type="text"
+                value={soundTag}
+                onChange={(e) => setSoundTag(e.target.value)}
+                placeholder="Tag"
+              />
+              <div className="sound-modal-actions">
+                <button
+                  onClick={() => {
+                    setSoundModal(null);
+                    setSoundTitle('');
+                    setSoundThumb(null);
+                    setSoundColor('');
+                    setSoundTag('');
+                  }}
+                >
+                  Cancel
+                </button>
+                <button onClick={saveDroppedSound}>Save</button>
+              </div>
+            </div>
           </div>
         )}
         {menu && (

--- a/src/library.css
+++ b/src/library.css
@@ -198,6 +198,95 @@
   align-items: center;
 }
 
+.library-tabs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.library-tabs button {
+  background: #2a2a2d;
+  border: 1px solid #3a3a3d;
+  color: #fff;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.library-tabs button.active {
+  background: #00f0ff;
+  color: #0f0f10;
+}
+
+.word-section,
+.sound-section {
+  margin-top: 20px;
+}
+
+.word-form {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.word-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sound-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.sound-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.sound-thumb {
+  width: 50px;
+  height: 50px;
+  object-fit: cover;
+}
+
+.sound-title {
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+}
+
+.sound-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.9);
+  z-index: 1003;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sound-modal-content {
+  background: #1b1b1e;
+  padding: 20px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 300px;
+}
+
+.sound-modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
 .color-dot {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
## Summary
- hide word and sound input forms from the All tab
- add drag-and-drop sound uploads that open a metadata modal
- style audio entry modal and list entries with color and tag support
- allow dropping MP3/MP4/WAV/AIFF files anywhere in the library grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0444fa7a08322943779019ad8c163