### PR TITLE
fix: normalize resource icon size

### DIFF
--- a/ResourceIcons.jsx
+++ b/ResourceIcons.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export function RIcon() {
   return (
-    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+    <svg width="24" height="24" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
       <rect width="256" height="256" fill="#D9D9D9"/>
       <rect width="256" height="256" fill="url(#pattern0_1223_127)"/>
       <defs>
@@ -17,7 +17,7 @@ export function RIcon() {
 
 export function XIcon() {
   return (
-    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
       <circle cx="128" cy="128" r="128" fill="white" />
     </svg>
   );

--- a/src/ResourceIcons.jsx
+++ b/src/ResourceIcons.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export function RIcon() {
   return (
-    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+    <svg width="24" height="24" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
       <rect width="256" height="256" fill="#D9D9D9"/>
       <rect width="256" height="256" fill="url(#pattern0_1223_127)"/>
       <defs>
@@ -17,7 +17,7 @@ export function RIcon() {
 
 export function XIcon() {
   return (
-    <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
       <circle cx="128" cy="128" r="128" fill="white" />
     </svg>
   );


### PR DESCRIPTION
## Summary
- reset resource icons to a standard 24x24 size to avoid oversized rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c413712f2083228e82d54652f1757b