### PR TITLE
Add delete option for sounds in library

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -219,6 +219,11 @@ export default function Library({ onBack }) {
     saveImages(updated);
   };
 
+  const deleteSound = (id) => {
+    const updated = sounds.filter((s) => s.id !== id);
+    saveSounds(updated);
+  };
+
   const moveImage = (fromId, toId) => {
     const fromIndex = images.findIndex((img) => img.id === fromId);
     const toIndex = images.findIndex((img) => img.id === toId);
@@ -1063,6 +1068,14 @@ export default function Library({ onBack }) {
               }}
             >
               Edit
+            </button>
+            <button
+              onClick={() => {
+                deleteSound(soundMenu.id);
+                setSoundMenu(null);
+              }}
+            >
+              Delete
             </button>
           </div>
         )}


### PR DESCRIPTION
## Summary
- allow removing saved sounds by adding delete option to sound context menu
- persist updated sound list to localStorage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c163b82ac4832285382ebc1645e082