### PR TITLE
style: make sound library cards resemble Spotify

### DIFF
--- a/src/library.css
+++ b/src/library.css
@@ -242,20 +242,52 @@
 .sound-item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 16px;
   margin-bottom: 10px;
+  background: linear-gradient(135deg, #1e1e1e, #282828);
+  color: #fff;
+  padding: 12px 16px;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sound-item:hover {
+  transform: scale(1.02);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
 }
 
 .sound-thumb {
-  width: 50px;
-  height: 50px;
+  width: 80px;
+  height: 80px;
   object-fit: cover;
+  border-radius: 8px;
+}
+
+.sound-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
 }
 
 .sound-title {
-  font-weight: bold;
+  font-weight: 600;
   display: flex;
   align-items: center;
+}
+
+.sound-item .tag {
+  align-self: flex-start;
+  background: #1db954;
+  color: #000;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.sound-item audio {
+  width: 100%;
 }
 
 .sound-modal {


### PR DESCRIPTION
## Summary
- restyle sound items with gradient, rounded layout and hover effects
- enlarge thumbnails and add green tag styling for Spotify-like look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c059473f60832285e45cf969befa38