### PR TITLE
Add edit and delete controls to ToolsBlog entries

### DIFF
--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './tools-blog.css';
 
 const THEMES = [
@@ -48,6 +48,57 @@ const PLACEHOLDER_POSTS = Array.from({ length: 48 }, (_, index) => {
 });
 
 export default function ToolsBlog({ onBack }) {
+  const [posts, setPosts] = useState(() =>
+    PLACEHOLDER_POSTS.map((post) => ({ ...post }))
+  );
+  const [editingPostId, setEditingPostId] = useState(null);
+  const [editDraft, setEditDraft] = useState(null);
+
+  const startEditing = (post) => {
+    setEditingPostId(post.id);
+    setEditDraft({
+      title: post.title,
+      status: post.status,
+      excerpt: post.excerpt,
+      stream: post.stream,
+      mood: post.mood,
+    });
+  };
+
+  const cancelEditing = () => {
+    setEditingPostId(null);
+    setEditDraft(null);
+  };
+
+  const saveEdits = (event) => {
+    event.preventDefault();
+    if (editDraft == null || editingPostId == null) {
+      return;
+    }
+
+    setPosts((previousPosts) =>
+      previousPosts.map((post) =>
+        post.id === editingPostId ? { ...post, ...editDraft } : post
+      )
+    );
+    cancelEditing();
+  };
+
+  const removePost = (postId) => {
+    setPosts((previousPosts) => previousPosts.filter((post) => post.id !== postId));
+    if (editingPostId === postId) {
+      cancelEditing();
+    }
+  };
+
+  const updateDraftField = (field) => (event) => {
+    const value = event.target.value;
+    setEditDraft((previousDraft) => ({
+      ...(previousDraft ?? {}),
+      [field]: value,
+    }));
+  };
+
   return (
     <div className="tools-blog">
       <header className="blog-header">
@@ -82,20 +133,148 @@ export default function ToolsBlog({ onBack }) {
       </header>
 
       <div className="blog-feed">
-        {PLACEHOLDER_POSTS.map((post) => (
-          <article key={post.id} className="blog-card">
-            <div className="blog-card-header">
-              <span className="blog-card-badge">{post.status}</span>
-              <span className="blog-card-index">#{String(post.id).padStart(2, '0')}</span>
-            </div>
-            <h2 className="blog-card-title">{post.title}</h2>
-            <p className="blog-card-body">{post.excerpt}</p>
-            <div className="blog-card-footer">
-              <span className="blog-card-tag">{post.stream}</span>
-              <span className="blog-card-mood">{post.mood}</span>
-            </div>
-          </article>
-        ))}
+        {posts.map((post, index) => {
+          const isEditing = editingPostId === post.id;
+          const currentStatus = isEditing && editDraft ? editDraft.status : post.status;
+          const displayIndex = `#${String(index + 1).padStart(2, '0')}`;
+
+          return (
+            <article key={post.id} className="blog-card">
+              <div className="blog-card-header">
+                <div className="blog-card-meta">
+                  <span className="blog-card-badge">{currentStatus}</span>
+                  <span className="blog-card-index">{displayIndex}</span>
+                </div>
+                {!isEditing && (
+                  <div className="blog-card-actions">
+                    <button
+                      type="button"
+                      className="blog-card-button"
+                      onClick={() => startEditing(post)}
+                    >
+                      Modify
+                    </button>
+                    <button
+                      type="button"
+                      className="blog-card-button blog-card-button--danger"
+                      onClick={() => removePost(post.id)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {isEditing ? (
+                <form className="blog-card-edit-form" onSubmit={saveEdits}>
+                  <div className="blog-card-field">
+                    <label className="blog-card-label" htmlFor={`title-${post.id}`}>
+                      Title
+                    </label>
+                    <input
+                      id={`title-${post.id}`}
+                      type="text"
+                      className="blog-card-input"
+                      value={editDraft?.title ?? ''}
+                      onChange={updateDraftField('title')}
+                    />
+                  </div>
+
+                  <div className="blog-card-field">
+                    <label className="blog-card-label" htmlFor={`excerpt-${post.id}`}>
+                      Excerpt
+                    </label>
+                    <textarea
+                      id={`excerpt-${post.id}`}
+                      className="blog-card-textarea"
+                      value={editDraft?.excerpt ?? ''}
+                      onChange={updateDraftField('excerpt')}
+                    />
+                  </div>
+
+                  <div className="blog-card-field">
+                    <label className="blog-card-label" htmlFor={`status-${post.id}`}>
+                      Status
+                    </label>
+                    <select
+                      id={`status-${post.id}`}
+                      className="blog-card-select"
+                      value={editDraft?.status ?? ''}
+                      onChange={updateDraftField('status')}
+                    >
+                      {STATUSES.map((statusOption) => (
+                        <option key={statusOption} value={statusOption}>
+                          {statusOption}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="blog-card-field">
+                    <label className="blog-card-label" htmlFor={`stream-${post.id}`}>
+                      Stream
+                    </label>
+                    <select
+                      id={`stream-${post.id}`}
+                      className="blog-card-select"
+                      value={editDraft?.stream ?? ''}
+                      onChange={updateDraftField('stream')}
+                    >
+                      {STREAMS.map((streamOption) => (
+                        <option key={streamOption} value={streamOption}>
+                          {streamOption}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="blog-card-field">
+                    <label className="blog-card-label" htmlFor={`mood-${post.id}`}>
+                      Mood
+                    </label>
+                    <select
+                      id={`mood-${post.id}`}
+                      className="blog-card-select"
+                      value={editDraft?.mood ?? ''}
+                      onChange={updateDraftField('mood')}
+                    >
+                      {MOODS.map((moodOption) => (
+                        <option key={moodOption} value={moodOption}>
+                          {moodOption}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="blog-card-form-actions">
+                    <button
+                      type="button"
+                      className="blog-card-button"
+                      onClick={cancelEditing}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      className="blog-card-button blog-card-button--primary"
+                    >
+                      Save
+                    </button>
+                  </div>
+                </form>
+              ) : (
+                <>
+                  <h2 className="blog-card-title">{post.title}</h2>
+                  <p className="blog-card-body">{post.excerpt}</p>
+                  <div className="blog-card-footer">
+                    <span className="blog-card-tag">{post.stream}</span>
+                    <span className="blog-card-mood">{post.mood}</span>
+                  </div>
+                </>
+              )}
+            </article>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -136,10 +136,18 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
   font-size: 0.75rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: #a1a4b5;
+}
+
+.blog-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .blog-card-badge {
@@ -151,6 +159,58 @@
 
 .blog-card-index {
   color: rgba(255, 255, 255, 0.35);
+}
+
+.blog-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.blog-card-button {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ececf4;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 180ms ease, border-color 180ms ease, color 180ms ease;
+}
+
+.blog-card-button:hover,
+.blog-card-button:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.28);
+  outline: none;
+}
+
+.blog-card-button--primary {
+  background: #f5f5f5;
+  color: #050505;
+  border-color: transparent;
+}
+
+.blog-card-button--primary:hover,
+.blog-card-button--primary:focus-visible {
+  background: #ffffff;
+  border-color: transparent;
+}
+
+.blog-card-button--danger {
+  background: rgba(255, 99, 99, 0.15);
+  border-color: rgba(255, 99, 99, 0.45);
+  color: #ffb2b2;
+}
+
+.blog-card-button--danger:hover,
+.blog-card-button--danger:focus-visible {
+  background: rgba(255, 99, 99, 0.25);
+  border-color: rgba(255, 99, 99, 0.6);
 }
 
 .blog-card-title {
@@ -166,6 +226,64 @@
   color: #d3d6e4;
   font-size: 1.05rem;
   line-height: 1.7;
+}
+
+.blog-card-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.blog-card-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.blog-card-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9fa3b5;
+}
+
+.blog-card-input,
+.blog-card-textarea,
+.blog-card-select {
+  width: 100%;
+  background: rgba(10, 10, 10, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 12px 14px;
+  color: #f5f5f5;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.blog-card-textarea {
+  min-height: 120px;
+  resize: vertical;
+  line-height: 1.6;
+}
+
+.blog-card-select {
+  cursor: pointer;
+}
+
+.blog-card-input:focus,
+.blog-card-textarea:focus,
+.blog-card-select:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.38);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.12);
+}
+
+.blog-card-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .blog-card-footer {
@@ -204,6 +322,11 @@
   .blog-card {
     border-radius: 22px;
     padding: 28px;
+  }
+
+  .blog-card-actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 }
 


### PR DESCRIPTION
## Summary
- add local state management to ToolsBlog so posts can be modified or removed
- provide inline editing form that updates title, excerpt, status, stream, and mood
- style the new management controls and form elements to match the existing blog aesthetic

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68c9c11be0cc8322993d9cdde7ab4977