### PR TITLE
Fix library image aspect ratio to keep original orientation

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -364,8 +364,8 @@ export default function Library({ onBack }) {
           quadrants: [],
           color: hex,
           dataUrl: result,
-          width: imgEl.width,
-          height: imgEl.height,
+          width: imgEl.naturalWidth,
+          height: imgEl.naturalHeight,
         };
         const updated = [...images, newImage];
         saveImages(updated);

--- a/src/library.css
+++ b/src/library.css
@@ -151,7 +151,7 @@
 .image-card img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   display: block;
   transition: transform 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- ensure newly uploaded images store natural dimensions for proper masonry layout
- display library images with `object-fit: contain` so their original aspect ratio is preserved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c42b76fa4c83228be256a38f85fe8f