### PR TITLE
style: make sound library cards resemble Spotify

### DIFF
--- a/src/library.css
+++ b/src/library.css
@@ -234,28 +234,72 @@
   margin: 0;
 }
 
+/* Display sounds in a responsive grid so each entry can be a square card */
 .sound-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
 }
 
+/* Style each sound entry as a vertical card */
 .sound-item {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: 12px;
+  background: linear-gradient(135deg, #1e1e1e, #282828);
+  color: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.sound-item:hover {
+  transform: scale(1.02);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+}
+
+/* Ensure thumbnails are square and fill the card width */
 .sound-thumb {
-  width: 50px;
-  height: 50px;
+  width: 100%;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
+  border-radius: 8px;
 }
 
+/* Stack meta information below the thumbnail */
+.sound-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  align-items: center;
+}
+
+/* Center the song title */
 .sound-title {
-  font-weight: bold;
+  font-weight: 600;
   display: flex;
   align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+/* Place tags below the title */
+.sound-item .tag {
+  align-self: center;
+  background: #1db954;
+  color: #000;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+/* Stretch audio controls across the card */
+.sound-item audio {
+  width: 100%;
+  margin-top: 8px;
 }
 
 .sound-modal {


### PR DESCRIPTION
## Summary
- display sound items in responsive grid with vertical cards and square thumbnails
- center metadata and stretch audio controls for Spotify-like layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c059473f60832285e45cf969befa38