### PR TITLE
Revamp notes dashboard UI for improved usability

### DIFF
--- a/NoteModal.jsx
+++ b/NoteModal.jsx
@@ -1,45 +1,120 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
+const TAGS = ['II', 'IE', 'EI', 'EE'];
+const TAG_COLORS = {
+  II: '#f59e0b',
+  IE: '#38bdf8',
+  EI: '#34d399',
+  EE: '#c084fc',
+};
+
 export default function NoteModal({ onClose }) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [tag, setTag] = useState('II');
+  const [tag, setTag] = useState(TAGS[0]);
 
-  const saveNote = () => {
+  const handleSave = () => {
+    const trimmedTitle = title.trim();
+    const trimmedContent = content.trim();
     const notes = JSON.parse(localStorage.getItem('notes') || '[]');
-    notes.push({ id: Date.now(), title: title || 'Untitled', content, tag });
+
+    const newNote = {
+      id: Date.now(),
+      title: trimmedTitle || 'Untitled',
+      content: trimmedContent,
+      tag,
+      createdAt: new Date().toISOString(),
+    };
+
+    notes.push(newNote);
     localStorage.setItem('notes', JSON.stringify(notes));
+
+    setTitle('');
+    setContent('');
+    setTag(TAGS[0]);
     onClose();
   };
 
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
-        <input
-          className="note-title"
-          placeholder="Add a new note"
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-        />
-        <textarea
-          className="note-content"
-          placeholder="Type your note here..."
-          value={content}
-          onChange={e => setContent(e.target.value)}
-        />
-        <select
-          className="note-tag"
-          value={tag}
-          onChange={e => setTag(e.target.value)}
-        >
-          <option value="II">II</option>
-          <option value="IE">IE</option>
-          <option value="EI">EI</option>
-          <option value="EE">EE</option>
-        </select>
-        <div className="actions">
-          <button className="save-button" onClick={saveNote}>Save</button>
+    <div className="modal-overlay" onClick={handleOverlayClick}>
+      <div
+        className="modal notes-modal note-editor-modal"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="note-editor__header">
+          <div>
+            <h3>Capture a new note</h3>
+            <p className="note-editor__subtitle">
+              Give it a clear intention and choose the quadrant so it remains easy to
+              find when you revisit your reflections.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="modal-close-button"
+            onClick={onClose}
+            aria-label="Close note editor"
+          >
+            &times;
+          </button>
+        </header>
+
+        <div className="note-editor__fields">
+          <label className="form-field">
+            <span>Title</span>
+            <input
+              className="note-title"
+              placeholder="Add a descriptive title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </label>
+
+          <label className="form-field">
+            <span>Notes</span>
+            <textarea
+              className="note-content"
+              placeholder="Capture the insight, context, and any next steps..."
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+            />
+          </label>
+        </div>
+
+        <div className="note-editor__footer">
+          <div className="form-field form-field--inline">
+            <span>Quadrant</span>
+            <div className="tag-options">
+              {TAGS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  data-tag={option}
+                  className={`tag-chip ${tag === option ? 'is-active' : ''}`}
+                  style={{ '--tag-color': TAG_COLORS[option] }}
+                  onClick={() => setTag(option)}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="note-editor__actions">
+            <button type="button" className="ghost-button" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="button" className="primary-button" onClick={handleSave}>
+              Save note
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -1,42 +1,326 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import './note-modal.css';
+
+const NOTES_PER_PAGE = 9;
+const TAG_FILTERS = ['ALL', 'II', 'IE', 'EI', 'EE'];
+const TAG_COLORS = {
+  ALL: '#38bdf8',
+  II: '#f59e0b',
+  IE: '#38bdf8',
+  EI: '#34d399',
+  EE: '#c084fc',
+};
+
+const getTagColor = (tag) => TAG_COLORS[tag] || TAG_COLORS.ALL;
+
+const normaliseTimestamp = (note) => {
+  if (note.createdAt) {
+    return { ...note, createdAt: note.createdAt };
+  }
+
+  if (typeof note.id === 'number') {
+    const derivedDate = new Date(note.id);
+    if (!Number.isNaN(derivedDate.getTime())) {
+      return { ...note, createdAt: derivedDate.toISOString() };
+    }
+  }
+
+  return { ...note, createdAt: new Date().toISOString() };
+};
+
+const formatTimestamp = (isoDate) => {
+  if (!isoDate) {
+    return 'Unknown date';
+  }
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown date';
+  }
+
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: date.getFullYear(),
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const previewContent = (content) => {
+  if (!content) {
+    return 'No additional context captured yet.';
+  }
+  const condensed = content.replace(/\s+/g, ' ').trim();
+  if (condensed.length <= 140) {
+    return condensed;
+  }
+  return `${condensed.slice(0, 137)}…`;
+};
+
+const countWords = (content) => {
+  if (!content || !content.trim()) {
+    return 0;
+  }
+  return content.trim().split(/\s+/).length;
+};
 
 export default function NotesListModal({ onClose }) {
   const [notes, setNotes] = useState([]);
-  const [selected, setSelected] = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [tagFilter, setTagFilter] = useState('ALL');
+  const [sortOrder, setSortOrder] = useState('desc');
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem('notes') || '[]');
-    setNotes(stored);
+    let needsPersist = false;
+    const normalised = stored.map((note) => {
+      const withDate = normaliseTimestamp(note);
+      if (withDate.createdAt !== note.createdAt) {
+        needsPersist = true;
+      }
+      return withDate;
+    });
+
+    normalised.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    setNotes(normalised);
+    setSelectedId(normalised[0]?.id ?? null);
+
+    if (needsPersist) {
+      localStorage.setItem('notes', JSON.stringify(normalised));
+    }
   }, []);
 
