### PR TITLE
feat: add interactive quadrant picker to library

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './library.css';
 import { DEFAULT_COLORS, loadPalette } from './colorConfig.js';
 import { extractDominantColor } from './dominantColor.js';
@@ -13,6 +13,40 @@ const hexToName = (hex) => {
     return hex;
   }
 };
+
+const QUADRANT_ORDER = ['IE', 'EE', 'II', 'EI'];
+
+function QuadrantPicker({ value = [], onChange }) {
+  const main = value[0];
+  const sub = value[1];
+  const handle = (outer, inner) => {
+    if (main === outer && sub === inner) {
+      onChange([]);
+    } else {
+      onChange([outer, inner]);
+    }
+  };
+  return (
+    <div className="quadrant-grid">
+      {QUADRANT_ORDER.map((outer) => (
+        <div
+          key={outer}
+          className={`quadrant-outer${main === outer ? ' selected' : ''}`}
+        >
+          {QUADRANT_ORDER.map((inner) => (
+            <div
+              key={outer + '-' + inner}
+              className={`quadrant-inner${
+                main === outer && sub === inner ? ' selected' : ''
+              }`}
+              onClick={() => handle(outer, inner)}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function Library({ onBack }) {
   const [images, setImages] = useState([]);
@@ -33,7 +67,6 @@ export default function Library({ onBack }) {
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const [originalImages, setOriginalImages] = useState([]);
   const [draggedId, setDraggedId] = useState(null);
-  const gridRef = useRef(null);
 
   const [words, setWords] = useState([]);
   const [wordInput, setWordInput] = useState('');
@@ -48,38 +81,7 @@ export default function Library({ onBack }) {
   const [editingSoundId, setEditingSoundId] = useState(null);
   const [soundThumbPreview, setSoundThumbPreview] = useState(null);
 
-  const calcSpan = (el) => {
-    if (!el) return;
-    const grid = gridRef.current || el.parentNode;
-    if (!grid) return;
-    const styles = getComputedStyle(grid);
-    const rowHeight = parseInt(styles.getPropertyValue('grid-auto-rows')) || 1;
-    const rowGap = parseInt(styles.getPropertyValue('row-gap')) || 0;
-    if (!rowHeight) return;
-
-    const img = el.querySelector('img, .sound-placeholder');
-    if (!img) return;
-
-    let height;
-    if (img.tagName === 'IMG' && img.naturalWidth) {
-      const width = el.clientWidth || img.naturalWidth;
-      height = (img.naturalHeight / img.naturalWidth) * width;
-    } else {
-      const width = el.clientWidth;
-      height = width; // assume square for non-image placeholders
-    }
-
-    const span = Math.ceil((height + rowGap) / (rowHeight + rowGap));
-    el.style.gridRowEnd = `span ${span}`;
-  };
-
-  const recalcSpans = () => {
-    document
-      .querySelectorAll('.image-grid')
-      .forEach((grid) =>
-        Array.from(grid.children).forEach((child) => calcSpan(child))
-      );
-  };
+  // Masonry span calculations removed to keep thumbnails uniformly sized.
 
   // Load saved images from localStorage on mount
   useEffect(() => {
@@ -87,11 +89,11 @@ export default function Library({ onBack }) {
     if (saved) {
       try {
         const parsed = JSON.parse(saved);
-        setImages(
-          Array.isArray(parsed)
-            ? parsed.map((img) => ({ span: img.span || 1, ...img }))
-            : []
-        );
+          setImages(
+            Array.isArray(parsed)
+              ? parsed.map((img) => ({ ...img, span: 1 }))
+              : []
+          );
       } catch (e) {
         console.error('Failed to parse saved images', e);
       }
@@ -137,14 +139,7 @@ export default function Library({ onBack }) {
     localStorage.setItem('libraryZoom', zoom);
   }, [zoom]);
 
-  useEffect(() => {
-    recalcSpans();
-  }, [images, sounds, zoom]);
-
-  useEffect(() => {
-    window.addEventListener('resize', recalcSpans);
-    return () => window.removeEventListener('resize', recalcSpans);
-  }, []);
+    // Removed masonry recalculation hooks.
 
   const maxZoom = 1; // max 100% of native size
 
@@ -195,11 +190,7 @@ export default function Library({ onBack }) {
     return () => window.removeEventListener('click', close);
   }, []);
 
-  useEffect(() => {
-    recalcSpans();
-    window.addEventListener('resize', recalcSpans);
-    return () => window.removeEventListener('resize', recalcSpans);
-  }, [images, sounds, zoom]);
+    // Removed masonry recalculation effect.
 
   const deleteImage = (id) => {
     const updated = images.filter((img) => img.id !== id);
@@ -238,10 +229,9 @@ export default function Library({ onBack }) {
       const rawSpan = startSpan + diff / baseWidth;
       const img = images.find((i) => i.id === id);
       const maxSpan = Math.max(1, Math.ceil(img.width / baseWidth));
-      const newSpan = Math.min(maxSpan, Math.max(1, Math.round(rawSpan)));
-      resizeImage(id, newSpan);
-      recalcSpans();
-    };
+        const newSpan = Math.min(maxSpan, Math.max(1, Math.round(rawSpan)));
+        resizeImage(id, newSpan);
+      };
     const onUp = () => {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
@@ -534,18 +524,21 @@ export default function Library({ onBack }) {
     const colWidth = 250 * zoom;
     const span = img.span || 1;
     return (
-      <div
-        key={img.id}
-        className="image-card"
-        style={{ width: colWidth * span, gridColumnEnd: `span ${span}` }}
-        draggable={sortMode !== 'title' && sortMode !== 'date'}
-        onContextMenu={(e) => {
-          e.preventDefault();
-          setMenu({ id: img.id, x: e.clientX, y: e.clientY });
-        }}
-        onClick={() => setLightbox(img)}
-        ref={calcSpan}
-        onDragStart={
+        <div
+          key={img.id}
+          className="image-card"
+          style={{
+            width: colWidth * span,
+            height: colWidth * span,
+            gridColumnEnd: `span ${span}`,
+          }}
+          draggable={sortMode !== 'title' && sortMode !== 'date'}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setMenu({ id: img.id, x: e.clientX, y: e.clientY });
+          }}
+          onClick={() => setLightbox(img)}
+          onDragStart={
           sortMode !== 'title' && sortMode !== 'date'
             ? () => setDraggedId(img.id)
             : undefined
@@ -582,30 +575,29 @@ export default function Library({ onBack }) {
             : undefined
         }
       >
-        <img
-          draggable={false}
-          src={img.dataUrl}
-          alt={img.title}
-          onLoad={(e) => {
-            const w = e.target.naturalWidth;
-            const h = e.target.naturalHeight;
-            if (w !== img.width || h !== img.height) {
-              const updated = images.map((i) =>
-                i.id === img.id ? { ...i, width: w, height: h } : i
-              );
-              saveImages(updated);
-              if (lightbox && lightbox.id === img.id) {
-                setLightbox((l) => ({ ...l, width: w, height: h }));
+          <img
+            draggable={false}
+            src={img.dataUrl}
+            alt={img.title}
+            onLoad={(e) => {
+              const w = e.target.naturalWidth;
+              const h = e.target.naturalHeight;
+              if (w !== img.width || h !== img.height) {
+                const updated = images.map((i) =>
+                  i.id === img.id ? { ...i, width: w, height: h } : i
+                );
+                saveImages(updated);
+                if (lightbox && lightbox.id === img.id) {
+                  setLightbox((l) => ({ ...l, width: w, height: h }));
+                }
               }
-            }
-            calcSpan(e.target.parentNode);
-          }}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            setMenu({ id: img.id, x: e.clientX, y: e.clientY });
-          }}
-          onClick={() => setLightbox(img)}
-        />
+            }}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setMenu({ id: img.id, x: e.clientX, y: e.clientY });
+            }}
+            onClick={() => setLightbox(img)}
+          />
         <div className="image-overlay">
           <h3>
             <span
@@ -626,14 +618,13 @@ export default function Library({ onBack }) {
   };
 
   const renderSoundCard = (snd) => (
-    <div
-      key={snd.id}
-      className="image-card sound-card"
-      ref={calcSpan}
-      onContextMenu={(e) => {
-        e.preventDefault();
-        setSoundMenu({ id: snd.id, x: e.clientX, y: e.clientY });
-      }}
+      <div
+        key={snd.id}
+        className="image-card sound-card"
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setSoundMenu({ id: snd.id, x: e.clientX, y: e.clientY });
+        }}
     >
       {snd.thumbnail ? (
         <img src={snd.thumbnail} alt={snd.title} draggable={false} />
@@ -829,7 +820,6 @@ export default function Library({ onBack }) {
             </div>
           ) : (
             <div
-              ref={gridRef}
               className="image-grid"
               style={{
                 gridTemplateColumns: `repeat(auto-fill, minmax(${
@@ -1096,69 +1086,28 @@ export default function Library({ onBack }) {
                     onBlur={() => updateImage(lightbox.id, { description: descInput })}
                   />
                   <div className="quad-section">
-                    <div className="quad-header">
-                      <h2>Quads</h2>
-                      {(lightbox.quadrants?.length || 0) < 2 && (
-                        <button
-                          className="add-quad-btn"
-                          onClick={() => {
-                            const nq = [...(lightbox.quadrants || []), ''];
-                            updateImage(lightbox.id, { quadrants: nq });
-                          }}
-                        >
-                          +
-                        </button>
-                      )}
-                    </div>
-                    <div className="quad-list">
-                      {(lightbox.quadrants && lightbox.quadrants.length > 0
-                        ? lightbox.quadrants
-                        : ['']
-                      ).map((q, idx) => (
-                        <select
-                          key={idx}
-                          value={q}
-                          className={`quad-select ${q ? 'quad-' + q : ''}`}
-                          onChange={(e) => {
-                            const val = e.target.value;
-                            let nq = [...(lightbox.quadrants || [])];
-                            if (val === '') {
-                              nq.splice(idx, 1);
-                            } else {
-                              nq[idx] = val;
-                            }
-                            updateImage(lightbox.id, { quadrants: nq });
-                          }}
-                        >
-                          <option value=""></option>
-                          <option value="II">II</option>
-                          <option value="IE">IE</option>
-                          <option value="EI">EI</option>
-                          <option value="EE">EE</option>
-                        </select>
-                      ))}
-                    </div>
+                    <QuadrantPicker
+                      value={lightbox.quadrants || []}
+                      onChange={(q) => updateImage(lightbox.id, { quadrants: q })}
+                    />
                   </div>
                   <div className="color-section">
-                    <h2>Colors</h2>
                     <div className="color-list">
                       {palette.map((c, idx) => (
-                        <div key={idx} className="color-entry">
-                          <button
-                            className={`color-circle${
-                              lightbox.color === c ? ' selected' : ''
-                            }`}
-                            style={{ background: c }}
-                            title={hexToName(c)}
-                            onClick={() => {
-                              const nc = lightbox.color === c ? '' : c;
-                              const updates = { color: nc };
-                              if (nc) updates.title = hexToName(nc);
-                              updateImage(lightbox.id, updates);
-                            }}
-                          />
-                          <span className="color-label">{hexToName(c)}</span>
-                        </div>
+                        <button
+                          key={idx}
+                          className={`color-circle${
+                            lightbox.color === c ? ' selected' : ''
+                          }`}
+                          style={{ background: c }}
+                          title={hexToName(c)}
+                          onClick={() => {
+                            const nc = lightbox.color === c ? '' : c;
+                            const updates = { color: nc };
+                            if (nc) updates.title = hexToName(nc);
+                            updateImage(lightbox.id, updates);
+                          }}
+                        />
                       ))}
                     </div>
                   </div>
@@ -1190,14 +1139,13 @@ export default function Library({ onBack }) {
                     />
                   </div>
                 </div>
-              </div>
-              <div className="zoom-indicator">
-                {Math.round(lightboxZoom * 100)}%
+                <div className="zoom-indicator">
+                  {Math.round(lightboxZoom * 100)}%
+                </div>
               </div>
             </div>
           )}
         </div>
-      )}
-    </div>
-  );
-}
+      </div>
+    );
+  }

--- a/src/library.css
+++ b/src/library.css
@@ -77,7 +77,6 @@
 .image-grid {
   display: grid;
   grid-auto-flow: dense;
-  grid-auto-rows: 10px;
   gap: 20px;
   position: relative;
 }
@@ -142,6 +141,7 @@
   transition: border 0.3s, box-shadow 0.3s;
   cursor: grab;
   width: 100%;
+  aspect-ratio: 1 / 1;
 }
 
 .image-card:active {
@@ -150,7 +150,8 @@
 
 .image-card img {
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
   display: block;
   transition: transform 0.3s ease;
 }
@@ -421,31 +422,34 @@
   margin-top: 8px;
 }
 
-.quad-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.quadrant-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
 }
 
-.quad-header h2 {
-  margin: 0;
-  font-size: 1rem;
+.quadrant-outer {
+  display: grid;
+  grid-template-columns: repeat(2, 16px);
+  grid-template-rows: repeat(2, 16px);
+  gap: 2px;
+  border: 1px solid #3a3a3d;
+  padding: 2px;
 }
 
-.add-quad-btn {
-  margin-left: auto;
-  background: #3a3a3d;
-  border: none;
-  color: #e0e0e0;
-  padding: 2px 6px;
-  border-radius: 4px;
+.quadrant-outer.selected {
+  border-color: #00f0ff;
+}
+
+.quadrant-inner {
+  width: 16px;
+  height: 16px;
+  border: 1px solid #3a3a3d;
   cursor: pointer;
 }
 
-.quad-list {
-  display: flex;
-  gap: 6px;
-  margin-top: 4px;
+.quadrant-inner.selected {
+  background: #00f0ff;
 }
 
 .color-section {
@@ -454,21 +458,9 @@
 
 .color-list {
   display: flex;
-  gap: 6px;
-  margin-top: 4px;
-}
-
-.color-entry {
-  display: flex;
   flex-direction: column;
-  align-items: center;
-}
-
-.color-label {
-  margin-top: 2px;
-  font-size: 10px;
-  text-transform: capitalize;
-  color: #e0e0e0;
+  gap: 4px;
+  margin-top: 4px;
 }
 
 .color-circle {
@@ -484,37 +476,6 @@
   box-shadow: 0 0 0 2px #00f0ff;
 }
 
-.quad-select {
-  background: #2a2a2d;
-  border: 1px solid #3a3a3d;
-  border-radius: 4px;
-  color: #e0e0e0;
-  padding: 2px 6px;
-}
-
-.quad-select option {
-  color: #e0e0e0;
-}
-
-.quad-II,
-.quad-select option[value='II'] {
-  color: #27ae60;
-}
-
-.quad-IE,
-.quad-select option[value='IE'] {
-  color: #2980b9;
-}
-
-.quad-EI,
-.quad-select option[value='EI'] {
-  color: #f1c40f;
-}
-
-.quad-EE,
-.quad-select option[value='EE'] {
-  color: #e74c3c;
-}
 
 .tag-list {
   display: flex;


### PR DESCRIPTION
## Summary
- replace dropdown quadrant tags with interactive grid selector
- streamline color palette UI and remove redundant headers
- normalize library thumbnails to square dimensions
- fix lightbox closing tags so build succeeds

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b8c3c33483228821eb9455c85279