### PR TITLE
Add media attachments and link support to ToolsBlog

### DIFF
--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -23,6 +23,139 @@ const STREAMS = [
 
 const MOODS = ['queued', 'listening', 'charging', 'wide-awake', 'low-fi', 'signal-boost'];
 
+const MAX_IMAGES = 4;
+
+const MEDIA_BLUEPRINTS = [
+  {
+    images: [
+      'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1487058792275-0ad4aaf24ca7?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1461749280684-dccba630e2f6?auto=format&fit=crop&w=1200&q=80',
+    ],
+    link: 'https://www.youtube.com/watch?v=8pJEc-Ky3zE',
+  },
+  {
+    images: [
+      'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1200&q=80',
+    ],
+    link: 'https://www.youtube.com/watch?v=SMKPKGW083c',
+  },
+  {
+    images: [
+      'https://images.unsplash.com/photo-1470790376778-a9fbc86d70e2?auto=format&fit=crop&w=1200&q=80',
+    ],
+    link: 'https://mazed.studio',
+  },
+  {
+    images: [
+      'https://images.unsplash.com/photo-1488229297570-58520851e868?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80',
+    ],
+    link: 'https://open.spotify.com/playlist/37i9dQZF1DX4sWSpwq3LiO',
+  },
+  {
+    images: [
+      'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80',
+      'https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=1200&q=80',
+    ],
+    link: 'https://youtu.be/z9Ul9ccDOqE',
+  },
+  {
+    images: [],
+    link: 'https://www.are.na/mazed-studio',
+  },
+];
+
+const sanitizeImages = (images) =>
+  Array.isArray(images)
+    ? images
+        .map((source) => (typeof source === 'string' ? source.trim() : ''))
+        .filter(Boolean)
+        .slice(0, MAX_IMAGES)
+    : [];
+
+const sanitizeLink = (value) => (typeof value === 'string' ? value.trim() : '');
+
+const parseYouTubeTimestamp = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  if (/^\d+$/.test(value)) {
+    return Number(value);
+  }
+
+  const match = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (!match) {
+    return null;
+  }
+
+  const [, hours, minutes, seconds] = match;
+  const totalSeconds =
+    (hours ? Number(hours) * 3600 : 0) +
+    (minutes ? Number(minutes) * 60 : 0) +
+    (seconds ? Number(seconds) : 0);
+
+  return totalSeconds > 0 ? totalSeconds : null;
+};
+
+const getYouTubeEmbedUrl = (value) => {
+  const link = sanitizeLink(value);
+  if (!link) {
+    return null;
+  }
+
+  try {
+    const url = new URL(link);
+    const host = url.hostname.replace(/^www\./i, '').toLowerCase();
+    const segments = url.pathname.split('/').filter(Boolean);
+
+    let videoId = '';
+    if (host === 'youtu.be') {
+      videoId = segments[0] ?? '';
+    } else if (host.endsWith('youtube.com')) {
+      if (url.searchParams.has('v')) {
+        videoId = url.searchParams.get('v') ?? '';
+      } else if (segments[0] === 'embed' && segments[1]) {
+        videoId = segments[1];
+      } else if (segments[0] === 'shorts' && segments[1]) {
+        videoId = segments[1];
+      }
+    } else {
+      return null;
+    }
+
+    if (!videoId) {
+      return null;
+    }
+
+    const params = new URLSearchParams();
+    params.set('rel', '0');
+
+    let startParam = url.searchParams.get('t') ?? url.searchParams.get('start');
+    if (!startParam && url.hash) {
+      const hashValue = url.hash.replace('#', '');
+      if (hashValue.toLowerCase().startsWith('t=')) {
+        startParam = hashValue.slice(2);
+      }
+    }
+    const startSeconds = parseYouTubeTimestamp(startParam);
+    if (startSeconds) {
+      params.set('start', String(startSeconds));
+    }
+
+    const query = params.toString();
+    return `https://www.youtube.com/embed/${videoId}?${query}`;
+  } catch (error) {
+    return null;
+  }
+};
+
 const MESSAGES = [
   'We are stretching a tall canvas to host entries from the training layer. Every card you see keeps the scroll lively while we wire the live feed.',
   'Future posts will flow in automatically once the bridge from the training layer is ready. Until then, this loop ensures the blog feels endless.',
@@ -37,6 +170,7 @@ const MESSAGES = [
 const PLACEHOLDER_POSTS = Array.from({ length: 48 }, (_, index) => {
   const themeIndex = index % THEMES.length;
   const cycle = Math.floor(index / THEMES.length) + 1;
+  const media = MEDIA_BLUEPRINTS[index % MEDIA_BLUEPRINTS.length] ?? {};
   return {
     id: index + 1,
     title: `${THEMES[themeIndex]} ${String(cycle).padStart(2, '0')}`,
@@ -44,16 +178,28 @@ const PLACEHOLDER_POSTS = Array.from({ length: 48 }, (_, index) => {
     excerpt: MESSAGES[index % MESSAGES.length],
     stream: STREAMS[index % STREAMS.length],
     mood: MOODS[index % MOODS.length],
+    images: sanitizeImages(media.images ?? []),
+    link: sanitizeLink(media.link),
   };
 });
 
+const VIEW_MODES = {
+  LIST: 'list',
+  GRID: 'grid',
+};
+
 export default function ToolsBlog({ onBack }) {
   const [posts, setPosts] = useState(() =>
-    PLACEHOLDER_POSTS.map((post) => ({ ...post }))
+    PLACEHOLDER_POSTS.map((post) => ({
+      ...post,
+      images: sanitizeImages(post.images),
+      link: sanitizeLink(post.link),
+    }))
   );
   const [editingPostId, setEditingPostId] = useState(null);
   const [editDraft, setEditDraft] = useState(null);
   const [openMenuPostId, setOpenMenuPostId] = useState(null);
+  const [viewMode, setViewMode] = useState(VIEW_MODES.LIST);
 
   const closeActionMenu = () => setOpenMenuPostId(null);
 
@@ -66,6 +212,8 @@ export default function ToolsBlog({ onBack }) {
       excerpt: post.excerpt,
       stream: post.stream,
       mood: post.mood,
+      images: sanitizeImages(post.images),
+      link: sanitizeLink(post.link),
     });
   };
 
@@ -80,9 +228,15 @@ export default function ToolsBlog({ onBack }) {
       return;
     }
 
+    const sanitizedDraft = {
+      ...editDraft,
+      images: sanitizeImages(editDraft.images),
+      link: sanitizeLink(editDraft.link),
+    };
+
     setPosts((previousPosts) =>
       previousPosts.map((post) =>
-        post.id === editingPostId ? { ...post, ...editDraft } : post
+        post.id === editingPostId ? { ...post, ...sanitizedDraft } : post
       )
     );
     cancelEditing();
@@ -100,6 +254,62 @@ export default function ToolsBlog({ onBack }) {
     setOpenMenuPostId((currentPostId) =>
       currentPostId === postId ? null : postId
     );
+  };
+
+  const handleViewModeChange = (mode) => {
+    setViewMode((currentMode) =>
+      currentMode === mode ? currentMode : mode
+    );
+  };
+
+  const addImageField = () => {
+    setEditDraft((previousDraft) => {
+      if (previousDraft == null) {
+        return previousDraft;
+      }
+
+      const currentImages = previousDraft.images ?? [];
+      if (currentImages.length >= MAX_IMAGES) {
+        return previousDraft;
+      }
+
+      return {
+        ...previousDraft,
+        images: [...currentImages, ''],
+      };
+    });
+  };
+
+  const updateImageField = (index, value) => {
+    setEditDraft((previousDraft) => {
+      if (previousDraft == null) {
+        return previousDraft;
+      }
+
+      const currentImages = [...(previousDraft.images ?? [])];
+      currentImages[index] = value;
+
+      return {
+        ...previousDraft,
+        images: currentImages,
+      };
+    });
+  };
+
+  const removeImageField = (index) => {
+    setEditDraft((previousDraft) => {
+      if (previousDraft == null) {
+        return previousDraft;
+      }
+
+      const currentImages = [...(previousDraft.images ?? [])];
+      currentImages.splice(index, 1);
+
+      return {
+        ...previousDraft,
+        images: currentImages,
+      };
+    });
   };
 
   const updateDraftField = (field) => (event) => {
@@ -177,6 +387,32 @@ export default function ToolsBlog({ onBack }) {
             <button type="button" className="blog-pill" disabled>
               Public toggle soon
             </button>
+            <div className="blog-view-toggle" role="group" aria-label="View mode">
+              <button
+                type="button"
+                className={`blog-view-button ${viewMode === VIEW_MODES.LIST ? 'blog-view-button--active' : ''}`}
+                onClick={() => handleViewModeChange(VIEW_MODES.LIST)}
+                aria-pressed={viewMode === VIEW_MODES.LIST}
+                aria-label="Show posts in a list"
+                title="List view"
+              >
+                <span className="blog-view-icon" aria-hidden="true">
+                  ☰
+                </span>
+              </button>
+              <button
+                type="button"
+                className={`blog-view-button ${viewMode === VIEW_MODES.GRID ? 'blog-view-button--active' : ''}`}
+                onClick={() => handleViewModeChange(VIEW_MODES.GRID)}
+                aria-pressed={viewMode === VIEW_MODES.GRID}
+                aria-label="Show posts in a grid"
+                title="Grid view"
+              >
+                <span className="blog-view-icon" aria-hidden="true">
+                  ⧉
+                </span>
+              </button>
+            </div>
           </div>
         </div>
         <div className="blog-subcopy">
@@ -185,14 +421,28 @@ export default function ToolsBlog({ onBack }) {
         </div>
       </header>
 
-      <div className="blog-feed">
+      <div className={`blog-feed blog-feed--${viewMode}`}>
         {posts.map((post, index) => {
           const isEditing = editingPostId === post.id;
           const currentStatus = isEditing && editDraft ? editDraft.status : post.status;
           const displayIndex = `#${String(index + 1).padStart(2, '0')}`;
+          const articleClassName = [
+            'blog-card',
+            viewMode === VIEW_MODES.GRID ? 'blog-card--grid' : '',
+            isEditing ? 'blog-card--editing' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          const draftImages = isEditing ? (editDraft?.images ?? []) : [];
+          const imageSources = sanitizeImages(post.images);
+          const linkToDisplay = sanitizeLink(post.link);
+          const youTubeEmbedUrl = getYouTubeEmbedUrl(linkToDisplay);
+          const hasLink = linkToDisplay.length > 0;
+          const hasMedia =
+            imageSources.length > 0 || Boolean(youTubeEmbedUrl) || hasLink;
 
           return (
-            <article key={post.id} className="blog-card">
+            <article key={post.id} className={articleClassName}>
               <div className="blog-card-header">
                 <div className="blog-card-meta">
                   <span className="blog-card-badge">{currentStatus}</span>
@@ -271,6 +521,84 @@ export default function ToolsBlog({ onBack }) {
                   </div>
 
                   <div className="blog-card-field">
+                    <label className="blog-card-label" htmlFor={`link-${post.id}`}>
+                      Attached link
+                    </label>
+                    <input
+                      id={`link-${post.id}`}
+                      type="url"
+                      className="blog-card-input"
+                      placeholder="https://"
+                      value={editDraft?.link ?? ''}
+                      onChange={updateDraftField('link')}
+                    />
+                    <p className="blog-card-hint">
+                      Drop any URL — YouTube links will automatically embed in the post.
+                    </p>
+                  </div>
+
+                  <div className="blog-card-field blog-card-field--media">
+                    <div className="blog-card-label-row">
+                      <span className="blog-card-label">Images</span>
+                      <span className="blog-card-label-helper">Up to {MAX_IMAGES}</span>
+                    </div>
+                    <div className="blog-card-image-list">
+                      {draftImages.length === 0 ? (
+                        <div className="blog-card-image-empty">No images attached yet.</div>
+                      ) : (
+                        draftImages.map((imageUrl, imageIndex) => {
+                          const hasImage =
+                            typeof imageUrl === 'string' && imageUrl.trim().length > 0;
+                          return (
+                            <div
+                              key={`image-${post.id}-${imageIndex}`}
+                              className="blog-card-image-row"
+                            >
+                              <div className="blog-card-image-thumb">
+                                {hasImage ? (
+                                  <img src={imageUrl} alt="" />
+                                ) : (
+                                  <span className="blog-card-image-placeholder">Preview</span>
+                                )}
+                              </div>
+                              <input
+                                type="url"
+                                className="blog-card-input"
+                                placeholder="https://example.com/image.jpg"
+                                value={imageUrl}
+                                onChange={(event) =>
+                                  updateImageField(imageIndex, event.target.value)
+                                }
+                                aria-label={`Image ${imageIndex + 1} URL`}
+                              />
+                              <button
+                                type="button"
+                                className="blog-card-icon-button blog-card-icon-button--small"
+                                onClick={() => removeImageField(imageIndex)}
+                                aria-label={`Remove image ${imageIndex + 1}`}
+                              >
+                                <span aria-hidden="true">✕</span>
+                              </button>
+                            </div>
+                          );
+                        })
+                      )}
+                    </div>
+                    {draftImages.length < MAX_IMAGES && (
+                      <button
+                        type="button"
+                        className="blog-card-button blog-card-button--ghost"
+                        onClick={addImageField}
+                      >
+                        Add image
+                      </button>
+                    )}
+                    <p className="blog-card-hint">
+                      Paste direct image URLs. The gallery adapts to one to four shots.
+                    </p>
+                  </div>
+
+                  <div className="blog-card-field">
                     <label className="blog-card-label" htmlFor={`status-${post.id}`}>
                       Status
                     </label>
@@ -344,6 +672,43 @@ export default function ToolsBlog({ onBack }) {
                 <>
                   <h2 className="blog-card-title">{post.title}</h2>
                   <p className="blog-card-body">{post.excerpt}</p>
+                  {hasMedia && (
+                    <div className="blog-card-media">
+                      {imageSources.length > 0 && (
+                        <div className="blog-card-gallery">
+                          {imageSources.map((source, mediaIndex) => (
+                            <div
+                              key={`${post.id}-image-${mediaIndex}`}
+                              className="blog-card-gallery-item"
+                            >
+                              <img src={source} alt="" loading="lazy" />
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      {youTubeEmbedUrl ? (
+                        <div className="blog-card-video">
+                          <iframe
+                            src={youTubeEmbedUrl}
+                            title={`${post.title} video`}
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            allowFullScreen
+                          />
+                        </div>
+                      ) : null}
+                      {hasLink && (
+                        <a
+                          className="blog-card-link"
+                          href={linkToDisplay}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <span aria-hidden="true">🔗</span>
+                          <span className="blog-card-link-text">{linkToDisplay}</span>
+                        </a>
+                      )}
+                    </div>
+                  )}
                   <div className="blog-card-footer">
                     <span className="blog-card-tag">{post.stream}</span>
                     <span className="blog-card-mood">{post.mood}</span>

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -64,6 +64,61 @@
   flex-wrap: wrap;
 }
 
+.blog-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.blog-view-button {
+  border: none;
+  background: transparent;
+  color: #c6c9d8;
+  font-size: 1.15rem;
+  padding: 8px;
+  width: 42px;
+  height: 40px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 180ms ease, color 180ms ease, transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.blog-view-button:hover,
+.blog-view-button:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  color: #f5f5f5;
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.blog-view-button--active {
+  background: #f5f5f5;
+  color: #050505;
+  box-shadow: 0 14px 30px -22px rgba(255, 255, 255, 0.9);
+}
+
+.blog-view-button--active .blog-view-icon {
+  color: #050505;
+}
+
+.blog-view-icon {
+  font-size: 1.05rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .blog-pill {
   padding: 6px 16px;
   border-radius: 999px;
@@ -109,10 +164,21 @@
   width: 100%;
   max-width: 960px;
   margin: 0 auto;
+  padding-bottom: 40px;
+}
+
+.blog-feed--list {
   display: flex;
   flex-direction: column;
   gap: 32px;
-  padding-bottom: 40px;
+}
+
+.blog-feed--grid {
+  max-width: 1240px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 26px;
+  align-items: start;
 }
 
 .blog-card {
@@ -130,6 +196,27 @@
 .blog-card:hover {
   transform: translateY(-4px);
   border-color: rgba(255, 255, 255, 0.18);
+}
+
+.blog-card--grid {
+  border-radius: 24px;
+  padding: 26px;
+  gap: 16px;
+  backdrop-filter: blur(2px);
+  background: linear-gradient(170deg, rgba(40, 40, 40, 0.9), rgba(5, 5, 5, 0.88));
+}
+
+.blog-feed--grid .blog-card--editing {
+  grid-column: 1 / -1;
+}
+
+.blog-card--grid .blog-card-header {
+  align-items: flex-start;
+}
+
+.blog-card--grid .blog-card-body {
+  font-size: 0.98rem;
+  line-height: 1.6;
 }
 
 .blog-card-header {
@@ -297,6 +384,94 @@
   line-height: 1.7;
 }
 
+.blog-card-media {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.blog-card-gallery {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.blog-card-gallery-item {
+  position: relative;
+  overflow: hidden;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  min-height: 180px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.blog-card-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.blog-card--grid .blog-card-gallery-item {
+  border-radius: 16px;
+  min-height: 150px;
+}
+
+.blog-card-video {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 10, 10, 0.82);
+  box-shadow: 0 28px 60px -36px rgba(0, 0, 0, 0.88);
+}
+
+.blog-card--grid .blog-card-video {
+  border-radius: 18px;
+}
+
+.blog-card-video iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.blog-card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(120, 154, 255, 0.4);
+  background: rgba(120, 154, 255, 0.12);
+  color: #c6d3ff;
+  font-size: 0.92rem;
+  text-decoration: none;
+  word-break: break-word;
+  transition: background 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.blog-card-link:hover,
+.blog-card-link:focus-visible {
+  background: rgba(120, 154, 255, 0.22);
+  box-shadow: 0 20px 36px -28px rgba(120, 154, 255, 0.55);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.blog-card-link span[aria-hidden='true'] {
+  font-size: 1.1rem;
+}
+
+.blog-card-link-text {
+  word-break: break-all;
+}
+
 .blog-card-edit-form {
   display: flex;
   flex-direction: column;
@@ -309,11 +484,29 @@
   gap: 8px;
 }
 
+.blog-card-field--media {
+  gap: 14px;
+}
+
+.blog-card-label-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .blog-card-label {
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #9fa3b5;
+}
+
+.blog-card-label-helper {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6f7488;
 }
 
 .blog-card-input,
@@ -338,6 +531,87 @@
 
 .blog-card-select {
   cursor: pointer;
+}
+
+.blog-card-hint {
+  margin: 4px 0 0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: #8e92a8;
+}
+
+.blog-card-image-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.blog-card-image-empty {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  color: #868aa1;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.blog-card-image-row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) 36px;
+  gap: 12px;
+  align-items: center;
+}
+
+.blog-card-image-thumb {
+  width: 72px;
+  height: 72px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #7a7f93;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.blog-card-image-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.blog-card-image-placeholder {
+  padding: 0 6px;
+}
+
+.blog-card-icon-button--small {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  font-size: 1rem;
+}
+
+.blog-card-icon-button--small span[aria-hidden='true'] {
+  transform: none;
+}
+
+.blog-card-button--ghost {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.16);
+  color: #d1d4e3;
+}
+
+.blog-card-button--ghost:hover,
+.blog-card-button--ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.24);
+  color: #f2f3fa;
 }
 
 .blog-card-input:focus,
@@ -397,6 +671,23 @@
     width: 100%;
     justify-content: flex-end;
   }
+
+  .blog-view-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .blog-feed--grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .blog-card-gallery {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .blog-card-gallery-item {
+    min-height: 160px;
+  }
 }
 
 @media (max-width: 640px) {
@@ -410,5 +701,18 @@
 
   .blog-title h1 {
     font-size: 1.5rem;
+  }
+
+  .blog-card-image-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .blog-card-image-thumb {
+    width: 100%;
+    height: 180px;
+  }
+
+  .blog-card-image-row .blog-card-icon-button--small {
+    justify-self: flex-end;
   }
 }


### PR DESCRIPTION
## Summary
- seed placeholder blog posts with reusable media blueprints and helpers that trim image lists, normalize links, and surface YouTube embeds
- extend the ToolsBlog editor and viewer to manage up to four image URLs plus an attached link, rendering galleries, video embeds, and link badges in each article
- restyle the view toggle to use icon-only buttons and add CSS for the new media gallery, image controls, and responsive layouts

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68caa04b93908322bbad2b5fa5034e7e