### PR TITLE
Restrict elevator animation to vertical sidebar controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
@@ -155,6 +155,13 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [sidebarIndex, setSidebarIndex] = useState(() =>
     tabs.findIndex((t) => t.label === (initialTab || tabs[0].label))
   );
+  const [floorAnimation, setFloorAnimation] = useState({
+    direction: null,
+    active: false,
+  });
+  const prevLayerRef = useRef(activeLayer);
+  const animationTimeoutRef = useRef(null);
+  const elevatorTriggerRef = useRef(false);
 
   const anyAppOpen =
     showJournal ||
@@ -217,10 +224,19 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
 
   const toolsTabIndex = tabs.findIndex((tab) => tab.label === 'Tools');
 
+  const triggerElevatorToLayer = (layerLabel) => {
+    const willChange = layerLabel !== activeLayer;
+    if (willChange) {
+      elevatorTriggerRef.current = true;
+      setActiveLayer(layerLabel);
+    }
+    return willChange;
+  };
+
   const openToolsHome = () => {
     setActiveTab('Tools');
     setSidebarIndex(toolsTabIndex);
-    setActiveLayer('Form');
+    triggerElevatorToLayer('Form');
     closeOpenApp();
     setSelectedAppIndex(-1);
   };
@@ -228,7 +244,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const openToolsBlog = () => {
     setActiveTab('Tools');
     setSidebarIndex(toolsTabIndex);
-    setActiveLayer('Semi-Formless');
+    triggerElevatorToLayer('Semi-Formless');
     closeOpenApp();
     setSelectedAppIndex(-1);
     window.postMessage(
@@ -258,6 +274,57 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       setShowToolsBlog(false);
     }
   }, [activeLayer]);
+
+  useEffect(() => {
+    const previousLayer = prevLayerRef.current;
+
+    if (previousLayer !== activeLayer) {
+      const previousIndex = layers.findIndex((layer) => layer.label === previousLayer);
+      const nextIndex = layers.findIndex((layer) => layer.label === activeLayer);
+      const shouldAnimate = elevatorTriggerRef.current;
+      elevatorTriggerRef.current = false;
+
+      if (
+        shouldAnimate &&
+        previousIndex !== -1 &&
+        nextIndex !== -1 &&
+        previousIndex !== nextIndex
+      ) {
+        const direction = nextIndex < previousIndex ? 'up' : 'down';
+        setFloorAnimation({ direction, active: true });
+
+        if (animationTimeoutRef.current) {
+          clearTimeout(animationTimeoutRef.current);
+        }
+
+        animationTimeoutRef.current = setTimeout(() => {
+          setFloorAnimation({ direction: null, active: false });
+          animationTimeoutRef.current = null;
+        }, 700);
+      } else {
+        if (animationTimeoutRef.current) {
+          clearTimeout(animationTimeoutRef.current);
+          animationTimeoutRef.current = null;
+        }
+
+        setFloorAnimation((prev) =>
+          prev.active || prev.direction ? { direction: null, active: false } : prev
+        );
+      }
+    }
+
+    prevLayerRef.current = activeLayer;
+  }, [activeLayer]);
+
+  useEffect(
+    () => () => {
+      if (animationTimeoutRef.current) {
+        clearTimeout(animationTimeoutRef.current);
+        animationTimeoutRef.current = null;
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     localStorage.setItem('appLayers', JSON.stringify(appLayers));
@@ -468,10 +535,15 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     );
   }
 
+  const elevatorClass =
+    floorAnimation.active && floorAnimation.direction
+      ? ` elevator-${floorAnimation.direction}`
+      : '';
+
   return (
     <QuestProvider>
       <ActivityLogger enabled={autoLog} />
-      <div className="app-container">
+      <div className={`app-container${elevatorClass}`}>
         <aside className="sidebar">
           <div className="layer-buttons">
             {layers.map((layer) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -27,6 +27,68 @@ body.menu-page {
   }
 }
 
+@keyframes elevator-up-motion {
+  0% {
+    transform: translateY(0);
+    filter: brightness(1);
+  }
+  30% {
+    transform: translateY(-40px);
+    filter: brightness(1.05);
+  }
+  55% {
+    transform: translateY(-56px);
+    filter: brightness(1.1);
+  }
+  100% {
+    transform: translateY(0);
+    filter: brightness(1);
+  }
+}
+
+@keyframes elevator-down-motion {
+  0% {
+    transform: translateY(0);
+    filter: brightness(1);
+  }
+  30% {
+    transform: translateY(40px);
+    filter: brightness(0.97);
+  }
+  55% {
+    transform: translateY(56px);
+    filter: brightness(0.93);
+  }
+  100% {
+    transform: translateY(0);
+    filter: brightness(1);
+  }
+}
+
+@keyframes elevator-up-light {
+  0% {
+    opacity: 0;
+  }
+  25% {
+    opacity: 0.35;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes elevator-down-light {
+  0% {
+    opacity: 0;
+  }
+  25% {
+    opacity: 0.3;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 body.character-page {
   background: var(--char-bg-url) no-repeat center center fixed;
   background-size: cover;
@@ -37,6 +99,43 @@ body.character-page {
 .app-container {
   display: flex;
   height: 100vh;
+  position: relative;
+  overflow: hidden;
+  filter: none;
+  will-change: transform, filter;
+}
+
+.app-container.elevator-up,
+.app-container.elevator-down {
+  animation-duration: 0.7s;
+  animation-fill-mode: both;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.app-container.elevator-up {
+  animation-name: elevator-up-motion;
+}
+
+.app-container.elevator-down {
+  animation-name: elevator-down-motion;
+}
+
+.app-container.elevator-up::after,
+.app-container.elevator-down::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.app-container.elevator-up::after {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0));
+  animation: elevator-up-light 0.7s ease-in-out forwards;
+}
+
+.app-container.elevator-down::after {
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.4));
+  animation: elevator-down-light 0.7s ease-in-out forwards;
 }
 
 .sidebar {


### PR DESCRIPTION
## Summary
- add an elevator trigger ref and helper so only sidebar floor buttons request the transition
- update the blog and home quick buttons to call the elevator helper instead of setting the layer directly
- guard the floor animation effect behind the trigger flag and reset it when other controls change layers

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c98c4087808322976e638036f80804