### PR TITLE
Refactor core navigation to centralized app registry

### DIFF
--- a/src/AkashicRecords.jsx
+++ b/src/AkashicRecords.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import './note-modal.css';
+import { getAppDefinition } from './config/appRegistry.jsx';
 
 export default function AkashicRecords({ onBack }) {
   const [items, setItems] = useState([]);
@@ -14,14 +15,23 @@ export default function AkashicRecords({ onBack }) {
     }
   }, []);
 
+  const enhancedItems = useMemo(
+    () =>
+      items.map((item) => ({
+        ...item,
+        title: getAppDefinition(item.id)?.title ?? item.id,
+      })),
+    [items]
+  );
+
   return (
     <div className="modal-overlay" onClick={onBack}>
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <h2>Akashic Records</h2>
         <ul className="notes-list">
-          {items.map((item) => (
+          {enhancedItems.map((item) => (
             <li key={item.id}>
-              {item.id} - {item.layer}
+              {item.title} - {item.layer}
             </li>
           ))}
         </ul>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,39 +1,36 @@
-import React, { useState, useEffect } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
-import NofapCalendar from './NofapCalendar.jsx';
-import VersionRating from './VersionRating.jsx';
-import QuestJournal from './QuestJournal.jsx';
-import WhoAmI from './WhoAmI.jsx';
-import MusicSearch from './MusicSearch.jsx';
-import Singing from './Singing.jsx';
-import ShadowWork from './ShadowWork.jsx';
-import Calendar from './Calendar.jsx';
-import Timeline from './Timeline.jsx';
-import Typomancy from './Typomancy.jsx';
-import Moodtracker from './Moodtracker.jsx';
-import Anima from './Anima.jsx';
-import ToolsBlog from './ToolsBlog.jsx';
-import MomentoMori from '../MomentoMori.jsx';
-import Watchdog from './Watchdog.jsx';
-import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
-import TodoGoals from './TodoGoals.jsx';
-import ActivityApp from './ActivityApp.jsx';
-import Orb from '../Orb.jsx';
-import IdeaBoard from './IdeaBoard.jsx';
-import ImplementationIdeas from './ImplementationIdeas.jsx';
-import CharacterEvolve from './CharacterEvolve.jsx';
+import SettingsModal from './SettingsModal.jsx';
 import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
 import FormlessCharacter from './FormlessCharacter.jsx';
-import SettingsModal from './SettingsModal.jsx';
-import AkashicRecords from './AkashicRecords.jsx';
-import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
 import ActivityLogger from './ActivityLogger.jsx';
+import { supabaseClient } from './supabaseClient.js';
+import {
+  toolApps,
+  pinnedToolApps,
+  getAppDefinition,
+  getToolAppDefinition,
+  createDefaultAppLayers,
+  isDockableApp,
+} from './config/appRegistry.jsx';
+import {
+  usePersistentState,
+  stringStorage,
+  booleanStorage,
+  jsonStorage,
+} from './hooks/usePersistentState.js';
 
 const placeholderImg =
   "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'50'%20height%3D'50'%3E%3Crect%20width%3D'50'%20height%3D'50'%20rx%3D'25'%20fill%3D'%23444'%2F%3E%3Ctext%20x%3D'25'%20y%3D'33'%20font-size%3D'26'%20text-anchor%3D'middle'%20fill%3D'%23aaa'%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E";
@@ -54,192 +51,143 @@ const layers = [
 const defaultMainBg = './assets/backgrounds/background_EI.jpg';
 const defaultCharBg = './assets/backgrounds/Viego_0.jpg';
 
+const pinnedAppIds = new Set(pinnedToolApps.map((app) => app.id));
+
 export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
+  const defaultAppLayers = useMemo(() => createDefaultAppLayers(), []);
   const [activeTab, setActiveTab] = useState(initialTab || tabs[0].label);
   const [activeLayer, setActiveLayer] = useState(layers[0].label);
-  const [showJournal, setShowJournal] = useState(false);
-  const [showNofap, setShowNofap] = useState(false);
-  const [showRatings, setShowRatings] = useState(false);
-  const [showWhoAmI, setShowWhoAmI] = useState(false);
-  const [showMusic, setShowMusic] = useState(false);
-  const [showSinging, setShowSinging] = useState(false);
-  const [showShadowWork, setShowShadowWork] = useState(false);
-  const [showCalendarApp, setShowCalendarApp] = useState(false);
-  const [showTimeline, setShowTimeline] = useState(false);
-  const [showTypomancy, setShowTypomancy] = useState(false);
-  const [showMoodtracker, setShowMoodtracker] = useState(false);
-  const [showMomentoMori, setShowMomentoMori] = useState(false);
-  const [showSemiCharacter, setShowSemiCharacter] = useState(false);
-  // Blog visibility starts hidden and becomes visible when on the Form layer.
-  // Use a unique name to avoid clashes with the top-level App component.
-  const [showToolsBlog, setShowToolsBlog] = useState(false);
-  const [showAnima, setShowAnima] = useState(false);
-  const [showBlog, setShowBlog] = useState(false);
-  const [showQuadrantComb, setShowQuadrantComb] = useState(false);
-  const [showTodoGoals, setShowTodoGoals] = useState(false);
-  const [showActivity, setShowActivity] = useState(false);
-  const [showCharacterEvolve, setShowCharacterEvolve] = useState(false);
-  const [showIdeaBoard, setShowIdeaBoard] = useState(false);
-  const [showImplementationIdeas, setShowImplementationIdeas] = useState(false);
-  const [showOrb, setShowOrb] = useState(false);
-  const [showWatchdog, setShowWatchdog] = useState(false);
-  const [showAkashicRecords, setShowAkashicRecords] = useState(false);
+  const [activeAppId, setActiveAppId] = useState(null);
+  const [contextMenu, setContextMenu] = useState(null);
+  const [selectedAppIndex, setSelectedAppIndex] = useState(-1);
+  const [sidebarIndex, setSidebarIndex] = useState(() =>
+    tabs.findIndex((tab) => tab.label === (initialTab || tabs[0].label))
+  );
   const [showProfile, setShowProfile] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [avatarUrl, setAvatarUrl] = useState(placeholderImg);
-  const [mainBg, setMainBg] = useState(
-    () => localStorage.getItem('mainBg') || defaultMainBg
+
+  const [theme, setTheme] = usePersistentState(
+    'theme',
+    () => 'dark',
+    stringStorage()
   );
-  const [charBg, setCharBg] = useState(
-    () => localStorage.getItem('charBg') || defaultCharBg
+  const [mainBg, setMainBg] = usePersistentState(
+    'mainBg',
+    () => defaultMainBg,
+    stringStorage()
+  );
+  const [charBg, setCharBg] = usePersistentState(
+    'charBg',
+    () => defaultCharBg,
+    stringStorage()
+  );
+  const [autoLog, setAutoLog] = usePersistentState(
+    'autoLog',
+    () => false,
+    booleanStorage()
+  );
+  const [rawAppLayers, setRawAppLayers] = usePersistentState(
+    'appLayers',
+    () => ({ ...defaultAppLayers }),
+    jsonStorage()
   );
 
-  const initialAppLayers = () => {
-    const defaults = {
-      journal: 'Form',
-      nofap: 'Form',
-      ratings: 'Form',
-      whoami: 'Form',
-      music: 'Form',
-      singing: 'Form',
-      shadow: 'Form',
-      calendar: 'Form',
-      timeline: 'Form',
-      typomancy: 'Form',
-      moodtracker: 'Form',
-      momentoMori: 'Form',
-      quadrantComb: 'Form',
-      anima: 'Form',
-      blog: 'Form',
-      todoGoals: 'Form',
-      activity: 'Form',
-      characterEvolve: 'Form',
-      ideaBoard: 'Form',
-      implementationIdeas: 'Form',
-      orb: 'Form',
-      watchdog: 'Form',
-    };
+  const appLayers = useMemo(
+    () => ({ ...defaultAppLayers, ...rawAppLayers }),
+    [defaultAppLayers, rawAppLayers]
+  );
 
-    const stored = localStorage.getItem('appLayers');
-    if (!stored) {
-      localStorage.setItem('appLayers', JSON.stringify(defaults));
-      return defaults;
+  useEffect(() => {
+    const merged = { ...defaultAppLayers, ...rawAppLayers };
+    const differs =
+      Object.keys(merged).length !== Object.keys(rawAppLayers).length ||
+      Object.keys(merged).some((key) => merged[key] !== rawAppLayers[key]);
+    if (differs) {
+      setRawAppLayers(merged);
     }
+  }, [defaultAppLayers, rawAppLayers, setRawAppLayers]);
 
-    try {
-      const parsed = JSON.parse(stored);
-      const merged = { ...defaults, ...parsed };
+  const cardRefs = useRef([]);
 
-      if (Object.keys(defaults).some((key) => !(key in parsed))) {
-        localStorage.setItem('appLayers', JSON.stringify(merged));
-      }
+  const handleCloseActiveApp = useCallback(() => {
+    setActiveAppId(null);
+  }, []);
 
-      return merged;
-    } catch {
-      localStorage.setItem('appLayers', JSON.stringify(defaults));
-      return defaults;
-    }
-  };
-
-  const [appLayers, setAppLayers] = useState(initialAppLayers);
-  const [contextMenu, setContextMenu] = useState(null);
-  const [autoLog, setAutoLog] = useState(
-    () => localStorage.getItem('autoLog') === 'true'
-  );
-
-  const [theme, setTheme] = useState(
-    () => localStorage.getItem('theme') || 'dark'
-  );
-
-  const [selectedAppIndex, setSelectedAppIndex] = useState(-1);
-  const [sidebarIndex, setSidebarIndex] = useState(() =>
-    tabs.findIndex((t) => t.label === (initialTab || tabs[0].label))
-  );
-
-  const anyAppOpen =
-    showJournal ||
-    showNofap ||
-    showRatings ||
-    showWhoAmI ||
-    showMusic ||
-    showSinging ||
-    showShadowWork ||
-    showCalendarApp ||
-    showTimeline ||
-    showTypomancy ||
-    showMoodtracker ||
-    showMomentoMori ||
-    showQuadrantComb ||
-    showAnima ||
-    showBlog ||
-    showTodoGoals ||
-    showActivity ||
-    showCharacterEvolve ||
-    showSemiCharacter ||
-    showIdeaBoard ||
-    showImplementationIdeas ||
-    showOrb ||
-    showWatchdog ||
-    showToolsBlog ||
-    showAkashicRecords ||
-    showProfile ||
-    showSettings;
-
-  const closeOpenApp = () => {
-    setShowJournal(false);
-    setShowNofap(false);
-    setShowRatings(false);
-    setShowWhoAmI(false);
-    setShowMusic(false);
-    setShowSinging(false);
-    setShowShadowWork(false);
-    setShowCalendarApp(false);
-    setShowTimeline(false);
-    setShowTypomancy(false);
-    setShowMoodtracker(false);
-    setShowMomentoMori(false);
-    setShowQuadrantComb(false);
-    setShowAnima(false);
-    setShowBlog(false);
-    setShowTodoGoals(false);
-    setShowActivity(false);
-    setShowCharacterEvolve(false);
-    setShowSemiCharacter(false);
-    setShowIdeaBoard(false);
-    setShowImplementationIdeas(false);
-    setShowOrb(false);
-    setShowWatchdog(false);
-    setShowToolsBlog(false);
-    setShowAkashicRecords(false);
+  const closeOpenApp = useCallback(() => {
     setShowProfile(false);
     setShowSettings(false);
-  };
+    setContextMenu(null);
+    handleCloseActiveApp();
+  }, [handleCloseActiveApp]);
+
+  const handleOpenApp = useCallback((appId) => {
+    setActiveAppId(appId);
+    setSelectedAppIndex(-1);
+    setContextMenu(null);
+  }, []);
+
+  const handleDragStart = useCallback((event, appId) => {
+    event.dataTransfer.setData('text/plain', appId);
+  }, []);
+
+  const moveAppToLayer = useCallback(
+    (appId, layerLabel) => {
+      if (!getToolAppDefinition(appId)) {
+        return;
+      }
+      setRawAppLayers((prev) => ({ ...prev, [appId]: layerLabel }));
+    },
+    [setRawAppLayers]
+  );
+
+  const handleDropOnLayer = useCallback(
+    (event, layerLabel) => {
+      event.preventDefault();
+      const appId = event.dataTransfer.getData('text/plain');
+      if (appId) {
+        moveAppToLayer(appId, layerLabel);
+      }
+    },
+    [moveAppToLayer]
+  );
+
+  const handleContextMenu = useCallback((event, appId) => {
+    event.preventDefault();
+    if (!getToolAppDefinition(appId)) {
+      return;
+    }
+    setContextMenu({
+      appId,
+      x: event.clientX,
+      y: event.clientY,
+      supportsDock: isDockableApp(appId),
+    });
+  }, []);
+
+  const handleOpenSplit = useCallback(() => {
+    if (contextMenu?.appId) {
+      window.postMessage(
+        { type: 'OPEN_SPLIT', appId: contextMenu.appId },
+        '*'
+      );
+      setContextMenu(null);
+    }
+  }, [contextMenu]);
+
+  const anyAppOpen = Boolean(activeAppId || showProfile || showSettings);
 
   useEffect(() => {
     document.body.classList.toggle('light-theme', theme === 'light');
-    localStorage.setItem('theme', theme);
   }, [theme]);
 
   useEffect(() => {
     document.body.style.setProperty('--main-bg-url', `url("${mainBg}")`);
-    localStorage.setItem('mainBg', mainBg);
   }, [mainBg]);
 
   useEffect(() => {
     document.body.style.setProperty('--char-bg-url', `url("${charBg}")`);
-    localStorage.setItem('charBg', charBg);
   }, [charBg]);
-
-  // Hide the Tools blog whenever we switch away from the Form layer
-  useEffect(() => {
-    if (activeLayer !== 'Form') {
-      setShowToolsBlog(false);
-    }
-  }, [activeLayer]);
-
-  useEffect(() => {
-    localStorage.setItem('appLayers', JSON.stringify(appLayers));
-  }, [appLayers]);
 
   useEffect(() => {
     const closeMenu = () => setContextMenu(null);
@@ -248,32 +196,121 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
-  }, [autoLog]);
+    let isMounted = true;
+
+    const loadAvatar = async () => {
+      const {
+        data: { user },
+      } = await supabaseClient.auth.getUser();
+      if (!user || !isMounted) return;
+
+      const storedPath = localStorage.getItem(`avatarPath_${user.id}`);
+      if (storedPath) {
+        const { data } = supabaseClient.storage
+          .from('avatars')
+          .getPublicUrl(storedPath);
+        if (data?.publicUrl && isMounted) {
+          setAvatarUrl(data.publicUrl);
+        }
+      }
+
+      const { data: profile } = await supabaseClient
+        .from('profiles')
+        .select('avatar_url')
+        .eq('id', user.id)
+        .single();
+
+      if (profile?.avatar_url) {
+        const { data } = supabaseClient.storage
+          .from('avatars')
+          .getPublicUrl(profile.avatar_url);
+        if (data?.publicUrl && isMounted) {
+          setAvatarUrl(data.publicUrl);
+          localStorage.setItem(`avatarPath_${user.id}`, profile.avatar_url);
+          localStorage.setItem(`avatarUrl_${user.id}`, data.publicUrl);
+        }
+      }
+    };
+
+    loadAvatar();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   useEffect(() => {
-    const handleKeyDown = (e) => {
-      const key = e.key.toLowerCase();
+    if (activeTab !== 'Tools') {
+      setSelectedAppIndex(-1);
+    }
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (anyAppOpen && selectedAppIndex !== -1) {
+      setSelectedAppIndex(-1);
+    }
+  }, [anyAppOpen, selectedAppIndex]);
+
+  useEffect(() => {
+    if (sidebarIndex < tabs.length) {
+      setActiveTab(tabs[sidebarIndex].label);
+    }
+  }, [sidebarIndex]);
+
+  const displayedCards = useMemo(() => {
+    const cards = toolApps
+      .filter((app) => appLayers[app.id] === activeLayer)
+      .map((app) => ({
+        id: app.id,
+        title: app.title,
+        icon: app.icon,
+        draggable: true,
+      }));
+
+    pinnedToolApps.forEach((app) => {
+      if (
+        app.layer === activeLayer &&
+        (!app.hideWhenActive || activeAppId !== app.id)
+      ) {
+        cards.push({
+          id: app.id,
+          title: app.title,
+          icon: app.icon,
+          draggable: false,
+        });
+      }
+    });
+
+    return cards;
+  }, [activeLayer, activeAppId, appLayers]);
+
+  useEffect(() => {
+    cardRefs.current = cardRefs.current.slice(0, displayedCards.length);
+  }, [displayedCards.length]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const key = event.key.toLowerCase();
 
       if (anyAppOpen) {
         if (key === 'escape') {
-          e.preventDefault();
+          event.preventDefault();
           closeOpenApp();
         }
         return;
       }
 
-      const totalSidebarItems = tabs.length + 3; // settings, profile, home
+      const totalSidebarItems = tabs.length + 3;
+
       if (selectedAppIndex === -1) {
         if (key === 'a') {
           setActiveLayer((prev) => {
-            const idx = layers.findIndex((l) => l.label === prev);
-            return layers[Math.max(0, idx - 1)].label;
+            const index = layers.findIndex((layer) => layer.label === prev);
+            return layers[Math.max(0, index - 1)].label;
           });
         } else if (key === 'd') {
           setActiveLayer((prev) => {
-            const idx = layers.findIndex((l) => l.label === prev);
-            return layers[Math.min(layers.length - 1, idx + 1)].label;
+            const index = layers.findIndex((layer) => layer.label === prev);
+            return layers[Math.min(layers.length - 1, index + 1)].label;
           });
         } else if (key === 'w') {
           setSidebarIndex((prev) => Math.max(0, prev - 1));
@@ -281,11 +318,11 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
           setSidebarIndex((prev) => Math.min(totalSidebarItems - 1, prev + 1));
         } else if (key === 'enter') {
           if (sidebarIndex < tabs.length) {
-            if (tabs[sidebarIndex].label === 'Tools') {
-              const cards = document.querySelectorAll('.feature-cards .app-card');
-              if (cards.length > 0) {
-                setSelectedAppIndex(0);
-              }
+            if (
+              tabs[sidebarIndex].label === 'Tools' &&
+              displayedCards.length > 0
+            ) {
+              setSelectedAppIndex(0);
             }
           } else {
             const actionIdx = sidebarIndex - tabs.length;
@@ -298,153 +335,145 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
             }
           }
         }
-      } else {
-        const cards = Array.from(
-          document.querySelectorAll('.feature-cards .app-card')
-        );
-        const currentRect = cards[selectedAppIndex].getBoundingClientRect();
-        const cx = currentRect.left + currentRect.width / 2;
-        const cy = currentRect.top + currentRect.height / 2;
+        return;
+      }
 
-        const moveSelection = (dir) => {
-          let best = selectedAppIndex;
-          let bestDist = Infinity;
-          cards.forEach((card, idx) => {
-            if (idx === selectedAppIndex) return;
-            const rect = card.getBoundingClientRect();
-            const x = rect.left + rect.width / 2;
-            const y = rect.top + rect.height / 2;
-            let valid = false;
-            if (dir === 'left') valid = x < cx - 5;
-            if (dir === 'right') valid = x > cx + 5;
-            if (dir === 'up') valid = y < cy - 5;
-            if (dir === 'down') valid = y > cy + 5;
-            if (valid) {
-              const dx = cx - x;
-              const dy = cy - y;
-              const dist = dx * dx + dy * dy;
-              if (dist < bestDist) {
-                bestDist = dist;
-                best = idx;
-              }
+      const cards = cardRefs.current.filter(Boolean);
+      if (!cards.length) {
+        setSelectedAppIndex(-1);
+        return;
+      }
+
+      const clampedIndex = Math.min(selectedAppIndex, cards.length - 1);
+      if (clampedIndex !== selectedAppIndex) {
+        setSelectedAppIndex(clampedIndex);
+      }
+
+      const currentCard = cards[clampedIndex];
+      if (!currentCard) {
+        setSelectedAppIndex(-1);
+        return;
+      }
+
+      const currentRect = currentCard.getBoundingClientRect();
+      const cx = currentRect.left + currentRect.width / 2;
+      const cy = currentRect.top + currentRect.height / 2;
+
+      const findNearest = (direction) => {
+        let bestIndex = clampedIndex;
+        let bestDistance = Infinity;
+
+        cards.forEach((card, index) => {
+          if (index === clampedIndex) return;
+          const rect = card.getBoundingClientRect();
+          const x = rect.left + rect.width / 2;
+          const y = rect.top + rect.height / 2;
+
+          let isCandidate = false;
+          if (direction === 'left') isCandidate = x < cx - 5;
+          if (direction === 'right') isCandidate = x > cx + 5;
+          if (direction === 'up') isCandidate = y < cy - 5;
+          if (direction === 'down') isCandidate = y > cy + 5;
+
+          if (isCandidate) {
+            const dx = cx - x;
+            const dy = cy - y;
+            const distance = dx * dx + dy * dy;
+            if (distance < bestDistance) {
+              bestDistance = distance;
+              bestIndex = index;
             }
-          });
-          setSelectedAppIndex(best);
-        };
+          }
+        });
 
-        if (key === 'a') moveSelection('left');
-        else if (key === 'd') moveSelection('right');
-        else if (key === 'w') moveSelection('up');
-        else if (key === 's') moveSelection('down');
-        else if (key === 'enter') {
-          cards[selectedAppIndex]?.click();
-          setSelectedAppIndex(-1);
-        } else if (key === 'escape') {
-          e.preventDefault();
-          setSelectedAppIndex(-1);
+        return bestIndex;
+      };
+
+      if (key === 'a') {
+        setSelectedAppIndex(findNearest('left'));
+      } else if (key === 'd') {
+        setSelectedAppIndex(findNearest('right'));
+      } else if (key === 'w') {
+        setSelectedAppIndex(findNearest('up'));
+      } else if (key === 's') {
+        setSelectedAppIndex(findNearest('down'));
+      } else if (key === 'enter') {
+        const card = displayedCards[clampedIndex];
+        if (card) {
+          handleOpenApp(card.id);
         }
+      } else if (key === 'escape') {
+        event.preventDefault();
+        setSelectedAppIndex(-1);
       }
     };
+
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [activeTab, anyAppOpen, selectedAppIndex, closeOpenApp, sidebarIndex]);
+  }, [
+    anyAppOpen,
+    closeOpenApp,
+    displayedCards,
+    handleOpenApp,
+    selectedAppIndex,
+    sidebarIndex,
+  ]);
 
   useEffect(() => {
-    if (sidebarIndex < tabs.length) {
-      setActiveTab(tabs[sidebarIndex].label);
+    if (selectedAppIndex >= displayedCards.length) {
+      setSelectedAppIndex(displayedCards.length ? displayedCards.length - 1 : -1);
     }
-  }, [sidebarIndex]);
+  }, [displayedCards.length, selectedAppIndex]);
 
-  useEffect(() => {
-    if (activeTab !== 'Tools' || anyAppOpen) {
-      setSelectedAppIndex(-1);
+  const activeDefinition = useMemo(
+    () => (activeAppId ? getAppDefinition(activeAppId) : null),
+    [activeAppId]
+  );
+
+  const activeAppElement = useMemo(() => {
+    if (!activeDefinition) {
+      return null;
     }
-  }, [activeTab, anyAppOpen]);
+    return activeDefinition.render({ onClose: handleCloseActiveApp });
+  }, [activeDefinition, handleCloseActiveApp]);
 
-  useEffect(() => {
-    const cards = document.querySelectorAll('.feature-cards .app-card');
-    cards.forEach((card, idx) => {
-      card.classList.toggle('selected', idx === selectedAppIndex);
-    });
-  }, [selectedAppIndex, activeTab, activeLayer]);
+  const isInlineApp =
+    activeAppId &&
+    (getToolAppDefinition(activeAppId) !== null || pinnedAppIds.has(activeAppId));
 
-  useEffect(() => {
-    const loadAvatar = async () => {
-      const {
-        data: { user },
-      } = await supabaseClient.auth.getUser();
-      if (!user) return;
+  const inlineAppContent = isInlineApp ? activeAppElement : null;
+  const floatingAppContent = !isInlineApp ? activeAppElement : null;
 
-      const storedPath = localStorage.getItem(`avatarPath_${user.id}`);
-      if (storedPath) {
-        const { data } = supabaseClient.storage.from('avatars').getPublicUrl(storedPath);
-        setAvatarUrl(data.publicUrl);
-      }
-
-      const { data: profile } = await supabaseClient
-        .from('profiles')
-        .select('avatar_url')
-        .eq('id', user.id)
-        .single();
-      if (profile?.avatar_url) {
-        const { data } = supabaseClient.storage
-          .from('avatars')
-          .getPublicUrl(profile.avatar_url);
-        setAvatarUrl(data.publicUrl);
-        localStorage.setItem(`avatarPath_${user.id}`, profile.avatar_url);
-        localStorage.setItem(`avatarUrl_${user.id}`, data.publicUrl);
-      }
-    };
-    loadAvatar();
+  const handleAvatarUpdated = useCallback((_path, url) => {
+    setAvatarUrl(url);
   }, []);
 
-  const handleAvatarUpdated = (_path, url) => {
-    setAvatarUrl(url);
-  };
+  const renderCard = (card, index) => {
+    const Icon = card.icon;
+    const isSelected = selectedAppIndex === index;
+    const isToolApp = getToolAppDefinition(card.id) !== null;
 
-  const moveAppToLayer = (appId, layerLabel) => {
-    setAppLayers((prev) => ({ ...prev, [appId]: layerLabel }));
-  };
-
-  const handleDragStart = (e, appId) => {
-    e.dataTransfer.setData('text/plain', appId);
-  };
-
-  const handleDropOnLayer = (e, layerLabel) => {
-    e.preventDefault();
-    const appId = e.dataTransfer.getData('text/plain');
-    if (appId) moveAppToLayer(appId, layerLabel);
-  };
-
-  const handleContextMenu = (e, appId) => {
-    e.preventDefault();
-    setContextMenu({ appId, x: e.clientX, y: e.clientY });
-  };
-
-  const handleOpenSplit = () => {
-    if (contextMenu) {
-      window.postMessage({ type: 'OPEN_SPLIT', appId: contextMenu.appId }, '*');
-      setContextMenu(null);
-    }
-  };
-
-  if (showCalendarApp) {
     return (
-      <QuestProvider>
-        <ActivityLogger enabled={autoLog} />
-        <Calendar onBack={() => setShowCalendarApp(false)} />
-      </QuestProvider>
+      <div
+        key={card.id}
+        ref={(element) => {
+          cardRefs.current[index] = element;
+        }}
+        className={`app-card ${isSelected ? 'selected' : ''}`}
+        onClick={() => handleOpenApp(card.id)}
+        onContextMenu={
+          isToolApp ? (event) => handleContextMenu(event, card.id) : undefined
+        }
+        draggable={isToolApp}
+        onDragStart={
+          isToolApp ? (event) => handleDragStart(event, card.id) : undefined
+        }
+      >
+        <Icon />
+        <span>{card.title}</span>
+      </div>
     );
-  }
-
-  if (showAkashicRecords) {
-    return (
-      <QuestProvider>
-        <ActivityLogger enabled={autoLog} />
-        <AkashicRecords onBack={() => setShowAkashicRecords(false)} />
-      </QuestProvider>
-    );
-  }
+  };
 
   return (
     <QuestProvider>
@@ -456,456 +485,162 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <div
                 key={layer.label}
                 title={layer.label}
-                className={`layer-button ${activeLayer === layer.label ? 'active' : ''}`}
+                className={`layer-button ${
+                  activeLayer === layer.label ? 'active' : ''
+                }`}
                 style={{ backgroundColor: layer.color }}
                 onClick={() => setActiveLayer(layer.label)}
-                onDragOver={(e) => e.preventDefault()}
-                onDrop={(e) => handleDropOnLayer(e, layer.label)}
+                onDragOver={(event) => event.preventDefault()}
+                onDrop={(event) => handleDropOnLayer(event, layer.label)}
               />
             ))}
           </div>
           <div className="bottom-buttons">
-          <div
-            className={`settings-button ${sidebarIndex === tabs.length ? 'selected' : ''}`}
-            onClick={() => {
-              setShowSettings(true);
-              setSidebarIndex(tabs.length);
-            }}
-          >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M13.6006 21.0761L19.0608 17.9236C19.6437 17.5871 19.9346 17.4188 20.1465 17.1834C20.3341 16.9751 20.4759 16.7297 20.5625 16.4632C20.6602 16.1626 20.6602 15.8267 20.6602 15.1568V8.84268C20.6602 8.17277 20.6602 7.83694 20.5625 7.53638C20.4759 7.26982 20.3341 7.02428 20.1465 6.816C19.9355 6.58161 19.6453 6.41405 19.0674 6.08043L13.5996 2.92359C13.0167 2.58706 12.7259 2.41913 12.416 2.35328C12.1419 2.295 11.8584 2.295 11.5843 2.35328C11.2744 2.41914 10.9826 2.58706 10.3997 2.92359L4.93843 6.07666C4.35623 6.41279 4.06535 6.58073 3.85352 6.816C3.66597 7.02428 3.52434 7.26982 3.43773 7.53638C3.33984 7.83765 3.33984 8.17436 3.33984 8.84742V15.1524C3.33984 15.8254 3.33984 16.1619 3.43773 16.4632C3.52434 16.7297 3.66597 16.9751 3.85352 17.1834C4.06548 17.4188 4.35657 17.5871 4.93945 17.9236L10.3997 21.0761C10.9826 21.4126 11.2744 21.5806 11.5843 21.6465C11.8584 21.7047 12.1419 21.7047 12.416 21.6465C12.7259 21.5806 13.0177 21.4126 13.6006 21.0761Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              <path d="M9 11.9998C9 13.6566 10.3431 14.9998 12 14.9998C13.6569 14.9998 15 13.6566 15 11.9998C15 10.3429 13.6569 8.99976 12 8.99976C10.3431 8.99976 9 10.3429 9 11.9998Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
+            <div
+              className={`settings-button ${
+                sidebarIndex === tabs.length ? 'selected' : ''
+              }`}
+              onClick={() => {
+                setShowSettings(true);
+                setSidebarIndex(tabs.length);
+              }}
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M13.6006 21.0761L19.0608 17.9236C19.6437 17.5871 19.9346 17.4188 20.1465 17.1834C20.3341 16.9751 20.4759 16.7297 20.5625 16.4632C20.6602 16.1626 20.6602 15.8267 20.6602 15.1568V8.84268C20.6602 8.17277 20.6602 7.83694 20.5625 7.53638C20.4759 7.26982 20.3341 7.02428 20.1465 6.816C19.9355 6.58161 19.6453 6.41405 19.0674 6.08043L13.5996 2.92359C13.0167 2.58706 12.7259 2.41913 12.416 2.35328C12.1419 2.295 11.8584 2.295 11.5843 2.35328C11.2744 2.41914 10.9826 2.58706 10.3997 2.92359L4.93843 6.07666C4.35623 6.41279 4.06535 6.58073 3.85352 6.816C3.66597 7.02428 3.52434 7.26982 3.43773 7.53638C3.33984 7.83765 3.33984 8.17436 3.33984 8.84742V15.1524C3.33984 15.8254 3.33984 16.1619 3.43773 16.4632C3.52434 16.7297 3.66597 16.9751 3.85352 17.1834C4.06548 17.4188 4.35657 17.5871 4.93945 17.9236L10.3997 21.0761C10.9826 21.4126 11.2744 21.5806 11.5843 21.6465C11.8584 21.7047 12.1419 21.7047 12.416 21.6465C12.7259 21.5806 13.0177 21.4126 13.6006 21.0761Z"
+                  stroke="white"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M9 11.9998C9 13.6566 10.3431 14.9998 12 14.9998C13.6569 14.9998 15 13.6566 15 11.9998C15 10.3429 13.6569 8.99976 12 8.99976C10.3431 8.99976 9 10.3429 9 11.9998Z"
+                  stroke="white"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            <div
+              className={`profile-button ${
+                sidebarIndex === tabs.length + 1 ? 'selected' : ''
+              }`}
+              onClick={() => {
+                setShowProfile(true);
+                setSidebarIndex(tabs.length + 1);
+              }}
+            >
+              <img className="sidebar-avatar" src={avatarUrl} alt="Profile" />
+            </div>
+            <div
+              className={`home-button ${
+                sidebarIndex === tabs.length + 2 ? 'selected' : ''
+              }`}
+              onClick={() => {
+                window.location.reload();
+                setSidebarIndex(tabs.length + 2);
+              }}
+            >
+              🏠
+            </div>
           </div>
-          <div
-            className={`profile-button ${sidebarIndex === tabs.length + 1 ? 'selected' : ''}`}
-            onClick={() => {
-              setShowProfile(true);
-              setSidebarIndex(tabs.length + 1);
-            }}
-          >
-            <img className="sidebar-avatar" src={avatarUrl} alt="Profile" />
-          </div>
-          <div
-            className={`home-button ${sidebarIndex === tabs.length + 2 ? 'selected' : ''}`}
-            onClick={() => {
-              window.location.reload();
-              setSidebarIndex(tabs.length + 2);
-            }}
-          >
-            🏠
-          </div>
-        </div>
         </aside>
         <div className="content">
           <h1>{activeTab}</h1>
-        {activeTab === 'Character' && (
-          activeLayer === 'Semi-Formless' ? (
-            <SemiFormlessCharacter />
-          ) : activeLayer === 'Formless' ? (
-            <FormlessCharacter />
-          ) : (
-            <StatsQuadrant />
-          )
-        )}
-        {activeTab === 'Tools' && (
-          <div className="tools-layout">
-            {showJournal ? (
-              <QuestJournal onBack={() => setShowJournal(false)} />
-            ) : showNofap ? (
-              <NofapCalendar onBack={() => setShowNofap(false)} />
-            ) : showRatings ? (
-              <VersionRating onBack={() => setShowRatings(false)} />
-            ) : showWhoAmI ? (
-              <WhoAmI onBack={() => setShowWhoAmI(false)} />
-            ) : showMusic ? (
-              <MusicSearch onBack={() => setShowMusic(false)} />
-            ) : showSinging ? (
-              <Singing onBack={() => setShowSinging(false)} />
-            ) : showShadowWork ? (
-              <ShadowWork onBack={() => setShowShadowWork(false)} />
-            ) : showCalendarApp ? (
-              <Calendar onBack={() => setShowCalendarApp(false)} />
-            ) : showTimeline ? (
-              <Timeline onBack={() => setShowTimeline(false)} />
-            ) : showTypomancy ? (
-              <Typomancy onBack={() => setShowTypomancy(false)} />
-            ) : showMoodtracker ? (
-              <Moodtracker onBack={() => setShowMoodtracker(false)} />
-            ) : showMomentoMori ? (
-              <MomentoMori onBack={() => setShowMomentoMori(false)} />
-            ) : showQuadrantComb ? (
-              <QuadrantCombinaisons onBack={() => setShowQuadrantComb(false)} />
-            ) : showAnima ? (
-              <Anima onBack={() => setShowAnima(false)} />
-            ) : showBlog ? (
-              <ToolsBlog onBack={() => setShowBlog(false)} />
-            ) : showTodoGoals ? (
-              <TodoGoals onBack={() => setShowTodoGoals(false)} />
-            ) : showActivity ? (
-              <ActivityApp onBack={() => setShowActivity(false)} />
-            ) : showCharacterEvolve ? (
-              <CharacterEvolve onBack={() => setShowCharacterEvolve(false)} />
-            ) : showSemiCharacter ? (
-              <SemiFormlessCharacter onBack={() => setShowSemiCharacter(false)} />
-            ) : showIdeaBoard ? (
-              <IdeaBoard onBack={() => setShowIdeaBoard(false)} />
-            ) : showImplementationIdeas ? (
-              <ImplementationIdeas onBack={() => setShowImplementationIdeas(false)} />
-            ) : showOrb ? (
-              <Orb onBack={() => setShowOrb(false)} />
-            ) : showWatchdog ? (
-              <Watchdog onBack={() => setShowWatchdog(false)} />
-            ) : activeLayer === 'Form' && showToolsBlog ? (
-              <ToolsBlog onBack={() => setShowToolsBlog(false)} />
+          {activeTab === 'Character' && (
+            activeLayer === 'Semi-Formless' ? (
+              <SemiFormlessCharacter />
+            ) : activeLayer === 'Formless' ? (
+              <FormlessCharacter />
             ) : (
-              <div className="feature-cards">
-                {appLayers.journal === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowJournal(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'journal')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'journal')}
-                  >
-                    <div className="journal-icon">📓</div>
-                    <span>Quest Journal</span>
-                  </div>
-                )}
-                {appLayers.nofap === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowNofap(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'nofap')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'nofap')}
-                  >
-                    <div className="calendar-preview" />
-                    <span>NoFap Calendar</span>
-                  </div>
-                )}
-                {appLayers.ratings === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowRatings(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'ratings')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'ratings')}
-                  >
-                    <div className="star-icon">⭐⭐⭐⭐⭐</div>
-                    <span>Version Ratings</span>
-                  </div>
-                )}
-                {appLayers.whoami === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowWhoAmI(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'whoami')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'whoami')}
-                  >
-                    <div className="question-icon">❓</div>
-                    <span>Who Am I?</span>
-                  </div>
-                )}
-                {appLayers.music === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowMusic(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'music')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'music')}
-                  >
-                    <div className="star-icon">🎵</div>
-                    <span>Music Search</span>
-                  </div>
-                )}
-                {appLayers.singing === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowSinging(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'singing')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'singing')}
-                  >
-                    <div className="star-icon">🎤</div>
-                    <span>Singing</span>
-                  </div>
-                )}
-                {appLayers.shadow === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowShadowWork(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'shadow')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'shadow')}
-                  >
-                    <div className="star-icon">🌑</div>
-                    <span>Shadow Work</span>
-                  </div>
-                )}
-                {appLayers.calendar === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowCalendarApp(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'calendar')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'calendar')}
-                  >
-                    <div className="star-icon">📅</div>
-                    <span>Calendar</span>
-                  </div>
-                )}
-                {appLayers.timeline === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowTimeline(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'timeline')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'timeline')}
-                  >
-                    <div className="star-icon">🕒</div>
-                    <span>Timeline</span>
-                  </div>
-                )}
-                {appLayers.typomancy === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowTypomancy(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'typomancy')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'typomancy')}
-                  >
-                    <div className="star-icon">⌨️</div>
-                    <span>Typomancy</span>
-                  </div>
-                )}
-                {appLayers.moodtracker === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowMoodtracker(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'moodtracker')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'moodtracker')}
-                  >
-                    <div className="star-icon">😊</div>
-                    <span>Moodtracker</span>
-                  </div>
-                )}
-                {appLayers.momentoMori === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowMomentoMori(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'momentoMori')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'momentoMori')}
-                  >
-                    <div className="star-icon">☠️</div>
-                    <span>Momento Mori</span>
-                  </div>
-                )}
-                {appLayers.quadrantComb === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowQuadrantComb(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'quadrantComb')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'quadrantComb')}
-                  >
-                    <div className="star-icon">🔀</div>
-                    <span>Quadrant combinaisons</span>
-                  </div>
-                )}
-                {appLayers.anima === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowAnima(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'anima')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'anima')}
-                  >
-                    <div className="star-icon">💃</div>
-                    <span>Anima</span>
-                  </div>
-                )}
-                {appLayers.blog === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowBlog(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'blog')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'blog')}
-                  >
-                    <div className="star-icon">📰</div>
-                    <span>Tools Blog</span>
-                  </div>
-                )}
-                {appLayers.todoGoals === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowTodoGoals(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'todoGoals')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'todoGoals')}
-                  >
-                    <div className="star-icon">✅</div>
-                    <span>Todo & Goals</span>
-                  </div>
-                )}
-                {appLayers.activity === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowActivity(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'activity')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'activity')}
-                  >
-                    <div className="star-icon">🏃</div>
-                    <span>Activity</span>
-                  </div>
-                )}
-                {appLayers.characterEvolve === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowCharacterEvolve(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'characterEvolve')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'characterEvolve')}
-                  >
-                    <div className="star-icon">🌱</div>
-                    <span>Character Evolve</span>
-                  </div>
-                )}
-                {appLayers.semiCharacter === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowSemiCharacter(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'semiCharacter')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'semiCharacter')}
-                  >
-                    <div className="star-icon">🔮</div>
-                    <span>Semi Character</span>
-                  </div>
-                )}
-                {appLayers.ideaBoard === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowIdeaBoard(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'ideaBoard')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'ideaBoard')}
-                  >
-                    <div className="star-icon">📝</div>
-                    <span>Idea Board</span>
-                  </div>
-                )}
-                {appLayers.implementationIdeas === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowImplementationIdeas(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'implementationIdeas')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'implementationIdeas')}
-                  >
-                    <div className="star-icon">📑</div>
-                    <span>Implementation Ideas</span>
-                  </div>
-                )}
-                {!showToolsBlog && activeLayer === 'Form' && (
-                  <div className="app-card" onClick={() => setShowToolsBlog(true)}>
-                    <div className="star-icon">📝</div>
-                    <span>Blog</span>
-                  </div>
-                )}
-                {appLayers.orb === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowOrb(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'orb')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'orb')}
-                  >
-                    <div className="star-icon">🧿</div>
-                    <span>Orb</span>
-                  </div>
-                )}
-                {appLayers.watchdog === activeLayer && (
-                  <div
-                    className="app-card"
-                    onClick={() => setShowWatchdog(true)}
-                    onContextMenu={(e) => handleContextMenu(e, 'watchdog')}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, 'watchdog')}
-                  >
-                    <div className="star-icon">🐶</div>
-                    <span>Watchdog</span>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        )}
-        {activeTab === 'World' && <World />}
-        {activeTab === 'Friends' && <FriendsList />}
-      </div>
-      <div className="bottom-nav">
-        {tabs.map((tab, idx) => (
-          <div
-            key={tab.label}
-            className={`tab ${activeTab === tab.label ? 'active' : ''} ${sidebarIndex === idx ? 'selected' : ''}`}
-            onClick={() => {
-              setActiveTab(tab.label);
-              setSidebarIndex(idx);
-            }}
-          >
-            <span className="icon">{tab.icon}</span>
-          </div>
-        ))}
-      </div>
-      {showProfile && (
-        <ProfileModal
-          onClose={() => setShowProfile(false)}
-          onAvatarUpdated={handleAvatarUpdated}
-        />
-      )}
-      {showSettings && (
-        <SettingsModal
-          onClose={() => setShowSettings(false)}
-          autoLog={autoLog}
-          onToggleAutoLog={setAutoLog}
-          theme={theme}
-          onToggleTheme={() =>
-            setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
-          }
-          onOpenAkashicRecords={() => setShowAkashicRecords(true)}
-          mainBg={mainBg}
-          onChangeMainBg={setMainBg}
-          charBg={charBg}
-          onChangeCharBg={setCharBg}
-          menuBg={menuBg}
-          onChangeMenuBg={onChangeMenuBg}
-        />
-      )}
-      {contextMenu && (
-        <ul
-          className="layer-menu"
-          style={{ top: contextMenu.y, left: contextMenu.x }}
-        >
-          {[{ label: 'Open in Split Screen', action: handleOpenSplit },
-            ...layers.map((layer) => ({
-              label: layer.label,
-              action: () => moveAppToLayer(contextMenu.appId, layer.label),
-            })),
-          ].map((opt) => (
-            <li key={opt.label} onClick={opt.action}>
-              {opt.label}
-            </li>
+              <StatsQuadrant />
+            )
+          )}
+          {activeTab === 'Tools' && (
+            <div className="tools-layout">
+              {inlineAppContent || (
+                <div className="feature-cards">
+                  {displayedCards.map((card, index) => renderCard(card, index))}
+                </div>
+              )}
+            </div>
+          )}
+          {activeTab === 'World' && <World />}
+          {activeTab === 'Friends' && <FriendsList />}
+        </div>
+        <div className="bottom-nav">
+          {tabs.map((tab, idx) => (
+            <div
+              key={tab.label}
+              className={`tab ${
+                activeTab === tab.label ? 'active' : ''
+              } ${sidebarIndex === idx ? 'selected' : ''}`}
+              onClick={() => {
+                setActiveTab(tab.label);
+                setSidebarIndex(idx);
+              }}
+            >
+              <span className="icon">{tab.icon}</span>
+            </div>
           ))}
-        </ul>
-      )}
-      <VersionLabel />
+        </div>
+        {showProfile && (
+          <ProfileModal
+            onClose={() => setShowProfile(false)}
+            onAvatarUpdated={handleAvatarUpdated}
+          />
+        )}
+        {showSettings && (
+          <SettingsModal
+            onClose={() => setShowSettings(false)}
+            autoLog={autoLog}
+            onToggleAutoLog={setAutoLog}
+            theme={theme}
+            onToggleTheme={() =>
+              setTheme((value) => (value === 'dark' ? 'light' : 'dark'))
+            }
+            onOpenAkashicRecords={() => {
+              setShowSettings(false);
+              handleOpenApp('akashicRecords');
+            }}
+            mainBg={mainBg}
+            onChangeMainBg={setMainBg}
+            charBg={charBg}
+            onChangeCharBg={setCharBg}
+            menuBg={menuBg}
+            onChangeMenuBg={onChangeMenuBg}
+          />
+        )}
+        {contextMenu && (
+          <ul
+            className="layer-menu"
+            style={{ top: contextMenu.y, left: contextMenu.x }}
+          >
+            {[
+              ...(contextMenu.supportsDock
+                ? [{ label: 'Open in Split Screen', action: handleOpenSplit }]
+                : []),
+              ...layers.map((layer) => ({
+                label: layer.label,
+                action: () => moveAppToLayer(contextMenu.appId, layer.label),
+              })),
+            ].map((option) => (
+              <li key={option.label} onClick={option.action}>
+                {option.label}
+              </li>
+            ))}
+          </ul>
+        )}
+        <VersionLabel />
       </div>
