### PR TITLE
Add Collective layer page and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -253,6 +253,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     );
   };
 
+  const openCollectiveLayer = () => {
+    setActiveTab('Tools');
+    setSidebarIndex(toolsTabIndex);
+    triggerElevatorToLayer('Formless');
+    closeOpenApp();
+    setSelectedAppIndex(-1);
+    window.postMessage(
+      { type: 'NAVIGATE_PAGE', page: 'collective' },
+      '*'
+    );
+  };
+
   useEffect(() => {
     document.body.classList.toggle('light-theme', theme === 'light');
     localStorage.setItem('theme', theme);
@@ -562,25 +574,28 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               type="button"
               className="sidebar-quick-button"
               style={{ backgroundColor: '#ff4d4f' }}
-              title="Coming soon"
-              aria-label="Coming soon"
+              onClick={openCollectiveLayer}
+              title="Open Collective layer (Layer 3)"
+              aria-label="Open Collective layer (Layer 3)"
+            >
+              🤝
+            </button>
+            <button
+              type="button"
+              className="sidebar-quick-button"
+              style={{ backgroundColor: '#2196f3' }}
+              onClick={openToolsBlog}
+              title="Open blog layer (Layer 2)"
+              aria-label="Open blog layer (Layer 2)"
             />
-          <button
-            type="button"
-            className="sidebar-quick-button"
-            style={{ backgroundColor: '#2196f3' }}
-            onClick={openToolsBlog}
-            title="Open blog layer (Layer 2)"
-            aria-label="Open blog layer (Layer 2)"
-          />
-          <button
-            type="button"
-            className="sidebar-quick-button"
-            style={{ backgroundColor: '#4caf50' }}
-            onClick={openToolsHome}
-            title="Return to training layer (Layer 1)"
-            aria-label="Return to training layer (Layer 1)"
-          />
+            <button
+              type="button"
+              className="sidebar-quick-button"
+              style={{ backgroundColor: '#4caf50' }}
+              onClick={openToolsHome}
+              title="Return to training layer (Layer 1)"
+              aria-label="Return to training layer (Layer 1)"
+            />
           </div>
           <div className="bottom-buttons">
           <div

--- a/src/Collective.jsx
+++ b/src/Collective.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import './collective.css';
+
+export default function Collective({ onBack }) {
+  return (
+    <div className="collective-page">
+      <header className="collective-header">
+        <button type="button" className="collective-back" onClick={onBack}>
+          ← Back to the Fifth Layer
+        </button>
+        <div className="collective-hero">
+          <span className="collective-badge">Layer 3</span>
+          <h1>Collective</h1>
+          <p>
+            The Collective is the living commons of Mazed. It will host shared galleries,
+            collaborative projects, and the social heartbeat of the app. Everything that
+            connects us will converge here.
+          </p>
+          <div className="collective-cta">
+            <button
+              type="button"
+              className="collective-action"
+              onClick={() => {
+                console.info('Collective upload flow coming soon.');
+              }}
+            >
+              Prepare an upload
+            </button>
+            <p>
+              Warm up the pipeline for stories, artwork, recordings, and every other
+              artefact we will co-create. The infrastructure will plug in here when it is
+              ready.
+            </p>
+          </div>
+        </div>
+      </header>
+      <div className="collective-body">
+        <main className="collective-main">
+          <section className="collective-panel">
+            <h2>Shared Gallery</h2>
+            <p>
+              A mosaic reserved for community uploads. Each tile below represents a future
+              contribution. Once the upload service goes live the gallery will stream
+              directly from our storage buckets.
+            </p>
+            <div className="collective-gallery-grid">
+              {['Artwork', 'Screenshots', 'Sketches', 'Notes'].map((label) => (
+                <div key={label} className="collective-tile">
+                  <span>{label}</span>
+                  <small>Placeholder feed waiting for uploads</small>
+                </div>
+              ))}
+            </div>
+          </section>
+          <section className="collective-panel">
+            <h2>Live Canvas</h2>
+            <p>
+              Reserve space for collaborative boards, watch parties, or streaming rooms.
+              Drop in real-time tools once they are ready and they will sit on this canvas.
+            </p>
+            <div className="collective-canvas">
+              <div className="collective-canvas-grid">
+                <div className="collective-canvas-cell highlight">Now</div>
+                <div className="collective-canvas-cell">Upcoming session</div>
+                <div className="collective-canvas-cell">Shared playlist</div>
+                <div className="collective-canvas-cell">Live reactions</div>
+              </div>
+            </div>
+          </section>
+          <section className="collective-panel collective-roadmap">
+            <h2>Rollout Roadmap</h2>
+            <ul>
+              <li>🔌 Wire Supabase storage and realtime channels for media uploads.</li>
+              <li>🖼️ Render community galleries with moderation tools.</li>
+              <li>🎙️ Embed live rooms for audio, video, or co-working sessions.</li>
+              <li>📣 Broadcast announcements and layered missions to the whole crew.</li>
+            </ul>
+          </section>
+        </main>
+        <aside className="collective-sidebar">
+          <section className="collective-panel">
+            <h3>Activity Feed</h3>
+            <ul className="collective-activity">
+              <li>
+                <span className="collective-dot" />
+                Live updates will surface here once the realtime bridge is connected.
+              </li>
+              <li>
+                <span className="collective-dot" />
+                Keep the space ready for status pings, shout-outs, and event invites.
+              </li>
+              <li>
+                <span className="collective-dot" />
+                Draft ideas in the Fifth layer and syndicate them here when approved.
+              </li>
+            </ul>
+          </section>
+          <section className="collective-panel collective-guidelines">
+            <h3>Upload Playbook</h3>
+            <p>
+              Prepare guidelines, prompts, and automation hooks. This checklist will help
+              us plug the future upload wizard straight into the UI.
+            </p>
+            <ol>
+              <li>Define media types and size thresholds.</li>
+              <li>Draft moderation flow and flagging signals.</li>
+              <li>Design the reveal animations for freshly shared artefacts.</li>
+              <li>Outline seasonal or thematic collections.</li>
+            </ol>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -35,6 +35,7 @@ import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
 import Orb from './Orb.jsx';
 import Watchdog from './Watchdog.jsx';
+import Collective from './Collective.jsx';
 
 export default function PageRouter() {
   const [page, setPage] = useState('5th');
@@ -252,6 +253,9 @@ export default function PageRouter() {
       break;
     case 'blog':
       leftContent = <ToolsBlog onBack={() => navigate('5th')} />;
+      break;
+    case 'collective':
+      leftContent = <Collective onBack={() => navigate('5th')} />;
       break;
     default:
       leftContent = <FifthMain onSelectQuadrant={(label) => navigate(label)} />;

--- a/src/collective.css
+++ b/src/collective.css
@@ -1,0 +1,257 @@
+.collective-page {
+  min-height: 100vh;
+  padding: 32px 48px 48px;
+  background: radial-gradient(circle at top, rgba(255, 77, 79, 0.3), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(33, 150, 243, 0.2), transparent 60%),
+    #0f1016;
+  color: #f5f6fa;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.collective-header {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.collective-back {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #f5f6fa;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.collective-back:hover,
+.collective-back:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+  transform: translateY(-2px);
+}
+
+.collective-hero {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.collective-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 77, 79, 0.2);
+  border: 1px solid rgba(255, 77, 79, 0.45);
+  color: #ffb3b4;
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.collective-hero h1 {
+  margin: 0;
+  font-size: 3.2rem;
+  letter-spacing: 0.04em;
+}
+
+.collective-hero p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(245, 246, 250, 0.85);
+}
+
+.collective-cta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border-radius: 18px;
+  background: rgba(16, 18, 26, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.35);
+}
+
+.collective-action {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #ff4d4f, #ff7875);
+  border: none;
+  border-radius: 999px;
+  padding: 12px 28px;
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.collective-action:hover,
+.collective-action:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(255, 77, 79, 0.45);
+}
+
+.collective-body {
+  display: flex;
+  gap: 28px;
+  align-items: flex-start;
+}
+
+.collective-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.collective-sidebar {
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.collective-panel {
+  background: rgba(18, 21, 30, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.collective-panel h2,
+.collective-panel h3 {
+  margin-top: 0;
+  letter-spacing: 0.03em;
+}
+
+.collective-panel p,
+.collective-panel li,
+.collective-panel small {
+  color: rgba(245, 246, 250, 0.8);
+  line-height: 1.55;
+}
+
+.collective-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.collective-tile {
+  border-radius: 16px;
+  padding: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 120px;
+  justify-content: center;
+  text-align: center;
+}
+
+.collective-tile span {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.collective-canvas {
+  margin-top: 18px;
+  border-radius: 18px;
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  padding: 24px;
+}
+
+.collective-canvas-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.collective-canvas-cell {
+  border-radius: 12px;
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.05);
+  text-align: center;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: rgba(245, 246, 250, 0.85);
+}
+
+.collective-canvas-cell.highlight {
+  background: linear-gradient(135deg, rgba(255, 77, 79, 0.6), rgba(255, 120, 117, 0.4));
+  color: #fff;
+}
+
+.collective-roadmap ul {
+  padding-left: 20px;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.collective-activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.collective-activity li {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.collective-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ff4d4f, #ff7875);
+  margin-top: 7px;
+  flex-shrink: 0;
+  box-shadow: 0 0 8px rgba(255, 77, 79, 0.6);
+}
+
+.collective-guidelines ol {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+@media (max-width: 1200px) {
+  .collective-body {
+    flex-direction: column;
+  }
+
+  .collective-sidebar {
+    width: 100%;
+  }
+}
+
+@media (max-width: 768px) {
+  .collective-page {
+    padding: 24px 20px 40px;
+  }
+
+  .collective-hero h1 {
+    font-size: 2.4rem;
+  }
+
+  .collective-gallery-grid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -178,6 +178,12 @@ body.character-page {
   border: none;
   padding: 0;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 22px;
+  line-height: 1;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   transition: transform 0.2s, box-shadow 0.2s;
 }


### PR DESCRIPTION
## Summary
- add a new Collective layer page with structured placeholders for upcoming community features and guidelines
- wire the red quick button to open the Collective space and extend the router plus button styling to support it

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c9a0a36f748322bc640522cc5081bf