### PR TITLE
Fix masonry image sizing

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -739,7 +739,7 @@ export default function Library({ onBack }) {
                         <div
                           className="image-grid"
                           style={{
-                            gridTemplateColumns: `repeat(auto-fill, minmax(${colWidth}px, 1fr))`,
+                            gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
                             gridAutoRows: `${rowHeight}px`,
                           }}
                           onDragOver={(e) => {
@@ -785,7 +785,7 @@ export default function Library({ onBack }) {
                         <div
                           className="image-grid"
                           style={{
-                            gridTemplateColumns: `repeat(auto-fill, minmax(${colWidth}px, 1fr))`,
+                            gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
                             gridAutoRows: `${rowHeight}px`,
                           }}
                         >
@@ -799,7 +799,7 @@ export default function Library({ onBack }) {
             <div
               className="image-grid"
               style={{
-                gridTemplateColumns: `repeat(auto-fill, minmax(${colWidth}px, 1fr))`,
+                gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
                 gridAutoRows: `${rowHeight}px`,
               }}
               onDragOver={
@@ -877,7 +877,7 @@ export default function Library({ onBack }) {
                   <div
                     className="image-grid"
                     style={{
-                      gridTemplateColumns: `repeat(auto-fill, minmax(${colWidth}px, 1fr))`,
+                      gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
                       gridAutoRows: `${rowHeight}px`,
                     }}
                   >


### PR DESCRIPTION
## Summary
- ensure masonry grid columns use fixed width so image cards match their aspect ratios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c576cea42c83228ac91d0c78a60ee3