### PR TITLE
Fix masonry layout for library images

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -74,10 +74,20 @@ export default function Library({ onBack }) {
     const rowHeight = parseInt(styles.getPropertyValue('grid-auto-rows')) || 1;
     const rowGap = parseInt(styles.getPropertyValue('row-gap')) || 0;
     if (!rowHeight) return;
-    const span = Math.ceil(
-      (el.getBoundingClientRect().height + rowGap) /
-        (rowHeight + rowGap)
-    );
+
+    const img = el.querySelector('img, .sound-placeholder');
+    if (!img) return;
+
+    let height;
+    if (img.tagName === 'IMG' && img.naturalWidth) {
+      const width = el.clientWidth || img.naturalWidth;
+      height = (img.naturalHeight / img.naturalWidth) * width;
+    } else {
+      const width = el.clientWidth;
+      height = width; // assume square for non-image placeholders
+    }
+
+    const span = Math.ceil((height + rowGap) / (rowHeight + rowGap));
     el.style.gridRowEnd = `span ${span}`;
   };
 

--- a/src/library.css
+++ b/src/library.css
@@ -152,8 +152,6 @@
   width: 100%;
   height: auto;
   display: block;
-  max-height: 400px;
-  object-fit: cover;
   transition: transform 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- compute masonry grid spans using natural image dimensions
- remove image max-height to display uncropped images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08c1a0bec832281708affaac96192