### PR TITLE
Fix NotesListModal filters markup

### DIFF
--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -411,26 +411,6 @@ export default function NotesListModal({ onClose }) {
               <button type="button" className="toolbar-button" onClick={handleToggleSort}>
                 {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
               </button>
-            )}
-          </div>
-
-          <div className="notes-filters">
-            <div className="notes-filter">
-              <span>Quadrant</span>
-              <div className="tag-options tag-options--filters">
-                {TAG_FILTERS.map((filter) => (
-                  <button
-                    key={filter}
-                    type="button"
-                    data-tag={filter}
-                    className={`tag-chip ${tagFilter === filter ? 'is-active' : ''}`}
-                    style={{ '--tag-color': getTagColor(filter) }}
-                    onClick={() => setTagFilter(filter)}
-                  >
-                    {filter}
-                  </button>
-                ))}
-              </div>
             </div>
           </div>
         </div>

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -411,26 +411,6 @@ export default function NotesListModal({ onClose }) {
               <button type="button" className="toolbar-button" onClick={handleToggleSort}>
                 {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
               </button>
-            )}
-          </div>
-
-          <div className="notes-filters">
-            <div className="notes-filter">
-              <span>Quadrant</span>
-              <div className="tag-options tag-options--filters">
-                {TAG_FILTERS.map((filter) => (
-                  <button
-                    key={filter}
-                    type="button"
-                    data-tag={filter}
-                    className={`tag-chip ${tagFilter === filter ? 'is-active' : ''}`}
-                    style={{ '--tag-color': getTagColor(filter) }}
-                    onClick={() => setTagFilter(filter)}
-                  >
-                    {filter}
-                  </button>
-                ))}
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the stray closing bracket and duplicated filter markup in the notes list modal
- keep the controls container well-formed so the modal renders and builds correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cac9e000f4832293b05215545125a7