### PR TITLE
feat: add interactive quadrant picker to library

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -14,6 +14,40 @@ const hexToName = (hex) => {
   }
 };
 
+const QUADRANT_ORDER = ['IE', 'EE', 'II', 'EI'];
+
+function QuadrantPicker({ value = [], onChange }) {
+  const main = value[0];
+  const sub = value[1];
+  const handle = (outer, inner) => {
+    if (main === outer && sub === inner) {
+      onChange([]);
+    } else {
+      onChange([outer, inner]);
+    }
+  };
+  return (
+    <div className="quadrant-grid">
+      {QUADRANT_ORDER.map((outer) => (
+        <div
+          key={outer}
+          className={`quadrant-outer${main === outer ? ' selected' : ''}`}
+        >
+          {QUADRANT_ORDER.map((inner) => (
+            <div
+              key={outer + '-' + inner}
+              className={`quadrant-inner${
+                main === outer && sub === inner ? ' selected' : ''
+              }`}
+              onClick={() => handle(outer, inner)}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function Library({ onBack }) {
   const [images, setImages] = useState([]);
   const [isDragging, setIsDragging] = useState(false);
@@ -1096,69 +1130,28 @@ export default function Library({ onBack }) {
                     onBlur={() => updateImage(lightbox.id, { description: descInput })}
                   />
                   <div className="quad-section">
-                    <div className="quad-header">
-                      <h2>Quads</h2>
-                      {(lightbox.quadrants?.length || 0) < 2 && (
-                        <button
-                          className="add-quad-btn"
-                          onClick={() => {
-                            const nq = [...(lightbox.quadrants || []), ''];
-                            updateImage(lightbox.id, { quadrants: nq });
-                          }}
-                        >
-                          +
-                        </button>
-                      )}
-                    </div>
-                    <div className="quad-list">
-                      {(lightbox.quadrants && lightbox.quadrants.length > 0
-                        ? lightbox.quadrants
-                        : ['']
-                      ).map((q, idx) => (
-                        <select
-                          key={idx}
-                          value={q}
-                          className={`quad-select ${q ? 'quad-' + q : ''}`}
-                          onChange={(e) => {
-                            const val = e.target.value;
-                            let nq = [...(lightbox.quadrants || [])];
-                            if (val === '') {
-                              nq.splice(idx, 1);
-                            } else {
-                              nq[idx] = val;
-                            }
-                            updateImage(lightbox.id, { quadrants: nq });
-                          }}
-                        >
-                          <option value=""></option>
-                          <option value="II">II</option>
-                          <option value="IE">IE</option>
-                          <option value="EI">EI</option>
-                          <option value="EE">EE</option>
-                        </select>
-                      ))}
-                    </div>
+                    <QuadrantPicker
+                      value={lightbox.quadrants || []}
+                      onChange={(q) => updateImage(lightbox.id, { quadrants: q })}
+                    />
                   </div>
                   <div className="color-section">
-                    <h2>Colors</h2>
                     <div className="color-list">
                       {palette.map((c, idx) => (
-                        <div key={idx} className="color-entry">
-                          <button
-                            className={`color-circle${
-                              lightbox.color === c ? ' selected' : ''
-                            }`}
-                            style={{ background: c }}
-                            title={hexToName(c)}
-                            onClick={() => {
-                              const nc = lightbox.color === c ? '' : c;
-                              const updates = { color: nc };
-                              if (nc) updates.title = hexToName(nc);
-                              updateImage(lightbox.id, updates);
-                            }}
-                          />
-                          <span className="color-label">{hexToName(c)}</span>
-                        </div>
+                        <button
+                          key={idx}
+                          className={`color-circle${
+                            lightbox.color === c ? ' selected' : ''
+                          }`}
+                          style={{ background: c }}
+                          title={hexToName(c)}
+                          onClick={() => {
+                            const nc = lightbox.color === c ? '' : c;
+                            const updates = { color: nc };
+                            if (nc) updates.title = hexToName(nc);
+                            updateImage(lightbox.id, updates);
+                          }}
+                        />
                       ))}
                     </div>
                   </div>

--- a/src/library.css
+++ b/src/library.css
@@ -421,31 +421,34 @@
   margin-top: 8px;
 }
 
-.quad-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.quadrant-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
 }
 
-.quad-header h2 {
-  margin: 0;
-  font-size: 1rem;
+.quadrant-outer {
+  display: grid;
+  grid-template-columns: repeat(2, 16px);
+  grid-template-rows: repeat(2, 16px);
+  gap: 2px;
+  border: 1px solid #3a3a3d;
+  padding: 2px;
 }
 
-.add-quad-btn {
-  margin-left: auto;
-  background: #3a3a3d;
-  border: none;
-  color: #e0e0e0;
-  padding: 2px 6px;
-  border-radius: 4px;
+.quadrant-outer.selected {
+  border-color: #00f0ff;
+}
+
+.quadrant-inner {
+  width: 16px;
+  height: 16px;
+  border: 1px solid #3a3a3d;
   cursor: pointer;
 }
 
-.quad-list {
-  display: flex;
-  gap: 6px;
-  margin-top: 4px;
+.quadrant-inner.selected {
+  background: #00f0ff;
 }
 
 .color-section {
@@ -454,21 +457,9 @@
 
 .color-list {
   display: flex;
-  gap: 6px;
-  margin-top: 4px;
-}
-
-.color-entry {
-  display: flex;
   flex-direction: column;
-  align-items: center;
-}
-
-.color-label {
-  margin-top: 2px;
-  font-size: 10px;
-  text-transform: capitalize;
-  color: #e0e0e0;
+  gap: 4px;
+  margin-top: 4px;
 }
 
 .color-circle {
@@ -484,37 +475,6 @@
   box-shadow: 0 0 0 2px #00f0ff;
 }
 
-.quad-select {
-  background: #2a2a2d;
-  border: 1px solid #3a3a3d;
-  border-radius: 4px;
-  color: #e0e0e0;
-  padding: 2px 6px;
-}
-
-.quad-select option {
-  color: #e0e0e0;
-}
-
-.quad-II,
-.quad-select option[value='II'] {
-  color: #27ae60;
-}
-
-.quad-IE,
-.quad-select option[value='IE'] {
-  color: #2980b9;
-}
-
-.quad-EI,
-.quad-select option[value='EI'] {
-  color: #f1c40f;
-}
-
-.quad-EE,
-.quad-select option[value='EE'] {
-  color: #e74c3c;
-}
 
 .tag-list {
   display: flex;


### PR DESCRIPTION
## Summary
- replace dropdown quadrant tags with interactive grid selector
- streamline color palette UI and remove redundant headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b8c3c33483228821eb9455c85279