### PR TITLE
Use masonry layout for library images

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -468,13 +468,11 @@ export default function Library({ onBack }) {
   };
 
   const renderImageCard = (img, index) => {
-    const displayWidth = img.width * zoom;
-    const displayHeight = img.height * zoom;
     return (
       <div
         key={img.id}
         className="image-card"
-        style={{ width: displayWidth, height: displayHeight }}
+        style={{ width: '100%' }}
         draggable={sortMode !== 'title' && sortMode !== 'date'}
         onContextMenu={(e) => {
           e.preventDefault();
@@ -713,6 +711,7 @@ export default function Library({ onBack }) {
                     </h3>
                     <div
                       className="image-grid"
+                      style={{ columnWidth: `${800 * zoom}px` }}
                       onDragOver={(e) => {
                         if (e.dataTransfer.files?.length) {
                           handleDragOver(e);
@@ -756,6 +755,7 @@ export default function Library({ onBack }) {
             <div
               ref={gridRef}
               className="image-grid"
+              style={{ columnWidth: `${800 * zoom}px` }}
               onDragOver={
                 sortMode !== 'title' && sortMode !== 'date'
                   ? (e) => {

--- a/src/library.css
+++ b/src/library.css
@@ -75,9 +75,7 @@
 }
 
 .image-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
+  column-gap: 20px;
   position: relative;
 }
 
@@ -139,8 +137,10 @@
   border: 1px solid #2a2a2d;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   transition: border 0.3s, box-shadow 0.3s;
-  flex: 0 0 auto;
   cursor: grab;
+  width: 100%;
+  break-inside: avoid;
+  margin-bottom: 20px;
 }
 
 .image-card:active {


### PR DESCRIPTION
## Summary
- Arrange Library images in a Pinterest-like masonry layout by using CSS column properties.
- Simplify image card styling so each fills its column width without fixed heights.
- Update grid containers to size columns based on zoom level.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0619c72b48322929bb217c6eded93