+      {floatingAppContent}
     </QuestProvider>
   );
 }

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -11,30 +11,8 @@ import ExitVideo from './ExitVideo.jsx';
 import Library from './Library.jsx';
 import LoadingScreen from './LoadingScreen.jsx';
 import DockLayout from './DockLayout.jsx';
-import NofapCalendar from './NofapCalendar.jsx';
-import QuestJournal from './QuestJournal.jsx';
-import VersionRating from './VersionRating.jsx';
-import WhoAmI from './WhoAmI.jsx';
-import MusicSearch from './MusicSearch.jsx';
-import Singing from './Singing.jsx';
-import ShadowWork from './ShadowWork.jsx';
-import Calendar from './Calendar.jsx';
-import Timeline from './Timeline.jsx';
-import Typomancy from './Typomancy.jsx';
-import Moodtracker from './Moodtracker.jsx';
-import MomentoMori from './MomentoMori.jsx';
-import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
-import Anima from './Anima.jsx';
 import ToolsBlog from './ToolsBlog.jsx';
-import TodoGoals from './TodoGoals.jsx';
-import ActivityApp from './ActivityApp.jsx';
-import CharacterEvolve from './CharacterEvolve.jsx';
-import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
-import FormlessCharacter from './FormlessCharacter.jsx';
-import IdeaBoard from './IdeaBoard.jsx';
-import ImplementationIdeas from './ImplementationIdeas.jsx';
-import Orb from './Orb.jsx';
-import Watchdog from './Watchdog.jsx';
+import { getAppDefinition } from './config/appRegistry.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
@@ -199,37 +177,24 @@ export default function PageRouter() {
     );
   }
 
