### PR TITLE
Handle storage errors when normalising notes

### DIFF
--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -245,7 +245,11 @@ export default function NotesListModal({ onClose }) {
     setSelectedId(displayNotes[0]?.id ?? null);
 
     if (shouldPersist) {
-      localStorage.setItem('notes', JSON.stringify(persistableNotes));
+      try {
+        localStorage.setItem('notes', JSON.stringify(persistableNotes));
+      } catch (error) {
+        console.warn('Failed to update stored notes', error);
+      }
     }
   }, []);
 

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -245,7 +245,11 @@ export default function NotesListModal({ onClose }) {
     setSelectedId(displayNotes[0]?.id ?? null);
 
     if (shouldPersist) {
-      localStorage.setItem('notes', JSON.stringify(persistableNotes));
+      try {
+        localStorage.setItem('notes', JSON.stringify(persistableNotes));
+      } catch (error) {
+        console.warn('Failed to update stored notes', error);
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- guard the notes library normalisation step against localStorage write failures
- log a warning instead of crashing when rewriting the cached notes collection
- mirror the fix in both copies of NotesListModal that ship with the app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd7d501808322b8e1ed02b9e7f480