### PR TITLE
Add sidebar quick buttons to the left navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -215,6 +215,23 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowSettings(false);
   };
 
+  const toolsTabIndex = tabs.findIndex((tab) => tab.label === 'Tools');
+
+  const openToolsHome = () => {
+    setActiveTab('Tools');
+    setSidebarIndex(toolsTabIndex);
+    closeOpenApp();
+    setSelectedAppIndex(-1);
+  };
+
+  const openToolsBlog = () => {
+    setActiveTab('Tools');
+    setSidebarIndex(toolsTabIndex);
+    closeOpenApp();
+    setSelectedAppIndex(-1);
+    setShowBlog(true);
+  };
+
   useEffect(() => {
     document.body.classList.toggle('light-theme', theme === 'light');
     localStorage.setItem('theme', theme);
@@ -463,6 +480,31 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                 onDrop={(e) => handleDropOnLayer(e, layer.label)}
               />
             ))}
+          </div>
+          <div className="sidebar-middle-buttons">
+            <button
+              type="button"
+              className="sidebar-quick-button"
+              style={{ backgroundColor: '#ff4d4f' }}
+              title="Coming soon"
+              aria-label="Coming soon"
+            />
+            <button
+              type="button"
+              className="sidebar-quick-button"
+              style={{ backgroundColor: '#2196f3' }}
+              onClick={openToolsHome}
+              title="Open training apps"
+              aria-label="Open training apps"
+            />
+            <button
+              type="button"
+              className="sidebar-quick-button"
+              style={{ backgroundColor: '#4caf50' }}
+              onClick={openToolsBlog}
+              title="Open Tools Blog"
+              aria-label="Open Tools Blog"
+            />
           </div>
           <div className="bottom-buttons">
           <div

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,6 +47,7 @@ body.character-page {
   width: 70px;
   background-color: rgba(128, 128, 128, 0.6);
   padding: 20px 0;
+  position: relative;
 }
 
 .layer-buttons {
@@ -58,6 +59,38 @@ body.character-page {
   flex-direction: row;
   gap: 15px;
   z-index: 1000;
+}
+
+.sidebar-middle-buttons {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  align-items: center;
+}
+
+.sidebar-quick-button {
+  width: 50px;
+  height: 50px;
+  border-radius: 12px;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.sidebar-quick-button:hover {
+  transform: scale(1.08);
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+}
+
+.sidebar-quick-button:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
 }
 
 .layer-button {


### PR DESCRIPTION
## Summary
- add red, blue, and green quick navigation buttons to the sidebar, wiring blue to the tools home and green to the blog
- style the new sidebar buttons so they sit centered on the left rail and match the existing layer controls

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c97e4b9f6c8322bd30b0d5d6771a56