+  const renderDockApp = useCallback(
+    (id) => {
+      if (!id) return null;
+      const definition = getAppDefinition(id);
+      return definition ? definition.render({ onClose: goBack }) : null;
+    },
+    [goBack]
+  );
+
+  const renderInlineApp = useCallback(
+    (id, onClose) => {
+      const definition = getAppDefinition(id);
+      return definition ? definition.render({ onClose }) : null;
+    },
+    []
+  );
+
   let leftContent;
-  const renderDockApp = (id) => {
-    const props = { onBack: goBack };
-    const mapping = {
-      journal: <QuestJournal {...props} />,
-      nofap: <NofapCalendar {...props} />,
-      ratings: <VersionRating {...props} />,
-      whoami: <WhoAmI {...props} />,
-      music: <MusicSearch {...props} />,
-      singing: <Singing {...props} />,
-      shadow: <ShadowWork {...props} />,
-      calendar: <Calendar {...props} />,
-      timeline: <Timeline {...props} />,
-      typomancy: <Typomancy {...props} />,
-      moodtracker: <Moodtracker {...props} />,
-      momentoMori: <MomentoMori {...props} />,
-      quadrantComb: <QuadrantCombinaisons onBack={goBack} />,
-      anima: <Anima onBack={goBack} />,
-      blog: <ToolsBlog onBack={goBack} />,
-      todoGoals: <TodoGoals onBack={goBack} />,
-      activity: <ActivityApp onBack={goBack} />,
-      characterEvolve: <CharacterEvolve onBack={goBack} />,
-      semiCharacter: <SemiFormlessCharacter onBack={goBack} />,
-      formlessCharacter: <FormlessCharacter onBack={goBack} />,
-      ideaBoard: <IdeaBoard onBack={goBack} />,
-      implementationIdeas: <ImplementationIdeas onBack={goBack} />,
-      orb: <Orb onBack={goBack} />,
-      watchdog: <Watchdog onBack={goBack} />,
-    };
-    return mapping[id] || null;
-  };
   switch (page) {
     case 'II':
       leftContent = <IImain menuBg={menuBg} onChangeMenuBg={setMenuBg} />;
@@ -247,7 +212,10 @@ export default function PageRouter() {
       leftContent = <Library onBack={() => navigate('5th')} />;
       break;
     case 'blog':
-      leftContent = <ToolsBlog onBack={() => navigate('5th')} />;
+      leftContent =
+        renderInlineApp('blog', () => navigate('5th')) ?? (
+          <ToolsBlog onBack={() => navigate('5th')} />
+        );
       break;
     default:
       leftContent = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;

--- a/src/config/appRegistry.jsx
+++ b/src/config/appRegistry.jsx
@@ -1,0 +1,259 @@
+import React from 'react';
+import QuestJournal from '../QuestJournal.jsx';
+import NofapCalendar from '../NofapCalendar.jsx';
+import VersionRating from '../VersionRating.jsx';
+import WhoAmI from '../WhoAmI.jsx';
+import MusicSearch from '../MusicSearch.jsx';
+import Singing from '../Singing.jsx';
+import ShadowWork from '../ShadowWork.jsx';
+import Calendar from '../Calendar.jsx';
+import Timeline from '../Timeline.jsx';
+import Typomancy from '../Typomancy.jsx';
+import Moodtracker from '../Moodtracker.jsx';
+import MomentoMori from '../MomentoMori.jsx';
+import QuadrantCombinaisons from '../QuadrantCombinaisons.jsx';
+import Anima from '../Anima.jsx';
+import ToolsBlog from '../ToolsBlog.jsx';
+import TodoGoals from '../TodoGoals.jsx';
+import ActivityApp from '../ActivityApp.jsx';
+import CharacterEvolve from '../CharacterEvolve.jsx';
+import SemiFormlessCharacter from '../SemiFormlessCharacter.jsx';
+import FormlessCharacter from '../FormlessCharacter.jsx';
+import IdeaBoard from '../IdeaBoard.jsx';
+import ImplementationIdeas from '../ImplementationIdeas.jsx';
+import Orb from '../Orb.jsx';
+import Watchdog from '../Watchdog.jsx';
+import AkashicRecords from '../AkashicRecords.jsx';
+
+const DEFAULT_LAYER = 'Form';
+
+const withBackHandler = (Component) => ({ onClose }) => (
+  <Component onBack={onClose} />
+);
+
+const makeIcon = (className, content = null) => () => (
+  <div className={className}>{content}</div>
+);
+
+const emojiIcon = (emoji) => makeIcon('star-icon', emoji);
+
+export const toolApps = [
+  {
+    id: 'journal',
+    title: 'Quest Journal',
+    icon: makeIcon('journal-icon', '📓'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(QuestJournal),
+  },
+  {
+    id: 'nofap',
+    title: 'NoFap Calendar',
+    icon: makeIcon('calendar-preview'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(NofapCalendar),
+  },
+  {
+    id: 'ratings',
+    title: 'Version Ratings',
+    icon: emojiIcon('⭐⭐⭐⭐⭐'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(VersionRating),
+  },
+  {
+    id: 'whoami',
+    title: 'Who Am I?',
+    icon: makeIcon('question-icon', '❓'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(WhoAmI),
+  },
+  {
+    id: 'music',
+    title: 'Music Search',
+    icon: emojiIcon('🎵'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(MusicSearch),
+  },
+  {
+    id: 'singing',
+    title: 'Singing',
+    icon: emojiIcon('🎤'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Singing),
+  },
+  {
+    id: 'shadow',
+    title: 'Shadow Work',
+    icon: emojiIcon('🌑'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(ShadowWork),
+  },
+  {
+    id: 'calendar',
+    title: 'Calendar',
+    icon: emojiIcon('🗓️'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Calendar),
+  },
+  {
+    id: 'timeline',
+    title: 'Timeline',
+    icon: emojiIcon('📆'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Timeline),
+  },
+  {
+    id: 'typomancy',
+    title: 'Typomancy',
+    icon: emojiIcon('⌨️'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Typomancy),
+  },
+  {
+    id: 'moodtracker',
+    title: 'Moodtracker',
+    icon: emojiIcon('😊'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Moodtracker),
+  },
+  {
+    id: 'momentoMori',
+    title: 'Momento Mori',
+    icon: emojiIcon('☠️'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(MomentoMori),
+  },
+  {
+    id: 'quadrantComb',
+    title: 'Quadrant combinaisons',
+    icon: emojiIcon('🔀'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(QuadrantCombinaisons),
+  },
+  {
+    id: 'anima',
+    title: 'Anima',
+    icon: emojiIcon('💃'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Anima),
+  },
+  {
+    id: 'blog',
+    title: 'Tools Blog',
+    icon: emojiIcon('📰'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(ToolsBlog),
+  },
+  {
+    id: 'todoGoals',
+    title: 'Todo & Goals',
+    icon: emojiIcon('✅'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(TodoGoals),
+  },
+  {
+    id: 'activity',
+    title: 'Activity',
+    icon: emojiIcon('🏃'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(ActivityApp),
+  },
+  {
+    id: 'characterEvolve',
+    title: 'Character Evolve',
+    icon: emojiIcon('🌱'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(CharacterEvolve),
+  },
+  {
+    id: 'semiCharacter',
+    title: 'Semi Character',
+    icon: emojiIcon('🔮'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(SemiFormlessCharacter),
+  },
+  {
+    id: 'ideaBoard',
+    title: 'Idea Board',
+    icon: emojiIcon('📝'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(IdeaBoard),
+  },
+  {
+    id: 'implementationIdeas',
+    title: 'Implementation Ideas',
+    icon: emojiIcon('📑'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(ImplementationIdeas),
+  },
+  {
+    id: 'orb',
+    title: 'Orb',
+    icon: emojiIcon('🧿'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Orb),
+  },
+  {
+    id: 'watchdog',
+    title: 'Watchdog',
+    icon: emojiIcon('🐶'),
+    defaultLayer: DEFAULT_LAYER,
+    render: withBackHandler(Watchdog),
+  },
+];
+
+export const pinnedToolApps = [
+  {
+    id: 'blogInline',
+    title: 'Blog',
+    layer: 'Form',
+    icon: emojiIcon('📝'),
+    render: withBackHandler(ToolsBlog),
+    hideWhenActive: true,
+  },
+];
+
+export const auxiliaryApps = [
+  {
+    id: 'akashicRecords',
+    title: 'Akashic Records',
+    render: withBackHandler(AkashicRecords),
+  },
+  {
+    id: 'formlessCharacter',
+    title: 'Formless Character',
+    render: withBackHandler(FormlessCharacter),
+  },
+];
+
+const registryEntries = [
+  ...toolApps,
+  ...pinnedToolApps,
+  ...auxiliaryApps,
+];
+
+const registry = new Map(registryEntries.map((app) => [app.id, app]));
+
+export function getAppDefinition(id) {
+  return registry.get(id) ?? null;
+}
+
+export function getToolAppDefinition(id) {
+  return toolApps.find((app) => app.id === id) ?? null;
+}
+
+export function isPinnedToolApp(id) {
+  return pinnedToolApps.some((app) => app.id === id);
+}
+
+export function createDefaultAppLayers() {
+  const defaults = {};
+  toolApps.forEach((app) => {
+    defaults[app.id] = app.defaultLayer ?? DEFAULT_LAYER;
+  });
+  return defaults;
+}
+
+export function isDockableApp(id) {
+  const app = getToolAppDefinition(id);
+  return app ? app.supportsDock !== false : false;
+}

--- a/src/hooks/usePersistentState.js
+++ b/src/hooks/usePersistentState.js
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const isBrowser = typeof window !== 'undefined';
+
+function resolveInitial(initialValue) {
+  return typeof initialValue === 'function' ? initialValue() : initialValue;
+}
+
+export function usePersistentState(key, initialValue, options = {}) {
+  const { serialize = JSON.stringify, deserialize = JSON.parse } = options;
+  const serializeRef = useRef(serialize);
+  const deserializeRef = useRef(deserialize);
+
+  serializeRef.current = serialize;
+  deserializeRef.current = deserialize;
+
+  const initializer = useCallback(() => {
+    if (!isBrowser) {
+      return resolveInitial(initialValue);
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(key);
+      if (storedValue == null) {
+        return resolveInitial(initialValue);
+      }
+      return deserializeRef.current(storedValue);
+    } catch (error) {
+      console.warn(`Failed to read persistent state for "${key}":`, error);
+      return resolveInitial(initialValue);
+    }
+  }, [initialValue, key]);
+
+  const [state, setState] = useState(initializer);
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+
+    try {
+      if (state === undefined) {
+        window.localStorage.removeItem(key);
+      } else {
+        const value = serializeRef.current(state);
+        window.localStorage.setItem(key, value);
+      }
+    } catch (error) {
+      console.warn(`Failed to persist state for "${key}":`, error);
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}
+
+export function stringStorage() {
+  return {
+    serialize: (value) => (value ?? '').toString(),
+    deserialize: (value) => value,
+  };
+}
+
+export function booleanStorage() {
+  return {
+    serialize: (value) => (value ? 'true' : 'false'),
+    deserialize: (value) => value === 'true',
+  };
+}
+
+export function jsonStorage() {
+  return {
+    serialize: (value) => JSON.stringify(value ?? {}),
+    deserialize: (value) => {
+      try {
+        return JSON.parse(value);
+      } catch {
+        return {};
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- refactor the Quadrant page to drive tool rendering, keyboard navigation, and persistence from a shared registry
- add a shared app registry and persistent state hook so PageRouter and AkashicRecords reuse the same definitions
- refresh Akashic Records and split-screen logic to leverage the new registry-based lookup
- rename the app registry config to `.jsx` and update imports so Vite can parse its embedded JSX icons

## Testing
- npm test -- --runInBand
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c960da87a483229209cf5552e8080f