### PR TITLE
Display sound cards alongside images in library

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -52,6 +52,29 @@ export default function Library({ onBack }) {
   const [editingSoundId, setEditingSoundId] = useState(null);
   const [soundThumbPreview, setSoundThumbPreview] = useState(null);
 
+  const calcSpan = (el) => {
+    if (!el) return;
+    const grid = gridRef.current || el.parentNode;
+    if (!grid) return;
+    const styles = getComputedStyle(grid);
+    const rowHeight = parseInt(styles.getPropertyValue('grid-auto-rows')) || 1;
+    const rowGap = parseInt(styles.getPropertyValue('row-gap')) || 0;
+    if (!rowHeight) return;
+    const span = Math.ceil(
+      (el.getBoundingClientRect().height + rowGap) /
+        (rowHeight + rowGap)
+    );
+    el.style.gridRowEnd = `span ${span}`;
+  };
+
+  const recalcSpans = () => {
+    document
+      .querySelectorAll('.image-grid')
+      .forEach((grid) =>
+        Array.from(grid.children).forEach((child) => calcSpan(child))
+      );
+  };
+
   // Load saved images from localStorage on mount
   useEffect(() => {
     const saved = localStorage.getItem('mazedImages');
@@ -102,6 +125,15 @@ export default function Library({ onBack }) {
   useEffect(() => {
     localStorage.setItem('libraryZoom', zoom);
   }, [zoom]);
+
+  useEffect(() => {
+    recalcSpans();
+  }, [images, sounds, zoom]);
+
+  useEffect(() => {
+    window.addEventListener('resize', recalcSpans);
+    return () => window.removeEventListener('resize', recalcSpans);
+  }, []);
 
   const maxZoom = 1; // max 100% of native size
 
@@ -468,19 +500,17 @@ export default function Library({ onBack }) {
   };
 
   const renderImageCard = (img, index) => {
-    const displayWidth = img.width * zoom;
-    const displayHeight = img.height * zoom;
     return (
       <div
         key={img.id}
         className="image-card"
-        style={{ width: displayWidth, height: displayHeight }}
         draggable={sortMode !== 'title' && sortMode !== 'date'}
         onContextMenu={(e) => {
           e.preventDefault();
           setMenu({ id: img.id, x: e.clientX, y: e.clientY });
         }}
         onClick={() => setLightbox(img)}
+        ref={calcSpan}
         onDragStart=
           {sortMode !== 'title' && sortMode !== 'date'
             ? (e) => {
@@ -587,6 +617,7 @@ export default function Library({ onBack }) {
                 setLightbox((l) => ({ ...l, width: w, height: h }));
               }
             }
+            calcSpan(e.target.parentNode);
           }}
           onContextMenu={(e) => {
             e.preventDefault();
@@ -606,6 +637,41 @@ export default function Library({ onBack }) {
       </div>
     );
   };
+
+  const renderSoundCard = (snd) => (
+    <div
+      key={snd.id}
+      className="image-card sound-card"
+      ref={calcSpan}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setSoundMenu({ id: snd.id, x: e.clientX, y: e.clientY });
+      }}
+    >
+      {snd.thumbnail ? (
+        <img src={snd.thumbnail} alt={snd.title} draggable={false} />
+      ) : (
+        <div className="sound-placeholder">♪</div>
+      )}
+      <div className="image-overlay">
+        <h3>
+          {snd.color && (
+            <span
+              className="color-dot"
+              style={{ background: snd.color }}
+            ></span>
+          )}
+          {snd.title}
+        </h3>
+        {snd.tag && <span className="tag">{snd.tag}</span>}
+        <audio
+          controls
+          src={snd.dataUrl}
+          className="sound-player"
+        ></audio>
+      </div>
+    </div>
+  );
 
   return (
     <div
@@ -704,8 +770,9 @@ export default function Library({ onBack }) {
           sortMode === 'color' ? (
             <div className="color-groups">
               {palette.map((c) => {
-                const group = images.filter((img) => img.color === c);
-                if (!group.length) return null;
+                const groupImgs = images.filter((img) => img.color === c);
+                  const groupSounds = sounds.filter((s) => s.color === c);
+                  if (!groupImgs.length && !groupSounds.length) return null;
                 return (
                   <div key={c} className="color-group">
                     <h3 className="color-title" style={{ color: c }}>
@@ -713,6 +780,11 @@ export default function Library({ onBack }) {
                     </h3>
                     <div
                       className="image-grid"
+                      style={{
+                        gridTemplateColumns: `repeat(auto-fill, minmax(${
+                          250 * zoom
+                        }px, 1fr))`,
+                      }}
                       onDragOver={(e) => {
                         if (e.dataTransfer.files?.length) {
                           handleDragOver(e);
@@ -741,12 +813,14 @@ export default function Library({ onBack }) {
                         resetDrag();
                       }}
                     >
-                      {group.map((img) =>
+                      {groupImgs.map((img) =>
                         renderImageCard(
                           img,
                           images.findIndex((i) => i.id === img.id)
                         )
                       )}
+                      {activeTab === 'all' &&
+                        groupSounds.map((s) => renderSoundCard(s))}
                     </div>
                   </div>
                 );
@@ -756,6 +830,11 @@ export default function Library({ onBack }) {
             <div
               ref={gridRef}
               className="image-grid"
+              style={{
+                gridTemplateColumns: `repeat(auto-fill, minmax(${
+                  250 * zoom
+                }px, 1fr))`,
+              }}
               onDragOver={
                 sortMode !== 'title' && sortMode !== 'date'
                   ? (e) => {
@@ -789,9 +868,23 @@ export default function Library({ onBack }) {
                     }
                   : undefined
               }
-            >
-              {images.map((img, index) => renderImageCard(img, index))}
-            </div>
+              >
+                {(
+                  activeTab === 'all'
+                    ? [...images.map((img) => ({ type: 'image', item: img })),
+                      ...sounds.map((s) => ({ type: 'sound', item: s }))]
+                        .sort((a, b) => a.item.id - b.item.id)
+                        .map(({ type, item }) =>
+                          type === 'image'
+                            ? renderImageCard(
+                                item,
+                                images.findIndex((i) => i.id === item.id)
+                              )
+                            : renderSoundCard(item)
+                        )
+                    : images.map((img, index) => renderImageCard(img, index))
+                )}
+              </div>
           )
         )}
         {(activeTab === 'all' || activeTab === 'words') && (
@@ -814,44 +907,17 @@ export default function Library({ onBack }) {
             </ul>
           </div>
         )}
-        {(activeTab === 'all' || activeTab === 'sounds') && (
+        {activeTab === 'sounds' && (
           <div className="sound-section">
-            <div className="sound-list">
-              {sounds.map((s) => (
-                <div
-                  key={s.id}
-                  className="sound-item"
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    setSoundMenu({ id: s.id, x: e.clientX, y: e.clientY });
-                  }}
-                >
-                  {s.thumbnail && (
-                    <img
-                      src={s.thumbnail}
-                      alt={s.title}
-                      className="sound-thumb"
-                    />
-                  )}
-                  <div className="sound-meta">
-                    <div className="sound-title">
-                      {s.color && (
-                        <span
-                          className="color-dot"
-                          style={{ background: s.color }}
-                        ></span>
-                      )}
-                      {s.title}
-                    </div>
-                    {s.tag && <span className="tag">{s.tag}</span>}
-                    <audio
-                      controls
-                      src={s.dataUrl}
-                      className="sound-player"
-                    ></audio>
-                  </div>
-                </div>
-              ))}
+            <div
+              className="image-grid"
+              style={{
+                gridTemplateColumns: `repeat(auto-fill, minmax(${
+                  250 * zoom
+                }px, 1fr))`,
+              }}
+            >
+              {sounds.map((s) => renderSoundCard(s))}
             </div>
           </div>
         )}

--- a/src/library.css
+++ b/src/library.css
@@ -75,8 +75,9 @@
 }
 
 .image-grid {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-auto-flow: dense;
+  grid-auto-rows: 10px;
   gap: 20px;
   position: relative;
 }
@@ -139,7 +140,6 @@
   border: 1px solid #2a2a2d;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
   transition: border 0.3s, box-shadow 0.3s;
-  flex: 0 0 auto;
   cursor: grab;
 }
 
@@ -149,6 +149,7 @@
 
 .image-card img {
   width: 100%;
+  height: auto;
   display: block;
   transition: transform 0.3s ease;
 }
@@ -234,74 +235,36 @@
   margin: 0;
 }
 
-/* Display sounds in a responsive grid so each entry can be a square card */
-.sound-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 20px;
-}
-
-/* Style each sound entry as a vertical card */
-.sound-item {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 12px;
-  background: linear-gradient(135deg, #1e1e1e, #282828);
-  color: #fff;
-  padding: 16px;
-  border-radius: 12px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.sound-item:hover {
-  transform: scale(1.02);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
-}
-
-/* Ensure thumbnails are square and fill the card width */
-.sound-thumb {
-  width: 100%;
+/* Sound cards mimic image cards with square aspect and overlay controls */
+.sound-card {
   aspect-ratio: 1 / 1;
-  object-fit: cover;
-  border-radius: 8px;
 }
 
-/* Stack meta information below the thumbnail */
-.sound-meta {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.sound-card img,
+.sound-placeholder {
   width: 100%;
-  align-items: flex-start;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 
-/* Center the song title */
-.sound-title {
-  font-weight: 600;
+.sound-placeholder {
+  background: #2a2a2d;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  text-align: left;
+  justify-content: center;
+  color: #777;
+  font-size: 2rem;
+}
+
+.sound-card .image-overlay {
+  display: flex;
+  flex-direction: column;
   gap: 4px;
 }
 
-/* Place tags below the title */
-.sound-item .tag {
-  align-self: flex-start;
-  background: #1db954;
-  color: #000;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 0.8rem;
-}
-
-.sound-player {
+.sound-card .sound-player {
   width: 100%;
-  margin-top: 8px;
-  background: #121212;
-  border-radius: 6px;
 }
 
 .sound-modal {


### PR DESCRIPTION
## Summary
- show images at their natural aspect ratio in the masonry grid
- render sounds as square image-style cards with hover audio controls
- use the same masonry layout for the Sounds tab
- read masonry row gap from computed styles to size image cards correctly
- blend sounds into the "All" grid and color groups so audio tiles appear alongside images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0619c72b48322929bb217c6eded93