+  const filteredNotes = useMemo(() => {
+    let result = [...notes];
+
+    if (tagFilter !== 'ALL') {
+      result = result.filter((note) => note.tag === tagFilter);
+    }
+
+    if (searchTerm.trim()) {
+      const lowered = searchTerm.trim().toLowerCase();
+      result = result.filter((note) => {
+        const title = note.title ? note.title.toLowerCase() : '';
+        const content = note.content ? note.content.toLowerCase() : '';
+        return title.includes(lowered) || content.includes(lowered);
+      });
+    }
+
+    result.sort((a, b) => {
+      const first = new Date(a.createdAt);
+      const second = new Date(b.createdAt);
+      return sortOrder === 'desc' ? second - first : first - second;
+    });
+
+    return result;
+  }, [notes, searchTerm, tagFilter, sortOrder]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, tagFilter, sortOrder]);
+
+  const totalPages = filteredNotes.length ? Math.ceil(filteredNotes.length / NOTES_PER_PAGE) : 1;
+  const activePage = Math.min(currentPage, totalPages);
+  const displayPage = filteredNotes.length ? activePage : 1;
+  const displayTotalPages = filteredNotes.length ? totalPages : 1;
+  const startIndex = (activePage - 1) * NOTES_PER_PAGE;
+  const paginatedNotes = filteredNotes.slice(startIndex, startIndex + NOTES_PER_PAGE);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  useEffect(() => {
+    if (!filteredNotes.length) {
+      setSelectedId(null);
+      return;
+    }
+
+    if (!paginatedNotes.some((note) => note.id === selectedId)) {
+      const fallback = paginatedNotes[0] ?? filteredNotes[0];
+      setSelectedId(fallback?.id ?? null);
+    }
+  }, [filteredNotes, paginatedNotes, selectedId]);
+
+  const selectedNote = useMemo(
+    () => filteredNotes.find((note) => note.id === selectedId) ?? null,
+    [filteredNotes, selectedId],
+  );
+
+  const handleSearchChange = (event) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleToggleSort = () => {
+    setSortOrder((previous) => (previous === 'desc' ? 'asc' : 'desc'));
+  };
+
+  const handleResetFilters = () => {
+    setSearchTerm('');
+    setTagFilter('ALL');
+    setSortOrder('desc');
+  };
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
-        {selected ? (
-          <>
-            <h3>{selected.title} [{selected.tag}]</h3>
-            <pre className="note-view-content">{selected.content}</pre>
-            <div className="actions">
-              <button className="save-button" onClick={() => setSelected(null)}>
-                Back
+    <div className="modal-overlay" onClick={handleOverlayClick}>
+      <div className="modal notes-modal notes-list-modal" onClick={(event) => event.stopPropagation()}>
+        <header className="notes-header">
+          <div>
+            <h3>Notes library</h3>
+            <p className="notes-subtitle">
+              {filteredNotes.length} {filteredNotes.length === 1 ? 'entry' : 'entries'} · {notes.length} total saved
+            </p>
+          </div>
+          <button
+            type="button"
+            className="modal-close-button"
+            onClick={onClose}
+            aria-label="Close notes library"
+          >
+            &times;
+          </button>
+        </header>
+
+        <div className="notes-controls">
+          <div className="notes-search">
+            <span className="notes-search__icon" aria-hidden="true">🔍</span>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={handleSearchChange}
+              placeholder="Search notes by title or keywords"
+            />
+            {searchTerm && (
+              <button
+                type="button"
+                className="ghost-button ghost-button--compact"
+                onClick={() => setSearchTerm('')}
+                aria-label="Clear search"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+
+          <div className="notes-filters">
+            <div className="notes-filter">
+              <span>Quadrant</span>
+              <div className="tag-options tag-options--filters">
+                {TAG_FILTERS.map((filter) => (
+                  <button
+                    key={filter}
+                    type="button"
+                    data-tag={filter}
+                    className={`tag-chip ${tagFilter === filter ? 'is-active' : ''}`}
+                    style={{ '--tag-color': getTagColor(filter) }}
+                    onClick={() => setTagFilter(filter)}
+                  >
+                    {filter}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="notes-filter">
+              <span>Sort</span>
+              <button type="button" className="toolbar-button" onClick={handleToggleSort}>
+                {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
               </button>
             </div>
-          </>
-        ) : (
-          <>
-            <h3>Saved Notes</h3>
-            <ul className="notes-list">
-              {notes.map(note => (
-                <li key={note.id}>
-                  <button className="note-line" onClick={() => setSelected(note)}>
-                    {note.title} [{note.tag}]
+          </div>
+        </div>
+
+        <div className="notes-body">
+          <div className="notes-grid">
+            {paginatedNotes.length === 0 ? (
+              <div className="notes-empty">
+                <h4>No notes match your filters</h4>
+                <p>Try adjusting your search or quadrant filters to see more results.</p>
+                {(searchTerm || tagFilter !== 'ALL' || sortOrder !== 'desc') && (
+                  <button type="button" className="ghost-button" onClick={handleResetFilters}>
+                    Reset filters
                   </button>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
+                )}
+              </div>
+            ) : (
+              paginatedNotes.map((note) => (
+                <button
+                  key={note.id}
+                  type="button"
+                  className={`notes-card ${selectedId === note.id ? 'is-selected' : ''}`}
+                  style={{ '--tag-color': getTagColor(note.tag) }}
+                  onClick={() => setSelectedId(note.id)}
+                >
+                  <div className="notes-card__header">
+                    <span className="note-card__tag" data-tag={note.tag}>
+                      {note.tag}
+                    </span>
+                    <span className="notes-card__date">{formatTimestamp(note.createdAt)}</span>
+                  </div>
+                  <h4 className="notes-card__title" title={note.title}>
+                    {note.title || 'Untitled note'}
+                  </h4>
+                  <p className="notes-card__preview">{previewContent(note.content)}</p>
+                </button>
+              ))
+            )}
+          </div>
+
+          <aside className="notes-detail">
+            {selectedNote ? (
+              <>
+                <div className="notes-detail__header">
+                  <span className="note-card__tag" data-tag={selectedNote.tag}>
+                    {selectedNote.tag}
+                  </span>
+                  <span className="notes-detail__date">{formatTimestamp(selectedNote.createdAt)}</span>
+                  <span className="notes-detail__meta">{countWords(selectedNote.content)} words</span>
+                </div>
+                <h4 className="notes-detail__title">{selectedNote.title || 'Untitled note'}</h4>
+                <pre className="note-view-content">{selectedNote.content || 'No additional context captured yet.'}</pre>
+              </>
+            ) : (
+              <div className="notes-empty-detail">
+                <h4>Select a note to read it</h4>
+                <p>Your detailed view will appear here once you choose a note on the left.</p>
+              </div>
+            )}
+          </aside>
+        </div>
+
+        <footer className="notes-footer">
+          <div className="notes-pagination">
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+              disabled={activePage <= 1}
+            >
+              Previous
+            </button>
+            <span>
+              Page {displayPage} of {displayTotalPages}
+            </span>
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+              disabled={activePage >= totalPages || !filteredNotes.length}
+            >
+              Next
+            </button>
+          </div>
+        </footer>
       </div>
     </div>
   );

--- a/note-modal.css
+++ b/note-modal.css
@@ -9,6 +9,7 @@
   justify-content: center;
   align-items: center;
   z-index: 1000;
+  backdrop-filter: blur(2px);
 }
 
 .modal {
@@ -67,6 +68,7 @@
   border: none;
   border-radius: 6px;
   cursor: pointer;
+  transition: background 0.2s ease;
 }
 
 .save-button:hover {
@@ -81,6 +83,7 @@
   border-radius: 6px;
   cursor: pointer;
   margin-left: 8px;
+  transition: background 0.2s ease;
 }
 
 .done-button:hover {
@@ -103,14 +106,17 @@
   background: #f0f0f0;
   text-align: left;
   cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .note-line:hover {
   background: #e0e0e0;
+  transform: translateY(-1px);
 }
 
 .note-view-content {
   white-space: pre-wrap;
+  margin: 0;
 }
 
 .akashic-button {
@@ -119,4 +125,593 @@
   cursor: pointer;
   align-self: flex-end;
   color: inherit;
+}
+
+/* --- Notes experience refresh --- */
+
+.notes-modal {
+  width: min(960px, calc(100vw - 48px));
+  max-height: 88vh;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.95) 0%, rgba(2, 6, 23, 0.92) 100%);
+  color: #e2e8f0;
+  padding: 28px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 32px 80px -32px rgba(15, 23, 42, 0.8);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow: hidden;
+  position: relative;
+}
+
+.note-editor-modal {
+  width: min(720px, calc(100vw - 48px));
+  gap: 24px;
+}
+
+.notes-list-modal {
+  width: min(1080px, calc(100vw - 48px));
+  gap: 24px;
+}
+
+.modal-close-button {
+  background: rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  color: #e2e8f0;
+  border-radius: 999px;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.modal-close-button:hover {
+  background: rgba(148, 163, 184, 0.24);
+  border-color: rgba(148, 163, 184, 0.36);
+  transform: translateY(-1px);
+}
+
+.notes-modal h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.note-editor__header,
+.notes-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.note-editor__subtitle,
+.notes-subtitle {
+  margin: 6px 0 0;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.notes-subtitle {
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+.note-editor__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.notes-modal .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #94a3b8;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.notes-modal .form-field span {
+  font-weight: 600;
+}
+
+.notes-modal .form-field input,
+.notes-modal .form-field textarea {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: normal;
+  text-transform: none;
+  background: rgba(15, 23, 42, 0.35);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 14px;
+  padding: 12px 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.notes-modal .form-field input:focus,
+.notes-modal .form-field textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
+}
+
+.notes-modal .note-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.notes-modal .note-content {
+  min-height: 220px;
+  resize: vertical;
+  line-height: 1.6;
+  font-size: 0.98rem;
+}
+
+.note-editor__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.form-field--inline {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.notes-modal .tag-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.tag-chip {
+  --tag-color: #38bdf8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.tag-chip:hover {
+  background: rgba(148, 163, 184, 0.22);
+  transform: translateY(-1px);
+}
+
+.tag-chip.is-active {
+  background: var(--tag-color);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #020617;
+}
+
+.primary-button {
+  padding: 10px 22px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px -16px rgba(37, 99, 235, 0.7);
+}
+
+.ghost-button {
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.3);
+  color: #e2e8f0;
+  font-weight: 500;
+  font-size: 0.9rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.ghost-button:hover {
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.4);
+  transform: translateY(-1px);
+}
+
+.ghost-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.ghost-button--compact {
+  padding: 6px 12px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.toolbar-button {
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.35);
+  color: #e2e8f0;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.toolbar-button:hover {
+  background: rgba(148, 163, 184, 0.24);
+  border-color: rgba(148, 163, 184, 0.4);
+  transform: translateY(-1px);
+}
+
+.note-editor__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.notes-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: stretch;
+}
+
+.notes-search {
+  flex: 1 1 280px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.notes-search input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: #f8fafc;
+  font-size: 0.95rem;
+  outline: none;
+}
+
+.notes-search input::placeholder {
+  color: #64748b;
+}
+
+.notes-search__icon {
+  font-size: 1rem;
+}
+
+.notes-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  align-items: center;
+}
+
+.notes-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: #94a3b8;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.notes-body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+.notes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+  align-content: flex-start;
+  overflow-y: auto;
+  padding-right: 6px;
+  min-height: 0;
+}
+
+.notes-card {
+  --tag-color: #38bdf8;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.55);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  min-height: 180px;
+}
+
+.notes-card:hover {
+  transform: translateY(-4px);
+  background: rgba(30, 41, 59, 0.75);
+  border-color: rgba(148, 163, 184, 0.32);
+  box-shadow: 0 18px 30px -22px rgba(15, 23, 42, 0.8);
+}
+
+.notes-card.is-selected {
+  border-color: var(--tag-color);
+  background: rgba(15, 23, 42, 0.82);
+  box-shadow: 0 20px 36px -24px var(--tag-color);
+}
+
+.notes-card__header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.note-card__tag {
+  --tag-color: #38bdf8;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: var(--tag-color);
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.note-card__tag[data-tag='ALL'],
+.tag-chip[data-tag='ALL'] {
+  --tag-color: #38bdf8;
+}
+
+.note-card__tag[data-tag='II'],
+.tag-chip[data-tag='II'] {
+  --tag-color: #f59e0b;
+}
+
+.note-card__tag[data-tag='IE'],
+.tag-chip[data-tag='IE'] {
+  --tag-color: #38bdf8;
+}
+
+.note-card__tag[data-tag='EI'],
+.tag-chip[data-tag='EI'] {
+  --tag-color: #34d399;
+}
+
+.note-card__tag[data-tag='EE'],
+.tag-chip[data-tag='EE'] {
+  --tag-color: #c084fc;
+}
+
+.notes-card__date,
+.notes-detail__date,
+.notes-detail__meta {
+  color: #94a3b8;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.notes-card__title {
+  margin: 4px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.notes-card__preview {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #cbd5f5;
+}
+
+.notes-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  padding: 22px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.notes-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.notes-detail__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.notes-modal .note-view-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px;
+  background: rgba(15, 23, 42, 0.3);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  color: #e2e8f0;
+  font-size: 0.96rem;
+  line-height: 1.65;
+}
+
+.notes-empty,
+.notes-empty-detail {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.35);
+  color: #cbd5f5;
+  min-height: 220px;
+}
+
+.notes-empty h4,
+.notes-empty-detail h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #f8fafc;
+}
+
+.notes-empty p,
+.notes-empty-detail p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.notes-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.notes-pagination {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.notes-pagination span {
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1080px) {
+  .notes-list-modal {
+    width: min(980px, calc(100vw - 32px));
+  }
+}
+
+@media (max-width: 960px) {
+  .notes-body {
+    grid-template-columns: 1fr;
+  }
+
+  .notes-detail {
+    order: -1;
+  }
+
+  .notes-grid {
+    max-height: 45vh;
+  }
+}
+
+@media (max-width: 720px) {
+  .note-editor__header,
+  .notes-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .modal-close-button {
+    align-self: flex-end;
+  }
+
+  .note-editor__footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .note-editor__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .notes-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .notes-filters {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 560px) {
+  .notes-modal {
+    padding: 20px;
+    gap: 18px;
+  }
+
+  .notes-search {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .notes-search__icon {
+    align-self: flex-start;
+  }
+
+  .ghost-button--compact {
+    align-self: flex-end;
+  }
+
+  .notes-card {
+    min-height: auto;
+  }
 }

--- a/src/NoteModal.jsx
+++ b/src/NoteModal.jsx
@@ -1,45 +1,120 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
+const TAGS = ['II', 'IE', 'EI', 'EE'];
+const TAG_COLORS = {
+  II: '#f59e0b',
+  IE: '#38bdf8',
+  EI: '#34d399',
+  EE: '#c084fc',
+};
+
 export default function NoteModal({ onClose }) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [tag, setTag] = useState('II');
+  const [tag, setTag] = useState(TAGS[0]);
 
-  const saveNote = () => {
+  const handleSave = () => {
+    const trimmedTitle = title.trim();
+    const trimmedContent = content.trim();
     const notes = JSON.parse(localStorage.getItem('notes') || '[]');
-    notes.push({ id: Date.now(), title: title || 'Untitled', content, tag });
+
+    const newNote = {
+      id: Date.now(),
+      title: trimmedTitle || 'Untitled',
+      content: trimmedContent,
+      tag,
+      createdAt: new Date().toISOString(),
+    };
+
+    notes.push(newNote);
     localStorage.setItem('notes', JSON.stringify(notes));
+
+    setTitle('');
+    setContent('');
+    setTag(TAGS[0]);
     onClose();
   };
 
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
-        <input
-          className="note-title"
-          placeholder="Add a new note"
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-        />
-        <textarea
-          className="note-content"
-          placeholder="Type your note here..."
-          value={content}
-          onChange={e => setContent(e.target.value)}
-        />
-        <select
-          className="note-tag"
-          value={tag}
-          onChange={e => setTag(e.target.value)}
-        >
-          <option value="II">II</option>
-          <option value="IE">IE</option>
-          <option value="EI">EI</option>
-          <option value="EE">EE</option>
-        </select>
-        <div className="actions">
-          <button className="save-button" onClick={saveNote}>Save</button>
+    <div className="modal-overlay" onClick={handleOverlayClick}>
+      <div
+        className="modal notes-modal note-editor-modal"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="note-editor__header">
+          <div>
+            <h3>Capture a new note</h3>
+            <p className="note-editor__subtitle">
+              Give it a clear intention and choose the quadrant so it remains easy to
+              find when you revisit your reflections.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="modal-close-button"
+            onClick={onClose}
+            aria-label="Close note editor"
+          >
+            &times;
+          </button>
+        </header>
+
+        <div className="note-editor__fields">
+          <label className="form-field">
+            <span>Title</span>
+            <input
+              className="note-title"
+              placeholder="Add a descriptive title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+            />
+          </label>
+
+          <label className="form-field">
+            <span>Notes</span>
+            <textarea
+              className="note-content"
+              placeholder="Capture the insight, context, and any next steps..."
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+            />
+          </label>
+        </div>
+
+        <div className="note-editor__footer">
+          <div className="form-field form-field--inline">
+            <span>Quadrant</span>
+            <div className="tag-options">
+              {TAGS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  data-tag={option}
+                  className={`tag-chip ${tag === option ? 'is-active' : ''}`}
+                  style={{ '--tag-color': TAG_COLORS[option] }}
+                  onClick={() => setTag(option)}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="note-editor__actions">
+            <button type="button" className="ghost-button" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="button" className="primary-button" onClick={handleSave}>
+              Save note
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -1,42 +1,326 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import './note-modal.css';
+
+const NOTES_PER_PAGE = 9;
+const TAG_FILTERS = ['ALL', 'II', 'IE', 'EI', 'EE'];
+const TAG_COLORS = {
+  ALL: '#38bdf8',
+  II: '#f59e0b',
+  IE: '#38bdf8',
+  EI: '#34d399',
+  EE: '#c084fc',
+};
+
+const getTagColor = (tag) => TAG_COLORS[tag] || TAG_COLORS.ALL;
+
+const normaliseTimestamp = (note) => {
+  if (note.createdAt) {
+    return { ...note, createdAt: note.createdAt };
+  }
+
+  if (typeof note.id === 'number') {
+    const derivedDate = new Date(note.id);
+    if (!Number.isNaN(derivedDate.getTime())) {
+      return { ...note, createdAt: derivedDate.toISOString() };
+    }
+  }
+
+  return { ...note, createdAt: new Date().toISOString() };
+};
+
+const formatTimestamp = (isoDate) => {
+  if (!isoDate) {
+    return 'Unknown date';
+  }
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown date';
+  }
+
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: date.getFullYear(),
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const previewContent = (content) => {
+  if (!content) {
+    return 'No additional context captured yet.';
+  }
+  const condensed = content.replace(/\s+/g, ' ').trim();
+  if (condensed.length <= 140) {
+    return condensed;
+  }
+  return `${condensed.slice(0, 137)}…`;
+};
+
+const countWords = (content) => {
+  if (!content || !content.trim()) {
+    return 0;
+  }
+  return content.trim().split(/\s+/).length;
+};
 
 export default function NotesListModal({ onClose }) {
   const [notes, setNotes] = useState([]);
-  const [selected, setSelected] = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [tagFilter, setTagFilter] = useState('ALL');
+  const [sortOrder, setSortOrder] = useState('desc');
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     const stored = JSON.parse(localStorage.getItem('notes') || '[]');
-    setNotes(stored);
+    let needsPersist = false;
+    const normalised = stored.map((note) => {
+      const withDate = normaliseTimestamp(note);
+      if (withDate.createdAt !== note.createdAt) {
+        needsPersist = true;
+      }
+      return withDate;
+    });
+
+    normalised.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    setNotes(normalised);
+    setSelectedId(normalised[0]?.id ?? null);
+
+    if (needsPersist) {
+      localStorage.setItem('notes', JSON.stringify(normalised));
+    }
   }, []);
 
+  const filteredNotes = useMemo(() => {
+    let result = [...notes];
+
+    if (tagFilter !== 'ALL') {
+      result = result.filter((note) => note.tag === tagFilter);
+    }
+
+    if (searchTerm.trim()) {
+      const lowered = searchTerm.trim().toLowerCase();
+      result = result.filter((note) => {
+        const title = note.title ? note.title.toLowerCase() : '';
+        const content = note.content ? note.content.toLowerCase() : '';
+        return title.includes(lowered) || content.includes(lowered);
+      });
+    }
+
+    result.sort((a, b) => {
+      const first = new Date(a.createdAt);
+      const second = new Date(b.createdAt);
+      return sortOrder === 'desc' ? second - first : first - second;
+    });
+
+    return result;
+  }, [notes, searchTerm, tagFilter, sortOrder]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, tagFilter, sortOrder]);
+
+  const totalPages = filteredNotes.length ? Math.ceil(filteredNotes.length / NOTES_PER_PAGE) : 1;
+  const activePage = Math.min(currentPage, totalPages);
+  const displayPage = filteredNotes.length ? activePage : 1;
+  const displayTotalPages = filteredNotes.length ? totalPages : 1;
+  const startIndex = (activePage - 1) * NOTES_PER_PAGE;
+  const paginatedNotes = filteredNotes.slice(startIndex, startIndex + NOTES_PER_PAGE);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  useEffect(() => {
+    if (!filteredNotes.length) {
+      setSelectedId(null);
+      return;
+    }
+
+    if (!paginatedNotes.some((note) => note.id === selectedId)) {
+      const fallback = paginatedNotes[0] ?? filteredNotes[0];
+      setSelectedId(fallback?.id ?? null);
+    }
+  }, [filteredNotes, paginatedNotes, selectedId]);
+
+  const selectedNote = useMemo(
+    () => filteredNotes.find((note) => note.id === selectedId) ?? null,
+    [filteredNotes, selectedId],
+  );
+
+  const handleSearchChange = (event) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleToggleSort = () => {
+    setSortOrder((previous) => (previous === 'desc' ? 'asc' : 'desc'));
+  };
+
+  const handleResetFilters = () => {
+    setSearchTerm('');
+    setTagFilter('ALL');
+    setSortOrder('desc');
+  };
+
+  const handleOverlayClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={e => e.stopPropagation()}>
-        {selected ? (
-          <>
-            <h3>{selected.title} [{selected.tag}]</h3>
-            <pre className="note-view-content">{selected.content}</pre>
-            <div className="actions">
-              <button className="save-button" onClick={() => setSelected(null)}>
-                Back
+    <div className="modal-overlay" onClick={handleOverlayClick}>
+      <div className="modal notes-modal notes-list-modal" onClick={(event) => event.stopPropagation()}>
+        <header className="notes-header">
+          <div>
+            <h3>Notes library</h3>
+            <p className="notes-subtitle">
+              {filteredNotes.length} {filteredNotes.length === 1 ? 'entry' : 'entries'} · {notes.length} total saved
+            </p>
+          </div>
+          <button
+            type="button"
+            className="modal-close-button"
+            onClick={onClose}
+            aria-label="Close notes library"
+          >
+            &times;
+          </button>
+        </header>
+
+        <div className="notes-controls">
+          <div className="notes-search">
+            <span className="notes-search__icon" aria-hidden="true">🔍</span>
+            <input
+              type="search"
+              value={searchTerm}
+              onChange={handleSearchChange}
+              placeholder="Search notes by title or keywords"
+            />
+            {searchTerm && (
+              <button
+                type="button"
+                className="ghost-button ghost-button--compact"
+                onClick={() => setSearchTerm('')}
+                aria-label="Clear search"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+
+          <div className="notes-filters">
+            <div className="notes-filter">
+              <span>Quadrant</span>
+              <div className="tag-options tag-options--filters">
+                {TAG_FILTERS.map((filter) => (
+                  <button
+                    key={filter}
+                    type="button"
+                    data-tag={filter}
+                    className={`tag-chip ${tagFilter === filter ? 'is-active' : ''}`}
+                    style={{ '--tag-color': getTagColor(filter) }}
+                    onClick={() => setTagFilter(filter)}
+                  >
+                    {filter}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="notes-filter">
+              <span>Sort</span>
+              <button type="button" className="toolbar-button" onClick={handleToggleSort}>
+                {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
               </button>
             </div>
-          </>
-        ) : (
-          <>
-            <h3>Saved Notes</h3>
-            <ul className="notes-list">
-              {notes.map(note => (
-                <li key={note.id}>
-                  <button className="note-line" onClick={() => setSelected(note)}>
-                    {note.title} [{note.tag}]
+          </div>
+        </div>
+
+        <div className="notes-body">
+          <div className="notes-grid">
+            {paginatedNotes.length === 0 ? (
+              <div className="notes-empty">
+                <h4>No notes match your filters</h4>
+                <p>Try adjusting your search or quadrant filters to see more results.</p>
+                {(searchTerm || tagFilter !== 'ALL' || sortOrder !== 'desc') && (
+                  <button type="button" className="ghost-button" onClick={handleResetFilters}>
+                    Reset filters
                   </button>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
+                )}
+              </div>
+            ) : (
+              paginatedNotes.map((note) => (
+                <button
+                  key={note.id}
+                  type="button"
+                  className={`notes-card ${selectedId === note.id ? 'is-selected' : ''}`}
+                  style={{ '--tag-color': getTagColor(note.tag) }}
+                  onClick={() => setSelectedId(note.id)}
+                >
+                  <div className="notes-card__header">
+                    <span className="note-card__tag" data-tag={note.tag}>
+                      {note.tag}
+                    </span>
+                    <span className="notes-card__date">{formatTimestamp(note.createdAt)}</span>
+                  </div>
+                  <h4 className="notes-card__title" title={note.title}>
+                    {note.title || 'Untitled note'}
+                  </h4>
+                  <p className="notes-card__preview">{previewContent(note.content)}</p>
+                </button>
+              ))
+            )}
+          </div>
+
+          <aside className="notes-detail">
+            {selectedNote ? (
+              <>
+                <div className="notes-detail__header">
+                  <span className="note-card__tag" data-tag={selectedNote.tag}>
+                    {selectedNote.tag}
+                  </span>
+                  <span className="notes-detail__date">{formatTimestamp(selectedNote.createdAt)}</span>
+                  <span className="notes-detail__meta">{countWords(selectedNote.content)} words</span>
+                </div>
+                <h4 className="notes-detail__title">{selectedNote.title || 'Untitled note'}</h4>
+                <pre className="note-view-content">{selectedNote.content || 'No additional context captured yet.'}</pre>
+              </>
+            ) : (
+              <div className="notes-empty-detail">
+                <h4>Select a note to read it</h4>
+                <p>Your detailed view will appear here once you choose a note on the left.</p>
+              </div>
+            )}
+          </aside>
+        </div>
+
+        <footer className="notes-footer">
+          <div className="notes-pagination">
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+              disabled={activePage <= 1}
+            >
+              Previous
+            </button>
+            <span>
+              Page {displayPage} of {displayTotalPages}
+            </span>
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
+              disabled={activePage >= totalPages || !filteredNotes.length}
+            >
+              Next
+            </button>
+          </div>
+        </footer>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- redesign the note creation modal with structured fields, tag chips, and a modernised layout while saving timestamps for new notes
- replace the saved notes modal with a searchable, filterable, paginated gallery and a dedicated detail preview pane
- refresh the shared modal stylesheet and mirror the updates in the duplicated components under `src/` for parity

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cab19446dc83229f14fd2d52a01254