### PR TITLE
Add blog shortcut to main view and revamp blog page

### DIFF
--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -106,11 +106,11 @@ export default function FifthMain({ onSelectQuadrant }) {
       if (key === 'a') {
         setMenuIndex((prev) => Math.max(0, prev - 1));
       } else if (key === 'd') {
-        setMenuIndex((prev) => Math.min(6, prev + 1));
+        setMenuIndex((prev) => Math.min(7, prev + 1));
       } else if (key === 'w') {
-        if (menuIndex >= 5) setMenuIndex((prev) => prev - 2);
+        if (menuIndex >= 6) setMenuIndex((prev) => prev - 2);
       } else if (key === 's') {
-        if (menuIndex >= 3 && menuIndex <= 4) setMenuIndex((prev) => prev + 2);
+        if (menuIndex >= 4 && menuIndex <= 5) setMenuIndex((prev) => prev + 2);
       } else if (key === 'enter') {
         if (menuIndex === 0) {
           onSelectQuadrant('library');
@@ -118,9 +118,11 @@ export default function FifthMain({ onSelectQuadrant }) {
           setShowList(true);
         } else if (menuIndex === 2) {
           setShowModal(true);
+        } else if (menuIndex === 3) {
+          onSelectQuadrant('blog');
         } else {
           const quadrants = ['II', 'IE', 'EI', 'EE'];
-          onSelectQuadrant(quadrants[menuIndex - 3]);
+          onSelectQuadrant(quadrants[menuIndex - 4]);
         }
       }
     };
@@ -138,36 +140,126 @@ export default function FifthMain({ onSelectQuadrant }) {
         <div className="drag-handle" onMouseDown={startRightDrag}></div>
       </div>
       <div className="bottom-menu">
-        <button
-          className={`side-button ${menuIndex === 0 ? 'selected' : ''}`}
-          onClick={() => onSelectQuadrant('library')}
-        >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3 7.5C3 6.67157 3.67157 6 4.5 6H19.5C20.3284 6 21 6.67157 21 7.5V16.5C21 17.3284 20.3284 18 19.5 18H4.5C3.67157 18 3 17.3284 3 16.5V7.5Z" stroke="white" strokeWidth="2"/>
-            <path d="M8 11L10.5 13.5L13.5 10.5L17 14" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        </button>
-        <button
-          className={`side-button ${menuIndex === 1 ? 'selected' : ''}`}
-          onClick={() => setShowList(true)}
-        >
-          <svg width="27" height="27" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 1L12 17M12 1H4.2002C3.08009 1 2.51962 1 2.0918 1.21799C1.71547 1.40973 1.40973 1.71547 1.21799 2.0918C1 2.51962 1 3.08009 1 4.2002V13.8002C1 14.9203 1 15.4796 1.21799 15.9074C1.40973 16.2837 1.71547 16.5905 2.0918 16.7822C2.51921 17 3.07901 17 4.19694 17L12 17M12 1H13.8002C14.9203 1 15.4796 1 15.9074 1.21799C16.2837 1.40973 16.5905 1.71547 16.7822 2.0918C17 2.5192 17 3.079 17 4.19691L17 13.8031C17 14.921 17 15.48 16.7822 15.9074C16.5905 16.2837 16.2837 16.5905 15.9074 16.7822C15.48 17 14.921 17 13.8031 17H12" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        </button>
-        <button
-          className={`side-button ${menuIndex === 2 ? 'selected' : ''}`}
-          onClick={() => setShowModal(true)}
-        >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M6.5 19H17.5C17.9647 19 18.197 18.9999 18.3902 18.9614C19.1836 18.8036 19.8036 18.1836 19.9614 17.3902C19.9999 17.197 19.9999 16.9647 19.9999 16.5C19.9999 16.0353 19.9999 15.8031 19.9614 15.6099C19.8036 14.8165 19.1836 14.1962 18.3902 14.0384C18.197 14 17.9647 14 17.5 14H6.5C6.03534 14 5.80306 14 5.60986 14.0384C4.81648 14.1962 4.19624 14.8165 4.03843 15.6099C4 15.8031 4 16.0354 4 16.5C4 16.9647 4 17.1969 4.03843 17.3901C4.19624 18.1835 4.81648 18.8036 5.60986 18.9614C5.80306 18.9999 6.03535 19 6.5 19Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            <path d="M6.5 10H17.5C17.9647 10 18.197 9.99986 18.3902 9.96143C19.1836 9.80361 19.8036 9.18356 19.9614 8.39018C19.9999 8.19698 19.9999 7.96465 19.9999 7.5C19.9999 7.03535 19.9999 6.80306 19.9614 6.60986C19.8036 5.81648 19.1836 5.19624 18.3902 5.03843C18.197 5 17.9647 5 17.5 5H6.5C6.03534 5 5.80306 5 5.60986 5.03843C4.81648 5.19624 4.19624 5.81648 4.03843 6.60986C4 6.80306 4 7.03539 4 7.50004C4 7.9647 4 8.19694 4.03843 8.39014C4.19624 9.18352 4.81648 9.80361 5.60986 9.96143C5.80306 9.99986 6.03535 10 6.5 10Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        </button>
-        <QuadrantMenu
-          onSelect={onSelectQuadrant}
-          selected={menuIndex - 3}
-        />
+        <div className="bottom-menu-section bottom-menu-left">
+          <button
+            type="button"
+            className={`side-button ${menuIndex === 0 ? 'selected' : ''}`}
+            onClick={() => onSelectQuadrant('library')}
+          >
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 7.5C3 6.67157 3.67157 6 4.5 6H19.5C20.3284 6 21 6.67157 21 7.5V16.5C21 17.3284 20.3284 18 19.5 18H4.5C3.67157 18 3 17.3284 3 16.5V7.5Z"
+                stroke="white"
+                strokeWidth="2"
+              />
+              <path
+                d="M8 11L10.5 13.5L13.5 10.5L17 14"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="bottom-menu-center">
+          <button
+            type="button"
+            className={`side-button ${menuIndex === 1 ? 'selected' : ''}`}
+            onClick={() => setShowList(true)}
+          >
+            <svg
+              width="27"
+              height="27"
+              viewBox="0 0 18 18"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 1L12 17M12 1H4.2002C3.08009 1 2.51962 1 2.0918 1.21799C1.71547 1.40973 1.40973 1.71547 1.21799 2.0918C1 2.51962 1 3.08009 1 4.2002V13.8002C1 14.9203 1 15.4796 1.21799 15.9074C1.40973 16.2837 1.71547 16.5905 2.0918 16.7822C2.51921 17 3.07901 17 4.19694 17L12 17M12 1H13.8002C14.9203 1 15.4796 1 15.9074 1.21799C16.2837 1.40973 16.5905 1.71547 16.7822 2.0918C17 2.5192 17 3.079 17 4.19691L17 13.8031C17 14.921 17 15.48 16.7822 15.9074C16.5905 16.2837 16.2837 16.5905 15.9074 16.7822C15.48 17 14.921 17 13.8031 17H12"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+          <button
+            type="button"
+            className={`side-button ${menuIndex === 2 ? 'selected' : ''}`}
+            onClick={() => setShowModal(true)}
+          >
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6.5 19H17.5C17.9647 19 18.197 18.9999 18.3902 18.9614C19.1836 18.8036 19.8036 18.1836 19.9614 17.3902C19.9999 17.197 19.9999 16.9647 19.9999 16.5C19.9999 16.0353 19.9999 15.8031 19.9614 15.6099C19.8036 14.8165 19.1836 14.1962 18.3902 14.0384C18.197 14 17.9647 14 17.5 14H6.5C6.03534 14 5.80306 14 5.60986 14.0384C4.81648 14.1962 4.19624 14.8165 4.03843 15.6099C4 15.8031 4 16.0354 4 16.5C4 16.9647 4 17.1969 4.03843 17.3901C4.19624 18.1835 4.81648 18.8036 5.60986 18.9614C5.80306 18.9999 6.03535 19 6.5 19Z"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M6.5 10H17.5C17.9647 10 18.197 9.99986 18.3902 9.96143C19.1836 9.80361 19.8036 9.18356 19.9614 8.39018C19.9999 8.19698 19.9999 7.96465 19.9999 7.5C19.9999 7.03535 19.9999 6.80306 19.9614 6.60986C19.8036 5.81648 19.1836 5.19624 18.3902 5.03843C18.197 5 17.9647 5 17.5 5H6.5C6.03534 5 5.80306 5 5.60986 5.03843C4.81648 5.19624 4.19624 5.81648 4.03843 6.60986C4 6.80306 4 7.03539 4 7.50004C4 7.9647 4 8.19694 4.03843 8.39014C4.19624 9.18352 4.81648 9.80361 5.60986 9.96143C5.80306 9.99986 6.03535 10 6.5 10Z"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+          <QuadrantMenu
+            onSelect={onSelectQuadrant}
+            selected={menuIndex >= 4 ? menuIndex - 4 : -1}
+          />
+        </div>
+        <div className="bottom-menu-section bottom-menu-right">
+          <button
+            type="button"
+            className={`side-button ${menuIndex === 3 ? 'selected' : ''}`}
+            onClick={() => onSelectQuadrant('blog')}
+          >
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4.5 4H19.5C20.3284 4 21 4.67157 21 5.5V15.5C21 16.3284 20.3284 17 19.5 17H9.41421L5 21.4142V5.5C5 4.67157 5.67157 4 6.5 4Z"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M8 8H16"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M8 11H14"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
       {showModal && <NoteModal onClose={() => setShowModal(false)} />}
       {showList && <NotesListModal onClose={() => setShowList(false)} />}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -246,6 +246,9 @@ export default function PageRouter() {
     case 'library':
       leftContent = <Library onBack={() => navigate('5th')} />;
       break;
+    case 'blog':
+      leftContent = <ToolsBlog onBack={() => navigate('5th')} />;
+      break;
     default:
       leftContent = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;
   }

--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -1,46 +1,102 @@
-import React, { useState } from 'react';
-import InfiniteScroll from 'react-infinite-scroll-component';
+import React from 'react';
 import './tools-blog.css';
 
-export default function ToolsBlog({ onBack }) {
-  const [posts, setPosts] = useState(
-    Array.from({ length: 10 }, (_, i) => ({ id: i, text: `Post #${i + 1}` }))
-  );
-  const [hasMore, setHasMore] = useState(true);
+const THEMES = [
+  'Training sync',
+  'Night shift log',
+  'Idea vault entry',
+  'Signal dispatch',
+  'Moodboard fragment',
+  'Momentum ping',
+];
 
-  const fetchMore = () => {
-    if (posts.length >= 100) {
-      setHasMore(false);
-      return;
-    }
-    setTimeout(() => {
-      setPosts((prev) =>
-        prev.concat(
-          Array.from({ length: 10 }, (_, i) => ({
-            id: prev.length + i,
-            text: `Post #${prev.length + i + 1}`,
-          }))
-        )
-      );
-    }, 300);
+const STATUSES = ['Draft', 'Incubating', 'Signal', 'Idea seed', 'Private', 'Queue'];
+
+const STREAMS = [
+  'training-layer',
+  'idea-feed',
+  'signal',
+  'night-mode',
+  'public-draft',
+  'open-loop',
+];
+
+const MOODS = ['queued', 'listening', 'charging', 'wide-awake', 'low-fi', 'signal-boost'];
+
+const MESSAGES = [
+  'We are stretching a tall canvas to host entries from the training layer. Every card you see keeps the scroll lively while we wire the live feed.',
+  'Future posts will flow in automatically once the bridge from the training layer is ready. Until then, this loop ensures the blog feels endless.',
+  'Consider this a Tumblr-style stream in rehearsal. The design will hold personal notes, drops from the dojo, and anything worth making public.',
+  'The blog will be able to flip between private and public states. These placeholder posts map out the rhythm for when the toggle arrives.',
+  'Each card hints at upcoming features: cross-posting from the training space, curated highlights, and community-ready stories.',
+  'Scroll freely — we are stress-testing the layout for long-form sessions, moodboards, and memory dumps from nightly explorations.',
+  'We want to keep the space atmospheric yet functional. Expect to pin hero entries, spotlight audio drops, and attach training artifacts soon.',
+  'Until automation is complete, treat this as a breathing storyboard for what the blog wants to become.',
+];
+
+const PLACEHOLDER_POSTS = Array.from({ length: 48 }, (_, index) => {
+  const themeIndex = index % THEMES.length;
+  const cycle = Math.floor(index / THEMES.length) + 1;
+  return {
+    id: index + 1,
+    title: `${THEMES[themeIndex]} ${String(cycle).padStart(2, '0')}`,
+    status: STATUSES[index % STATUSES.length],
+    excerpt: MESSAGES[index % MESSAGES.length],
+    stream: STREAMS[index % STREAMS.length],
+    mood: MOODS[index % MOODS.length],
   };
+});
 
+export default function ToolsBlog({ onBack }) {
   return (
-    <div className="tools-blog" id="tools-blog">
-      <button className="back-button" onClick={onBack}>Back</button>
-      <InfiniteScroll
-        dataLength={posts.length}
-        next={fetchMore}
-        hasMore={hasMore}
-        loader={<p>Loading...</p>}
-        scrollableTarget="tools-blog"
-      >
-        {posts.map((p) => (
-          <div key={p.id} className="blog-post">
-            {p.text}
+    <div className="tools-blog">
+      <header className="blog-header">
+        <div className="blog-header-top">
+          <button
+            type="button"
+            className="blog-back-button back-button"
+            onClick={onBack}
+          >
+            Back
+          </button>
+          <div className="blog-title">
+            <h1>Tumblr-style training blog</h1>
+            <p>
+              A living space for long-form drops. We are rehearsing the vibe while the
+              training layer learns to publish directly into this feed.
+            </p>
           </div>
+          <div className="blog-controls">
+            <button type="button" className="blog-pill blog-pill--active" disabled>
+              Draft mode
+            </button>
+            <button type="button" className="blog-pill" disabled>
+              Public toggle soon
+            </button>
+          </div>
+        </div>
+        <div className="blog-subcopy">
+          Scroll as far as you want — the column is intentionally deep so future
+          entries from the dojo have room to breathe.
+        </div>
+      </header>
+
+      <div className="blog-feed">
+        {PLACEHOLDER_POSTS.map((post) => (
+          <article key={post.id} className="blog-card">
+            <div className="blog-card-header">
+              <span className="blog-card-badge">{post.status}</span>
+              <span className="blog-card-index">#{String(post.id).padStart(2, '0')}</span>
+            </div>
+            <h2 className="blog-card-title">{post.title}</h2>
+            <p className="blog-card-body">{post.excerpt}</p>
+            <div className="blog-card-footer">
+              <span className="blog-card-tag">{post.stream}</span>
+              <span className="blog-card-mood">{post.mood}</span>
+            </div>
+          </article>
         ))}
-      </InfiniteScroll>
+      </div>
     </div>
   );
 }

--- a/src/main-page.css
+++ b/src/main-page.css
@@ -58,7 +58,31 @@ body {
   transform: translateX(-50%);
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  width: min(90vw, 780px);
+  padding: 0 20px;
+  box-sizing: border-box;
+  flex-wrap: wrap;
+}
+
+.bottom-menu-section {
+  display: flex;
+  align-items: center;
   gap: 15px;
+  flex: 0 0 auto;
+}
+
+.bottom-menu-section.bottom-menu-right {
+  justify-content: flex-end;
+}
+
+.bottom-menu-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+  flex: 1 1 auto;
 }
 
 .side-button {

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -1,33 +1,222 @@
 .tools-blog {
-  background: #000;
-  color: #fff;
-  height: calc(100vh - 60px);
+  background: radial-gradient(140% 140% at 50% 0%, rgba(60, 60, 60, 0.35) 0%, #040404 55%);
+  color: #f7f7fb;
+  min-height: 100vh;
   width: 100%;
   box-sizing: border-box;
-  overflow: auto;
-  padding: 20px;
-  border-radius: 0;
+  padding: 48px 24px 120px;
   display: flex;
   flex-direction: column;
-  flex: 1;
+  gap: 32px;
+  overflow-y: auto;
 }
 
-.back-button {
-  background: #222;
-  color: #fff;
-  border: none;
-  padding: 8px 12px;
-  margin-bottom: 10px;
-  cursor: pointer;
+.tools-blog::-webkit-scrollbar {
+  width: 10px;
 }
 
-.back-button:hover {
-  background: #333;
+.tools-blog::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
 }
 
-.blog-post {
-  background: #111;
-  margin-bottom: 15px;
-  padding: 15px;
-  border-radius: 6px;
+.tools-blog::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.blog-header {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.blog-header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.blog-title h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fdfdfd;
+}
+
+.blog-title p {
+  margin: 6px 0 0;
+  max-width: 520px;
+  line-height: 1.6;
+  color: #b8bbca;
+}
+
+.blog-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.blog-pill {
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ececf4;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: not-allowed;
+}
+
+.blog-pill.blog-pill--active {
+  background: #f5f5f5;
+  color: #050505;
+  border-color: transparent;
+  cursor: default;
+}
+
+.tools-blog .blog-back-button {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #f5f5f5;
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tools-blog .blog-back-button:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.blog-subcopy {
+  color: #a9adc3;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  max-width: 720px;
+}
+
+.blog-feed {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding-bottom: 40px;
+}
+
+.blog-card {
+  background: linear-gradient(165deg, rgba(30, 30, 30, 0.92), rgba(10, 10, 10, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 28px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: 0 30px 80px -50px rgba(0, 0, 0, 0.9);
+  transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.blog-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #a1a4b5;
+}
+
+.blog-card-badge {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.blog-card-index {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.blog-card-title {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #fdfdfd;
+}
+
+.blog-card-body {
+  margin: 0;
+  color: #d3d6e4;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.blog-card-footer {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: #9fa3b5;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.blog-card-footer span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.blog-card-tag::before {
+  content: '#';
+  margin-right: 4px;
+}
+
+.blog-card-mood::before {
+  content: '•';
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+@media (max-width: 900px) {
+  .tools-blog {
+    padding: 40px 18px 100px;
+  }
+
+  .blog-card {
+    border-radius: 22px;
+    padding: 28px;
+  }
+}
+
+@media (max-width: 640px) {
+  .blog-header-top {
+    align-items: flex-start;
+  }
+
+  .blog-controls {
+    justify-content: flex-start;
+  }
+
+  .blog-title h1 {
+    font-size: 1.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- add a dedicated Blog button to the Fifth Main bottom menu and wire keyboard navigation to support it
- rearrange the menu layout to mirror the Library button and keep spacing balanced
- route the new entry point to a redesigned Tumblr-style blog page with a scrolling placeholder feed
- refresh the blog styling to provide a dark, scroll-heavy canvas ready for future content

## Testing
- npm test -- FifthMain

------
https://chatgpt.com/codex/tasks/task_e_68c9533af6948322a14a0cbaf8c6a9c7