### PR TITLE
Use masonry layout for library images

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -34,10 +34,28 @@ export default function Library({ onBack }) {
   const [originalImages, setOriginalImages] = useState([]);
   const dragIndex = useRef(null);
   const gridRef = useRef(null);
+  const cardRefs = useRef([]);
   const dragItem = useRef(null);
   const dragPlaceholder = useRef(null);
   const dragOffset = useRef({ x: 0, y: 0 });
   const dragMoveListener = useRef(null);
+
+  const updateRowSpans = () => {
+    const rowHeight = 10;
+    const gap = 20;
+    cardRefs.current.forEach((card) => {
+      if (card) {
+        const img = card.querySelector('img');
+        if (img) {
+          const span = Math.ceil(
+            (img.getBoundingClientRect().height + gap) /
+              (rowHeight + gap)
+          );
+          card.style.gridRowEnd = `span ${span}`;
+        }
+      }
+    });
+  };
 
   const [words, setWords] = useState([]);
   const [wordInput, setWordInput] = useState('');
@@ -151,6 +169,12 @@ export default function Library({ onBack }) {
     window.addEventListener('click', close);
     return () => window.removeEventListener('click', close);
   }, []);
+
+  useEffect(() => {
+    updateRowSpans();
+    window.addEventListener('resize', updateRowSpans);
+    return () => window.removeEventListener('resize', updateRowSpans);
+  }, [images, zoom]);
 
   const deleteImage = (id) => {
     const updated = images.filter((img) => img.id !== id);
@@ -468,13 +492,12 @@ export default function Library({ onBack }) {
   };
 
   const renderImageCard = (img, index) => {
-    const displayWidth = img.width * zoom;
-    const displayHeight = img.height * zoom;
     return (
       <div
         key={img.id}
         className="image-card"
-        style={{ width: displayWidth, height: displayHeight }}
+        style={{ width: '100%' }}
+        ref={(el) => (cardRefs.current[index] = el)}
         draggable={sortMode !== 'title' && sortMode !== 'date'}
         onContextMenu={(e) => {
           e.preventDefault();
@@ -587,6 +610,7 @@ export default function Library({ onBack }) {
                 setLightbox((l) => ({ ...l, width: w, height: h }));
               }
             }
+            updateRowSpans();
           }}
           onContextMenu={(e) => {
             e.preventDefault();
@@ -713,6 +737,9 @@ export default function Library({ onBack }) {
                     </h3>
                     <div
                       className="image-grid"
+                      style={{
+                        gridTemplateColumns: `repeat(auto-fill, minmax(${800 * zoom}px, 1fr))`,
+                      }}
                       onDragOver={(e) => {
                         if (e.dataTransfer.files?.length) {
                           handleDragOver(e);
@@ -756,6 +783,9 @@ export default function Library({ onBack }) {
             <div
               ref={gridRef}
               className="image-grid"
+              style={{
+                gridTemplateColumns: `repeat(auto-fill, minmax(${800 * zoom}px, 1fr))`,
+              }}
               onDragOver={
                 sortMode !== 'title' && sortMode !== 'date'
                   ? (e) => {

--- a/src/library.css
+++ b/src/library.css
@@ -75,8 +75,9 @@
 }
 
 .image-grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-auto-rows: 10px;
+  grid-auto-flow: dense;
   gap: 20px;
   position: relative;
 }
@@ -139,8 +140,8 @@
   border: 1px solid #2a2a2d;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   transition: border 0.3s, box-shadow 0.3s;
-  flex: 0 0 auto;
   cursor: grab;
+  width: 100%;
 }
 
 .image-card:active {
@@ -150,6 +151,8 @@
 .image-card img {
   width: 100%;
   display: block;
+  max-height: 400px;
+  object-fit: cover;
   transition: transform 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- Switch Library masonry to grid-based layout that fills rows left-to-right
- Clamp oversized images with max-height and cropping for consistent cards
- Recalculate grid row spans after image load to keep masonry flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0619c72b48322929bb217c6eded93