### PR TITLE
Add Tumblr-style grid view option to tools blog

### DIFF
--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -47,6 +47,11 @@ const PLACEHOLDER_POSTS = Array.from({ length: 48 }, (_, index) => {
   };
 });
 
+const VIEW_MODES = {
+  LIST: 'list',
+  GRID: 'grid',
+};
+
 export default function ToolsBlog({ onBack }) {
   const [posts, setPosts] = useState(() =>
     PLACEHOLDER_POSTS.map((post) => ({ ...post }))
@@ -54,6 +59,7 @@ export default function ToolsBlog({ onBack }) {
   const [editingPostId, setEditingPostId] = useState(null);
   const [editDraft, setEditDraft] = useState(null);
   const [openMenuPostId, setOpenMenuPostId] = useState(null);
+  const [viewMode, setViewMode] = useState(VIEW_MODES.LIST);
 
   const closeActionMenu = () => setOpenMenuPostId(null);
 
@@ -99,6 +105,12 @@ export default function ToolsBlog({ onBack }) {
   const toggleActionMenu = (postId) => {
     setOpenMenuPostId((currentPostId) =>
       currentPostId === postId ? null : postId
+    );
+  };
+
+  const handleViewModeChange = (mode) => {
+    setViewMode((currentMode) =>
+      currentMode === mode ? currentMode : mode
     );
   };
 
@@ -177,6 +189,30 @@ export default function ToolsBlog({ onBack }) {
             <button type="button" className="blog-pill" disabled>
               Public toggle soon
             </button>
+            <div className="blog-view-toggle" role="group" aria-label="View mode">
+              <button
+                type="button"
+                className={`blog-view-button ${viewMode === VIEW_MODES.LIST ? 'blog-view-button--active' : ''}`}
+                onClick={() => handleViewModeChange(VIEW_MODES.LIST)}
+                aria-pressed={viewMode === VIEW_MODES.LIST}
+              >
+                <span className="blog-view-icon" aria-hidden="true">
+                  ☰
+                </span>
+                <span className="blog-view-label">List</span>
+              </button>
+              <button
+                type="button"
+                className={`blog-view-button ${viewMode === VIEW_MODES.GRID ? 'blog-view-button--active' : ''}`}
+                onClick={() => handleViewModeChange(VIEW_MODES.GRID)}
+                aria-pressed={viewMode === VIEW_MODES.GRID}
+              >
+                <span className="blog-view-icon" aria-hidden="true">
+                  ⧉
+                </span>
+                <span className="blog-view-label">Grid</span>
+              </button>
+            </div>
           </div>
         </div>
         <div className="blog-subcopy">
@@ -185,14 +221,21 @@ export default function ToolsBlog({ onBack }) {
         </div>
       </header>
 
-      <div className="blog-feed">
+      <div className={`blog-feed blog-feed--${viewMode}`}>
         {posts.map((post, index) => {
           const isEditing = editingPostId === post.id;
           const currentStatus = isEditing && editDraft ? editDraft.status : post.status;
           const displayIndex = `#${String(index + 1).padStart(2, '0')}`;
+          const articleClassName = [
+            'blog-card',
+            viewMode === VIEW_MODES.GRID ? 'blog-card--grid' : '',
+            isEditing ? 'blog-card--editing' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
 
           return (
-            <article key={post.id} className="blog-card">
+            <article key={post.id} className={articleClassName}>
               <div className="blog-card-header">
                 <div className="blog-card-meta">
                   <span className="blog-card-badge">{currentStatus}</span>

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -64,6 +64,66 @@
   flex-wrap: wrap;
 }
 
+.blog-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.blog-view-button {
+  border: none;
+  background: transparent;
+  color: #c6c9d8;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 8px 12px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 180ms ease, color 180ms ease, transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.blog-view-button:hover,
+.blog-view-button:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  color: #f5f5f5;
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.blog-view-button--active {
+  background: #f5f5f5;
+  color: #050505;
+  box-shadow: 0 14px 30px -22px rgba(255, 255, 255, 0.9);
+}
+
+.blog-view-button--active .blog-view-icon {
+  color: #050505;
+}
+
+.blog-view-icon {
+  font-size: 1.05rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.blog-view-label {
+  display: inline-flex;
+  align-items: center;
+}
+
 .blog-pill {
   padding: 6px 16px;
   border-radius: 999px;
@@ -109,10 +169,21 @@
   width: 100%;
   max-width: 960px;
   margin: 0 auto;
+  padding-bottom: 40px;
+}
+
+.blog-feed--list {
   display: flex;
   flex-direction: column;
   gap: 32px;
-  padding-bottom: 40px;
+}
+
+.blog-feed--grid {
+  max-width: 1240px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 26px;
+  align-items: start;
 }
 
 .blog-card {
@@ -130,6 +201,27 @@
 .blog-card:hover {
   transform: translateY(-4px);
   border-color: rgba(255, 255, 255, 0.18);
+}
+
+.blog-card--grid {
+  border-radius: 24px;
+  padding: 26px;
+  gap: 16px;
+  backdrop-filter: blur(2px);
+  background: linear-gradient(170deg, rgba(40, 40, 40, 0.9), rgba(5, 5, 5, 0.88));
+}
+
+.blog-feed--grid .blog-card--editing {
+  grid-column: 1 / -1;
+}
+
+.blog-card--grid .blog-card-header {
+  align-items: flex-start;
+}
+
+.blog-card--grid .blog-card-body {
+  font-size: 0.98rem;
+  line-height: 1.6;
 }
 
 .blog-card-header {
@@ -396,6 +488,15 @@
   .blog-card-actions {
     width: 100%;
     justify-content: flex-end;
+  }
+
+  .blog-view-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .blog-feed--grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- add a view mode toggle to the tools blog so the feed can switch between list and grid layouts
- style the new controls and cards so the grid view borrows a Tumblr-like multi-column presentation with responsive polish

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68caa04b93908322bbad2b5fa5034e7e