### PR TITLE
Rebuild notes reader modal from scratch

### DIFF
--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import './note-modal.css';
 
-const NOTES_PER_PAGE = 9;
-const TAG_FILTERS = ['ALL', 'II', 'IE', 'EI', 'EE'];
+const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE'];
+const TAG_OPTIONS = ['ALL', ...QUADRANT_TAGS];
 const TAG_COLORS = {
   ALL: '#38bdf8',
   II: '#f59e0b',
@@ -11,493 +11,536 @@ const TAG_COLORS = {
   EE: '#c084fc',
 };
 
-const VALID_NOTE_TAGS = new Set(TAG_FILTERS.slice(1));
+const getLocalStorage = () => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const isPlainObject = (value) => value != null && typeof value === 'object' && !Array.isArray(value);
+
+const isValidDate = (value) => value instanceof Date && !Number.isNaN(value.getTime());
+
+const parseDate = (value) => {
+  if (value == null) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return isValidDate(value) ? value : null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    const dateFromNumber = new Date(value);
+    return isValidDate(dateFromNumber) ? dateFromNumber : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const dateFromString = new Date(trimmed);
+    if (isValidDate(dateFromString)) {
+      return dateFromString;
+    }
+
+    const numeric = Number(trimmed);
+    if (!Number.isNaN(numeric)) {
+      const dateFromNumeric = new Date(numeric);
+      if (isValidDate(dateFromNumeric)) {
+        return dateFromNumeric;
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof value === 'bigint') {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return null;
+    }
+
+    const dateFromBigInt = new Date(numeric);
+    return isValidDate(dateFromBigInt) ? dateFromBigInt : null;
+  }
+
+  if (isPlainObject(value)) {
+    if (typeof value.toDate === 'function') {
+      try {
+        const dateFromMethod = parseDate(value.toDate());
+        if (dateFromMethod) {
+          return dateFromMethod;
+        }
+      } catch {
+        // ignore conversion failures from custom toDate implementations
+      }
+    }
+
+    const secondsSource =
+      value.seconds ?? value._seconds ?? value.epochSeconds ?? value.value ?? null;
+    if (secondsSource != null) {
+      const seconds = Number(secondsSource);
+      if (Number.isFinite(seconds)) {
+        let milliseconds = seconds * 1000;
+
+        const nanosSource = value.nanoseconds ?? value._nanoseconds ?? value.nanos ?? 0;
+        const nanos = Number(nanosSource);
+        if (Number.isFinite(nanos)) {
+          milliseconds += Math.floor(nanos / 1e6);
+        }
+
+        const dateFromSeconds = new Date(milliseconds);
+        if (isValidDate(dateFromSeconds)) {
+          return dateFromSeconds;
+        }
+      }
+    }
+
+    if (typeof value.valueOf === 'function') {
+      const primitive = value.valueOf();
+      if (primitive !== value) {
+        const fromPrimitive = parseDate(primitive);
+        if (fromPrimitive) {
+          return fromPrimitive;
+        }
+      }
+    }
+  }
+
+  return null;
+};
+
+const formatDateTime = (date) => {
+  if (!isValidDate(date)) {
+    return 'Unknown date';
+  }
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  } catch {
+    return date.toISOString();
+  }
+};
+
+const toText = (value) => {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toText(item)).filter(Boolean).join('\n');
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+
+  return '';
+};
+
+const createPreview = (content) => {
+  const trimmed = content.replace(/\s+/g, ' ').trim();
+  if (!trimmed) {
+    return 'No additional context yet.';
+  }
+
+  return trimmed.length > 160 ? `${trimmed.slice(0, 157)}…` : trimmed;
+};
+
+const normaliseNote = (entry, index) => {
+  if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean' || typeof entry === 'bigint') {
+    const text = toText(entry).trim();
+    if (!text) {
+      return null;
+    }
+
+    const createdAt = new Date(0);
+
+    return {
+      id: `note-${index}`,
+      referenceId: null,
+      title: text.slice(0, 60) || 'Untitled note',
+      content: text,
+      tag: 'II',
+      createdAt,
+      createdAtLabel: formatDateTime(createdAt),
+      updatedAtLabel: null,
+      preview: createPreview(text),
+      searchable: text.toLowerCase(),
+      sortKey: createdAt.getTime(),
+      wordCount: text ? text.split(/\s+/).filter(Boolean).length : 0,
+      characterCount: text.length,
+    };
+  }
+
+  if (!isPlainObject(entry)) {
+    return null;
+  }
+
+  let referenceId = null;
+  const idSource =
+    entry.id ?? entry.noteId ?? entry.uuid ?? entry.key ?? entry.identifier ?? entry.note_id;
+  if (typeof idSource === 'string' && idSource.trim()) {
+    referenceId = idSource.trim();
+  } else if (typeof idSource === 'number' && Number.isFinite(idSource)) {
+    referenceId = String(idSource);
+  } else if (typeof idSource === 'bigint') {
+    referenceId = idSource.toString();
+  }
+
+  const baseId = referenceId ? `${referenceId}-${index}` : `note-${index}`;
+
+  const rawTitle = toText(entry.title ?? entry.name ?? entry.heading ?? '');
+  const rawContent = toText(entry.content ?? entry.body ?? entry.note ?? entry.text ?? '');
+  const content = rawContent;
+  const titleFromContent = content.split(/\n/).find((line) => line.trim()) || '';
+  const title = rawTitle.trim() || titleFromContent.trim() || 'Untitled note';
+
+  const tagCandidate = toText(entry.tag ?? entry.quadrant ?? entry.category ?? '').trim().toUpperCase();
+  const tag = QUADRANT_TAGS.includes(tagCandidate) ? tagCandidate : 'II';
+
+  const createdAtSource =
+    entry.createdAt ??
+    entry.created_at ??
+    entry.created ??
+    entry.date ??
+    entry.timestamp ??
+    entry.time ??
+    entry.inserted_at ??
+    entry.savedAt ??
+    null;
+  const createdAt = parseDate(createdAtSource) ?? new Date(0);
+  const sortKey = isValidDate(createdAt) ? createdAt.getTime() : 0;
+
+  const updatedAtSource =
+    entry.updatedAt ?? entry.updated_at ?? entry.modifiedAt ?? entry.editedAt ?? entry.lastUpdated;
+  const updatedAt = parseDate(updatedAtSource);
+
+  const preview = createPreview(content);
+  const searchable = `${title} ${content} ${tag}`.toLowerCase();
+  const wordCount = content.trim() ? content.trim().split(/\s+/).length : 0;
+
+  return {
+    id: baseId,
+    referenceId,
+    title,
+    content,
+    tag,
+    createdAt,
+    createdAtLabel: formatDateTime(createdAt),
+    updatedAtLabel: updatedAt ? formatDateTime(updatedAt) : null,
+    preview,
+    searchable,
+    sortKey,
+    wordCount,
+    characterCount: content.length,
+  };
+};
 
 const loadStoredNotes = () => {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return [];
+  }
+
   try {
-    const raw = localStorage.getItem('notes');
+    const raw = storage.getItem('notes');
     if (!raw) {
       return [];
     }
 
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      return parsed;
-    }
+    const source = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.notes)
+      ? parsed.notes
+      : [];
 
-    if (parsed && Array.isArray(parsed.notes)) {
-      return parsed.notes;
-    }
-  } catch (error) {
-    console.warn('Failed to parse stored notes', error);
-  }
-
-  return [];
-};
-
-const toPlainText = (value) => {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (value == null) {
-    return '';
-  }
-
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => toPlainText(item))
+    const normalised = source
+      .map((entry, index) => normaliseNote(entry, index))
       .filter(Boolean)
-      .join('\n')
-      .trim();
+      .map((note, index) => ({
+        ...note,
+        id: `${note.id}-${index}`,
+        sortKey: Number.isFinite(note.sortKey) ? note.sortKey : 0,
+      }));
+
+    normalised.sort((a, b) => {
+      if (b.sortKey !== a.sortKey) {
+        return b.sortKey - a.sortKey;
+      }
+
+      return a.title.localeCompare(b.title);
+    });
+
+    return normalised;
+  } catch (error) {
+    console.warn('Failed to load notes from storage', error);
+    return [];
   }
-
-  if (typeof value === 'object') {
-    if (typeof value.text === 'string') {
-      return value.text;
-    }
-
-    if (Array.isArray(value.ops)) {
-      return value.ops
-        .map((operation) => {
-          const insert = operation?.insert;
-          if (typeof insert === 'string') {
-            return insert;
-          }
-
-          if (insert && typeof insert === 'object') {
-            if (typeof insert.text === 'string') {
-              return insert.text;
-            }
-
-            if (Array.isArray(insert)) {
-              return toPlainText(insert);
-            }
-          }
-
-          return '';
-        })
-        .join('');
-    }
-
-    try {
-      return JSON.stringify(value);
-    } catch (error) {
-      return String(value);
-    }
-  }
-
-  return String(value);
 };
 
-const sanitiseTitle = (value) => {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (value == null) {
-    return '';
-  }
-
-  return String(value);
-};
-
-const resolveTimestamp = (note, fallbackBase, index) => {
-  if (note.createdAt) {
-    const fromStored = new Date(note.createdAt);
-    if (!Number.isNaN(fromStored.getTime())) {
-      return fromStored.toISOString();
-    }
-  }
-
-  if (typeof note.id === 'number') {
-    const fromId = new Date(note.id);
-    if (!Number.isNaN(fromId.getTime())) {
-      return fromId.toISOString();
-    }
-  }
-
-  const fallback = new Date(fallbackBase + index);
-  if (!Number.isNaN(fallback.getTime())) {
-    return fallback.toISOString();
-  }
-
-  return new Date().toISOString();
-};
-
-const normaliseEntry = (entry, fallbackBase, index) => {
-  const base = entry && typeof entry === 'object' ? { ...entry } : { content: entry };
-  let mutated = !entry || typeof entry !== 'object';
-
-  if (base.id == null || base.id === '') {
-    base.id = `note-${fallbackBase}-${index}`;
-    mutated = true;
-  }
-
-  const safeTag = VALID_NOTE_TAGS.has(base.tag) ? base.tag : 'II';
-  if (safeTag !== base.tag) {
-    mutated = true;
-  }
-
-  const safeTitle = sanitiseTitle(base.title);
-  if (safeTitle !== base.title) {
-    mutated = true;
-  }
-
-  const safeContent = toPlainText(base.content);
-  if (safeContent !== base.content) {
-    mutated = true;
-  }
-
-  const createdAt = resolveTimestamp(base, fallbackBase, index);
-  if (createdAt !== base.createdAt) {
-    mutated = true;
-  }
-
-  const persistable = {
-    ...base,
-    id: base.id,
-    tag: safeTag,
-    title: safeTitle,
-    content: safeContent,
-    createdAt,
-  };
-
-  const display = {
-    id: persistable.id,
-    tag: persistable.tag,
-    title: persistable.title,
-    content: persistable.content,
-    createdAt: persistable.createdAt,
-  };
-
-  return { persistable, display, mutated };
-};
-
-const sortByDateDesc = (first, second) => new Date(second.createdAt) - new Date(first.createdAt);
-
-const formatTimestamp = (isoDate) => {
-  if (!isoDate) {
-    return 'Unknown date';
-  }
-  const date = new Date(isoDate);
-  if (Number.isNaN(date.getTime())) {
-    return 'Unknown date';
-  }
-
-  return date.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: date.getFullYear(),
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
-
-const previewContent = (content) => {
-  if (!content) {
-    return 'No additional context captured yet.';
-  }
-  const condensed = content.replace(/\s+/g, ' ').trim();
-  if (condensed.length <= 140) {
-    return condensed;
-  }
-  return `${condensed.slice(0, 137)}…`;
-};
-
-const countWords = (content) => {
-  if (!content || !content.trim()) {
-    return 0;
-  }
-  return content.trim().split(/\s+/).length;
-};
-
-const getTagColor = (tag) => TAG_COLORS[tag] || TAG_COLORS.ALL;
+const pluralise = (count, singular, plural) => (count === 1 ? singular : plural);
 
 export default function NotesListModal({ onClose }) {
-  const [notes, setNotes] = useState([]);
-  const [selectedId, setSelectedId] = useState(null);
+  const [notes, setNotes] = useState(() => loadStoredNotes());
   const [searchTerm, setSearchTerm] = useState('');
-  const [tagFilter, setTagFilter] = useState('ALL');
-  const [sortOrder, setSortOrder] = useState('desc');
-  const [currentPage, setCurrentPage] = useState(1);
-
-  useEffect(() => {
-    const stored = loadStoredNotes();
-    const fallbackBase = Date.now();
-    const persistableNotes = [];
-    const displayNotes = [];
-    let shouldPersist = false;
-
-    stored.forEach((entry, index) => {
-      const { persistable, display, mutated } = normaliseEntry(entry, fallbackBase, index);
-      persistableNotes.push(persistable);
-      displayNotes.push(display);
-      if (mutated) {
-        shouldPersist = true;
-      }
-    });
-
-    persistableNotes.sort(sortByDateDesc);
-    displayNotes.sort(sortByDateDesc);
-
-    setNotes(displayNotes);
-    setSelectedId(displayNotes[0]?.id ?? null);
-
-    if (shouldPersist) {
-      localStorage.setItem('notes', JSON.stringify(persistableNotes));
-    }
-  }, []);
+  const [activeTag, setActiveTag] = useState('ALL');
+  const [selectedId, setSelectedId] = useState(null);
 
   const filteredNotes = useMemo(() => {
-    const trimmedSearch = searchTerm.trim().toLowerCase();
-    let working = notes;
-
-    if (tagFilter !== 'ALL') {
-      working = working.filter((note) => note.tag === tagFilter);
-    }
-
-    if (trimmedSearch) {
-      working = working.filter((note) => {
-        const title = note.title ? note.title.toLowerCase() : '';
-        const content = note.content ? note.content.toLowerCase() : '';
-        return title.includes(trimmedSearch) || content.includes(trimmedSearch);
-      });
-    }
-
-    const sorted = [...working];
-    sorted.sort((first, second) => {
-      const firstDate = new Date(first.createdAt);
-      const secondDate = new Date(second.createdAt);
-      return sortOrder === 'desc' ? secondDate - firstDate : firstDate - secondDate;
-    });
-
-    return sorted;
-  }, [notes, searchTerm, tagFilter, sortOrder]);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchTerm, tagFilter, sortOrder]);
-
-  const totalPages = filteredNotes.length ? Math.ceil(filteredNotes.length / NOTES_PER_PAGE) : 1;
-  const activePage = Math.min(currentPage, totalPages);
-  const startIndex = (activePage - 1) * NOTES_PER_PAGE;
-  const paginatedNotes = filteredNotes.slice(startIndex, startIndex + NOTES_PER_PAGE);
-  const displayPage = filteredNotes.length ? activePage : 1;
-  const displayTotalPages = filteredNotes.length ? totalPages : 1;
-
-  useEffect(() => {
-    if (currentPage > totalPages) {
-      setCurrentPage(totalPages);
-    }
-  }, [currentPage, totalPages]);
-
-  useEffect(() => {
-    if (!filteredNotes.length) {
-      if (selectedId !== null) {
-        setSelectedId(null);
+    const query = searchTerm.trim().toLowerCase();
+    return notes.filter((note) => {
+      const matchesTag = activeTag === 'ALL' || note.tag === activeTag;
+      if (!matchesTag) {
+        return false;
       }
+
+      if (!query) {
+        return true;
+      }
+
+      return note.searchable.includes(query);
+    });
+  }, [notes, activeTag, searchTerm]);
+
+  useEffect(() => {
+    if (filteredNotes.length === 0) {
+      setSelectedId(null);
       return;
     }
 
-    const hasSelected = filteredNotes.some((note) => note.id === selectedId);
-    if (!hasSelected) {
-      const fallback = paginatedNotes[0] ?? filteredNotes[0];
-      setSelectedId(fallback?.id ?? null);
+    setSelectedId((currentId) => {
+      if (currentId && filteredNotes.some((note) => note.id === currentId)) {
+        return currentId;
+      }
+
+      return filteredNotes[0].id;
+    });
+  }, [filteredNotes]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
     }
-  }, [filteredNotes, paginatedNotes, selectedId]);
 
-  const selectedNote = useMemo(
-    () => filteredNotes.find((note) => note.id === selectedId) ?? null,
-    [filteredNotes, selectedId],
-  );
+    const handleStorage = (event) => {
+      if (event.key === 'notes') {
+        setNotes(loadStoredNotes());
+      }
+    };
 
-  const selectedWordCount = selectedNote ? countWords(selectedNote.content) : 0;
-  const filtersActive = searchTerm || tagFilter !== 'ALL' || sortOrder !== 'desc';
+    const handleFocus = () => {
+      setNotes(loadStoredNotes());
+    };
 
-  const handleSearchChange = (event) => {
-    setSearchTerm(event.target.value);
-  };
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener('focus', handleFocus);
 
-  const handleToggleSort = () => {
-    setSortOrder((previous) => (previous === 'desc' ? 'asc' : 'desc'));
-  };
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, []);
 
-  const handleResetFilters = () => {
-    setSearchTerm('');
-    setTagFilter('ALL');
-    setSortOrder('desc');
-    setCurrentPage(1);
-  };
+  const tagCounts = useMemo(() => {
+    const counts = { ALL: notes.length };
+    QUADRANT_TAGS.forEach((tag) => {
+      counts[tag] = 0;
+    });
+
+    notes.forEach((note) => {
+      counts[note.tag] = (counts[note.tag] ?? 0) + 1;
+    });
+
+    return counts;
+  }, [notes]);
+
+  const selectedNote = filteredNotes.find((note) => note.id === selectedId) ?? null;
+
+  const subtitle = useMemo(() => {
+    if (notes.length === 0) {
+      return 'You have not captured any notes yet. Write a reflection from the Fifth to see it here.';
+    }
+
+    if (filteredNotes.length === 0) {
+      return 'No notes match your filters. Clear the search or pick a different quadrant to continue.';
+    }
+
+    if (activeTag === 'ALL' && !searchTerm.trim() && filteredNotes.length === notes.length) {
+      return `Browsing all ${notes.length} saved ${pluralise(notes.length, 'note', 'notes')}.`;
+    }
+
+    return `Showing ${filteredNotes.length} of ${notes.length} saved ${pluralise(notes.length, 'note', 'notes')}.`;
+  }, [notes, filteredNotes, activeTag, searchTerm]);
 
   const handleOverlayClick = (event) => {
-    if (event.target === event.currentTarget) {
+    if (event.target === event.currentTarget && typeof onClose === 'function') {
       onClose();
     }
   };
 
+  const handleRefresh = () => {
+    setNotes(loadStoredNotes());
+  };
+
   return (
     <div className="modal-overlay" onClick={handleOverlayClick}>
-      <div
-        className="modal notes-modal notes-list-modal"
-        onClick={(event) => event.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="notes-library-title"
-      >
+      <div className="modal notes-modal notes-list-modal" onClick={(event) => event.stopPropagation()}>
         <header className="notes-header">
           <div>
-            <h3 id="notes-library-title">Notes library</h3>
-            <p className="notes-subtitle">
-              {filteredNotes.length} {filteredNotes.length === 1 ? 'entry' : 'entries'} · {notes.length} total saved
-            </p>
+            <h3>Your notes library</h3>
+            <p className="notes-subtitle">{subtitle}</p>
           </div>
           <button
             type="button"
             className="modal-close-button"
             onClick={onClose}
-            aria-label="Close notes library"
+            aria-label="Close notes list"
           >
             &times;
           </button>
         </header>
 
         <div className="notes-controls">
-          <div className="notes-search">
+          <label className="notes-search">
             <span className="notes-search__icon" aria-hidden="true">
               🔍
             </span>
             <input
               type="search"
+              placeholder="Search notes by title, content, or quadrant"
               value={searchTerm}
-              onChange={handleSearchChange}
-              placeholder="Search notes by title or keywords"
-              aria-label="Search notes"
+              onChange={(event) => setSearchTerm(event.target.value)}
             />
-            {searchTerm && (
-              <button
-                type="button"
-                className="ghost-button ghost-button--compact"
-                onClick={() => setSearchTerm('')}
-                aria-label="Clear search"
-              >
-                Clear
-              </button>
-            )}
-          </div>
+          </label>
 
           <div className="notes-filters">
             <div className="notes-filter">
               <span>Quadrant</span>
-              <div className="tag-options tag-options--filters">
-                {TAG_FILTERS.map((filter) => (
+              <div className="tag-options">
+                {TAG_OPTIONS.map((option) => (
                   <button
-                    key={filter}
+                    key={option}
                     type="button"
-                    data-tag={filter}
-                    className={`tag-chip ${tagFilter === filter ? 'is-active' : ''}`}
-                    style={{ '--tag-color': getTagColor(filter) }}
-                    onClick={() => setTagFilter(filter)}
-                    aria-pressed={tagFilter === filter}
+                    data-tag={option}
+                    className={`tag-chip ${activeTag === option ? 'is-active' : ''}`}
+                    style={{ '--tag-color': TAG_COLORS[option] }}
+                    onClick={() => setActiveTag(option)}
                   >
-                    {filter}
+                    {option}
+                    <span aria-hidden="true"> ({tagCounts[option] ?? 0})</span>
                   </button>
                 ))}
               </div>
-            </div>
-
-            <div className="notes-filter">
-              <span>Sort</span>
-              <button type="button" className="toolbar-button" onClick={handleToggleSort}>
-                {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
-              </button>
             </div>
           </div>
         </div>
 
         <div className="notes-body">
-          <div className="notes-grid" aria-live="polite">
-            {paginatedNotes.length === 0 ? (
+          <div className="notes-grid">
+            {filteredNotes.length === 0 ? (
               <div className="notes-empty">
-                <h4>No notes match your filters</h4>
-                <p>Try adjusting your search or quadrant filters to see more results.</p>
-                {filtersActive && (
-                  <button type="button" className="ghost-button" onClick={handleResetFilters}>
-                    Reset filters
-                  </button>
-                )}
+                <h4>No notes to show</h4>
+                <p>Try clearing the search or selecting a different quadrant to continue browsing.</p>
               </div>
             ) : (
-              paginatedNotes.map((note) => (
+              filteredNotes.map((note) => (
                 <button
                   key={note.id}
                   type="button"
                   className={`notes-card ${selectedId === note.id ? 'is-selected' : ''}`}
-                  style={{ '--tag-color': getTagColor(note.tag) }}
+                  style={{ '--tag-color': TAG_COLORS[note.tag] }}
                   onClick={() => setSelectedId(note.id)}
-                  aria-pressed={selectedId === note.id}
                 >
                   <div className="notes-card__header">
                     <span className="note-card__tag" data-tag={note.tag}>
                       {note.tag}
                     </span>
-                    <span className="notes-card__date">{formatTimestamp(note.createdAt)}</span>
+                    <span className="notes-card__date">{note.createdAtLabel}</span>
                   </div>
-                  <h4 className="notes-card__title" title={note.title}>
-                    {note.title || 'Untitled note'}
-                  </h4>
-                  <p className="notes-card__preview">{previewContent(note.content)}</p>
+                  <h4 className="notes-card__title">{note.title}</h4>
+                  <p className="notes-card__preview">{note.preview}</p>
                 </button>
               ))
             )}
           </div>
 
-          <div className="notes-detail" aria-live="polite">
+          <aside className="notes-detail">
             {selectedNote ? (
-              <React.Fragment>
+              <>
                 <div className="notes-detail__header">
                   <span className="note-card__tag" data-tag={selectedNote.tag}>
                     {selectedNote.tag}
                   </span>
-                  <span className="notes-detail__date">{formatTimestamp(selectedNote.createdAt)}</span>
-                  <span className="notes-detail__meta">
-                    {selectedWordCount} {selectedWordCount === 1 ? 'word' : 'words'}
-                  </span>
+                  <div className="notes-detail__meta">
+                    <span>Created {selectedNote.createdAtLabel}</span>
+                    {selectedNote.updatedAtLabel ? (
+                      <span>Updated {selectedNote.updatedAtLabel}</span>
+                    ) : null}
+                    <span>
+                      {selectedNote.wordCount}{' '}
+                      {pluralise(selectedNote.wordCount, 'word', 'words')}
+                    </span>
+                    <span>{selectedNote.characterCount} characters</span>
+                    {selectedNote.referenceId ? (
+                      <span>Ref. {selectedNote.referenceId}</span>
+                    ) : null}
+                  </div>
                 </div>
-                <h4 className="notes-detail__title">{selectedNote.title || 'Untitled note'}</h4>
-                <pre className="note-view-content">
-                  {selectedNote.content || 'No additional context captured yet.'}
-                </pre>
-              </React.Fragment>
+                <h4 className="notes-detail__title">{selectedNote.title}</h4>
+                <div className="note-view-content">
+                  {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
+                </div>
+              </>
             ) : (
               <div className="notes-empty-detail">
-                <h4>Select a note to read it</h4>
-                <p>Your detailed view will appear here once you choose a note on the left.</p>
+                <h4>{notes.length === 0 ? 'No saved notes yet' : 'Select a note to read it'}</h4>
+                <p>
+                  {notes.length === 0
+                    ? 'Capture your reflections from the Fifth quadrant to build your personal library.'
+                    : 'Choose any note from the list to explore its full content.'}
+                </p>
               </div>
             )}
-          </div>
+          </aside>
         </div>
 
         <footer className="notes-footer">
           <div className="notes-pagination">
-            <button
-              type="button"
-              className="ghost-button"
-              onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
-              disabled={activePage <= 1}
-            >
-              Previous
-            </button>
             <span>
-              Page {displayPage} of {displayTotalPages}
+              {notes.length === 0
+                ? 'No notes stored'
+                : filteredNotes.length === notes.length && activeTag === 'ALL' && !searchTerm.trim()
+                ? `${notes.length} ${pluralise(notes.length, 'note', 'notes')}`
+                : `${filteredNotes.length} of ${notes.length} notes`}
             </span>
             <button
               type="button"
-              className="ghost-button"
-              onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
-              disabled={activePage >= totalPages || !filteredNotes.length}
+              className="ghost-button ghost-button--compact"
+              onClick={handleRefresh}
             >
-              Next
+              Refresh
             </button>
           </div>
         </footer>
@@ -505,3 +548,4 @@ export default function NotesListModal({ onClose }) {
     </div>
   );
 }
+

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import './note-modal.css';
 
-const NOTES_PER_PAGE = 9;
-const TAG_FILTERS = ['ALL', 'II', 'IE', 'EI', 'EE'];
+const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE'];
+const TAG_OPTIONS = ['ALL', ...QUADRANT_TAGS];
 const TAG_COLORS = {
   ALL: '#38bdf8',
   II: '#f59e0b',
@@ -11,493 +11,536 @@ const TAG_COLORS = {
   EE: '#c084fc',
 };
 
-const VALID_NOTE_TAGS = new Set(TAG_FILTERS.slice(1));
+const getLocalStorage = () => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const isPlainObject = (value) => value != null && typeof value === 'object' && !Array.isArray(value);
+
+const isValidDate = (value) => value instanceof Date && !Number.isNaN(value.getTime());
+
+const parseDate = (value) => {
+  if (value == null) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return isValidDate(value) ? value : null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    const dateFromNumber = new Date(value);
+    return isValidDate(dateFromNumber) ? dateFromNumber : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const dateFromString = new Date(trimmed);
+    if (isValidDate(dateFromString)) {
+      return dateFromString;
+    }
+
+    const numeric = Number(trimmed);
+    if (!Number.isNaN(numeric)) {
+      const dateFromNumeric = new Date(numeric);
+      if (isValidDate(dateFromNumeric)) {
+        return dateFromNumeric;
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof value === 'bigint') {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return null;
+    }
+
+    const dateFromBigInt = new Date(numeric);
+    return isValidDate(dateFromBigInt) ? dateFromBigInt : null;
+  }
+
+  if (isPlainObject(value)) {
+    if (typeof value.toDate === 'function') {
+      try {
+        const dateFromMethod = parseDate(value.toDate());
+        if (dateFromMethod) {
+          return dateFromMethod;
+        }
+      } catch {
+        // ignore conversion failures from custom toDate implementations
+      }
+    }
+
+    const secondsSource =
+      value.seconds ?? value._seconds ?? value.epochSeconds ?? value.value ?? null;
+    if (secondsSource != null) {
+      const seconds = Number(secondsSource);
+      if (Number.isFinite(seconds)) {
+        let milliseconds = seconds * 1000;
+
+        const nanosSource = value.nanoseconds ?? value._nanoseconds ?? value.nanos ?? 0;
+        const nanos = Number(nanosSource);
+        if (Number.isFinite(nanos)) {
+          milliseconds += Math.floor(nanos / 1e6);
+        }
+
+        const dateFromSeconds = new Date(milliseconds);
+        if (isValidDate(dateFromSeconds)) {
+          return dateFromSeconds;
+        }
+      }
+    }
+
+    if (typeof value.valueOf === 'function') {
+      const primitive = value.valueOf();
+      if (primitive !== value) {
+        const fromPrimitive = parseDate(primitive);
+        if (fromPrimitive) {
+          return fromPrimitive;
+        }
+      }
+    }
+  }
+
+  return null;
+};
+
+const formatDateTime = (date) => {
+  if (!isValidDate(date)) {
+    return 'Unknown date';
+  }
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date);
+  } catch {
+    return date.toISOString();
+  }
+};
+
+const toText = (value) => {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toText(item)).filter(Boolean).join('\n');
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+
+  return '';
+};
+
+const createPreview = (content) => {
+  const trimmed = content.replace(/\s+/g, ' ').trim();
+  if (!trimmed) {
+    return 'No additional context yet.';
+  }
+
+  return trimmed.length > 160 ? `${trimmed.slice(0, 157)}…` : trimmed;
+};
+
+const normaliseNote = (entry, index) => {
+  if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean' || typeof entry === 'bigint') {
+    const text = toText(entry).trim();
+    if (!text) {
+      return null;
+    }
+
+    const createdAt = new Date(0);
+
+    return {
+      id: `note-${index}`,
+      referenceId: null,
+      title: text.slice(0, 60) || 'Untitled note',
+      content: text,
+      tag: 'II',
+      createdAt,
+      createdAtLabel: formatDateTime(createdAt),
+      updatedAtLabel: null,
+      preview: createPreview(text),
+      searchable: text.toLowerCase(),
+      sortKey: createdAt.getTime(),
+      wordCount: text ? text.split(/\s+/).filter(Boolean).length : 0,
+      characterCount: text.length,
+    };
+  }
+
+  if (!isPlainObject(entry)) {
+    return null;
+  }
+
+  let referenceId = null;
+  const idSource =
+    entry.id ?? entry.noteId ?? entry.uuid ?? entry.key ?? entry.identifier ?? entry.note_id;
+  if (typeof idSource === 'string' && idSource.trim()) {
+    referenceId = idSource.trim();
+  } else if (typeof idSource === 'number' && Number.isFinite(idSource)) {
+    referenceId = String(idSource);
+  } else if (typeof idSource === 'bigint') {
+    referenceId = idSource.toString();
+  }
+
+  const baseId = referenceId ? `${referenceId}-${index}` : `note-${index}`;
+
+  const rawTitle = toText(entry.title ?? entry.name ?? entry.heading ?? '');
+  const rawContent = toText(entry.content ?? entry.body ?? entry.note ?? entry.text ?? '');
+  const content = rawContent;
+  const titleFromContent = content.split(/\n/).find((line) => line.trim()) || '';
+  const title = rawTitle.trim() || titleFromContent.trim() || 'Untitled note';
+
+  const tagCandidate = toText(entry.tag ?? entry.quadrant ?? entry.category ?? '').trim().toUpperCase();
+  const tag = QUADRANT_TAGS.includes(tagCandidate) ? tagCandidate : 'II';
+
+  const createdAtSource =
+    entry.createdAt ??
+    entry.created_at ??
+    entry.created ??
+    entry.date ??
+    entry.timestamp ??
+    entry.time ??
+    entry.inserted_at ??
+    entry.savedAt ??
+    null;
+  const createdAt = parseDate(createdAtSource) ?? new Date(0);
+  const sortKey = isValidDate(createdAt) ? createdAt.getTime() : 0;
+
+  const updatedAtSource =
+    entry.updatedAt ?? entry.updated_at ?? entry.modifiedAt ?? entry.editedAt ?? entry.lastUpdated;
+  const updatedAt = parseDate(updatedAtSource);
+
+  const preview = createPreview(content);
+  const searchable = `${title} ${content} ${tag}`.toLowerCase();
+  const wordCount = content.trim() ? content.trim().split(/\s+/).length : 0;
+
+  return {
+    id: baseId,
+    referenceId,
+    title,
+    content,
+    tag,
+    createdAt,
+    createdAtLabel: formatDateTime(createdAt),
+    updatedAtLabel: updatedAt ? formatDateTime(updatedAt) : null,
+    preview,
+    searchable,
+    sortKey,
+    wordCount,
+    characterCount: content.length,
+  };
+};
 
 const loadStoredNotes = () => {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return [];
+  }
+
   try {
-    const raw = localStorage.getItem('notes');
+    const raw = storage.getItem('notes');
     if (!raw) {
       return [];
     }
 
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      return parsed;
-    }
+    const source = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.notes)
+      ? parsed.notes
+      : [];
 
-    if (parsed && Array.isArray(parsed.notes)) {
-      return parsed.notes;
-    }
-  } catch (error) {
-    console.warn('Failed to parse stored notes', error);
-  }
-
-  return [];
-};
-
-const toPlainText = (value) => {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (value == null) {
-    return '';
-  }
-
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => toPlainText(item))
+    const normalised = source
+      .map((entry, index) => normaliseNote(entry, index))
       .filter(Boolean)
-      .join('\n')
-      .trim();
+      .map((note, index) => ({
+        ...note,
+        id: `${note.id}-${index}`,
+        sortKey: Number.isFinite(note.sortKey) ? note.sortKey : 0,
+      }));
+
+    normalised.sort((a, b) => {
+      if (b.sortKey !== a.sortKey) {
+        return b.sortKey - a.sortKey;
+      }
+
+      return a.title.localeCompare(b.title);
+    });
+
+    return normalised;
+  } catch (error) {
+    console.warn('Failed to load notes from storage', error);
+    return [];
   }
-
-  if (typeof value === 'object') {
-    if (typeof value.text === 'string') {
-      return value.text;
-    }
-
-    if (Array.isArray(value.ops)) {
-      return value.ops
-        .map((operation) => {
-          const insert = operation?.insert;
-          if (typeof insert === 'string') {
-            return insert;
-          }
-
-          if (insert && typeof insert === 'object') {
-            if (typeof insert.text === 'string') {
-              return insert.text;
-            }
-
-            if (Array.isArray(insert)) {
-              return toPlainText(insert);
-            }
-          }
-
-          return '';
-        })
-        .join('');
-    }
-
-    try {
-      return JSON.stringify(value);
-    } catch (error) {
-      return String(value);
-    }
-  }
-
-  return String(value);
 };
 
-const sanitiseTitle = (value) => {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (value == null) {
-    return '';
-  }
-
-  return String(value);
-};
-
-const resolveTimestamp = (note, fallbackBase, index) => {
-  if (note.createdAt) {
-    const fromStored = new Date(note.createdAt);
-    if (!Number.isNaN(fromStored.getTime())) {
-      return fromStored.toISOString();
-    }
-  }
-
-  if (typeof note.id === 'number') {
-    const fromId = new Date(note.id);
-    if (!Number.isNaN(fromId.getTime())) {
-      return fromId.toISOString();
-    }
-  }
-
-  const fallback = new Date(fallbackBase + index);
-  if (!Number.isNaN(fallback.getTime())) {
-    return fallback.toISOString();
-  }
-
-  return new Date().toISOString();
-};
-
-const normaliseEntry = (entry, fallbackBase, index) => {
-  const base = entry && typeof entry === 'object' ? { ...entry } : { content: entry };
-  let mutated = !entry || typeof entry !== 'object';
-
-  if (base.id == null || base.id === '') {
-    base.id = `note-${fallbackBase}-${index}`;
-    mutated = true;
-  }
-
-  const safeTag = VALID_NOTE_TAGS.has(base.tag) ? base.tag : 'II';
-  if (safeTag !== base.tag) {
-    mutated = true;
-  }
-
-  const safeTitle = sanitiseTitle(base.title);
-  if (safeTitle !== base.title) {
-    mutated = true;
-  }
-
-  const safeContent = toPlainText(base.content);
-  if (safeContent !== base.content) {
-    mutated = true;
-  }
-
-  const createdAt = resolveTimestamp(base, fallbackBase, index);
-  if (createdAt !== base.createdAt) {
-    mutated = true;
-  }
-
-  const persistable = {
-    ...base,
-    id: base.id,
-    tag: safeTag,
-    title: safeTitle,
-    content: safeContent,
-    createdAt,
-  };
-
-  const display = {
-    id: persistable.id,
-    tag: persistable.tag,
-    title: persistable.title,
-    content: persistable.content,
-    createdAt: persistable.createdAt,
-  };
-
-  return { persistable, display, mutated };
-};
-
-const sortByDateDesc = (first, second) => new Date(second.createdAt) - new Date(first.createdAt);
-
-const formatTimestamp = (isoDate) => {
-  if (!isoDate) {
-    return 'Unknown date';
-  }
-  const date = new Date(isoDate);
-  if (Number.isNaN(date.getTime())) {
-    return 'Unknown date';
-  }
-
-  return date.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: date.getFullYear(),
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
-
-const previewContent = (content) => {
-  if (!content) {
-    return 'No additional context captured yet.';
-  }
-  const condensed = content.replace(/\s+/g, ' ').trim();
-  if (condensed.length <= 140) {
-    return condensed;
-  }
-  return `${condensed.slice(0, 137)}…`;
-};
-
-const countWords = (content) => {
-  if (!content || !content.trim()) {
-    return 0;
-  }
-  return content.trim().split(/\s+/).length;
-};
-
-const getTagColor = (tag) => TAG_COLORS[tag] || TAG_COLORS.ALL;
+const pluralise = (count, singular, plural) => (count === 1 ? singular : plural);
 
 export default function NotesListModal({ onClose }) {
-  const [notes, setNotes] = useState([]);
-  const [selectedId, setSelectedId] = useState(null);
+  const [notes, setNotes] = useState(() => loadStoredNotes());
   const [searchTerm, setSearchTerm] = useState('');
-  const [tagFilter, setTagFilter] = useState('ALL');
-  const [sortOrder, setSortOrder] = useState('desc');
-  const [currentPage, setCurrentPage] = useState(1);
-
-  useEffect(() => {
-    const stored = loadStoredNotes();
-    const fallbackBase = Date.now();
-    const persistableNotes = [];
-    const displayNotes = [];
-    let shouldPersist = false;
-
-    stored.forEach((entry, index) => {
-      const { persistable, display, mutated } = normaliseEntry(entry, fallbackBase, index);
-      persistableNotes.push(persistable);
-      displayNotes.push(display);
-      if (mutated) {
-        shouldPersist = true;
-      }
-    });
-
-    persistableNotes.sort(sortByDateDesc);
-    displayNotes.sort(sortByDateDesc);
-
-    setNotes(displayNotes);
-    setSelectedId(displayNotes[0]?.id ?? null);
-
-    if (shouldPersist) {
-      localStorage.setItem('notes', JSON.stringify(persistableNotes));
-    }
-  }, []);
+  const [activeTag, setActiveTag] = useState('ALL');
+  const [selectedId, setSelectedId] = useState(null);
 
   const filteredNotes = useMemo(() => {
-    const trimmedSearch = searchTerm.trim().toLowerCase();
-    let working = notes;
-
-    if (tagFilter !== 'ALL') {
-      working = working.filter((note) => note.tag === tagFilter);
-    }
-
-    if (trimmedSearch) {
-      working = working.filter((note) => {
-        const title = note.title ? note.title.toLowerCase() : '';
-        const content = note.content ? note.content.toLowerCase() : '';
-        return title.includes(trimmedSearch) || content.includes(trimmedSearch);
-      });
-    }
-
-    const sorted = [...working];
-    sorted.sort((first, second) => {
-      const firstDate = new Date(first.createdAt);
-      const secondDate = new Date(second.createdAt);
-      return sortOrder === 'desc' ? secondDate - firstDate : firstDate - secondDate;
-    });
-
-    return sorted;
-  }, [notes, searchTerm, tagFilter, sortOrder]);
-
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchTerm, tagFilter, sortOrder]);
-
-  const totalPages = filteredNotes.length ? Math.ceil(filteredNotes.length / NOTES_PER_PAGE) : 1;
-  const activePage = Math.min(currentPage, totalPages);
-  const startIndex = (activePage - 1) * NOTES_PER_PAGE;
-  const paginatedNotes = filteredNotes.slice(startIndex, startIndex + NOTES_PER_PAGE);
-  const displayPage = filteredNotes.length ? activePage : 1;
-  const displayTotalPages = filteredNotes.length ? totalPages : 1;
-
-  useEffect(() => {
-    if (currentPage > totalPages) {
-      setCurrentPage(totalPages);
-    }
-  }, [currentPage, totalPages]);
-
-  useEffect(() => {
-    if (!filteredNotes.length) {
-      if (selectedId !== null) {
-        setSelectedId(null);
+    const query = searchTerm.trim().toLowerCase();
+    return notes.filter((note) => {
+      const matchesTag = activeTag === 'ALL' || note.tag === activeTag;
+      if (!matchesTag) {
+        return false;
       }
+
+      if (!query) {
+        return true;
+      }
+
+      return note.searchable.includes(query);
+    });
+  }, [notes, activeTag, searchTerm]);
+
+  useEffect(() => {
+    if (filteredNotes.length === 0) {
+      setSelectedId(null);
       return;
     }
 
-    const hasSelected = filteredNotes.some((note) => note.id === selectedId);
-    if (!hasSelected) {
-      const fallback = paginatedNotes[0] ?? filteredNotes[0];
-      setSelectedId(fallback?.id ?? null);
+    setSelectedId((currentId) => {
+      if (currentId && filteredNotes.some((note) => note.id === currentId)) {
+        return currentId;
+      }
+
+      return filteredNotes[0].id;
+    });
+  }, [filteredNotes]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
     }
-  }, [filteredNotes, paginatedNotes, selectedId]);
 
-  const selectedNote = useMemo(
-    () => filteredNotes.find((note) => note.id === selectedId) ?? null,
-    [filteredNotes, selectedId],
-  );
+    const handleStorage = (event) => {
+      if (event.key === 'notes') {
+        setNotes(loadStoredNotes());
+      }
+    };
 
-  const selectedWordCount = selectedNote ? countWords(selectedNote.content) : 0;
-  const filtersActive = searchTerm || tagFilter !== 'ALL' || sortOrder !== 'desc';
+    const handleFocus = () => {
+      setNotes(loadStoredNotes());
+    };
 
-  const handleSearchChange = (event) => {
-    setSearchTerm(event.target.value);
-  };
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener('focus', handleFocus);
 
-  const handleToggleSort = () => {
-    setSortOrder((previous) => (previous === 'desc' ? 'asc' : 'desc'));
-  };
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, []);
 
-  const handleResetFilters = () => {
-    setSearchTerm('');
-    setTagFilter('ALL');
-    setSortOrder('desc');
-    setCurrentPage(1);
-  };
+  const tagCounts = useMemo(() => {
+    const counts = { ALL: notes.length };
+    QUADRANT_TAGS.forEach((tag) => {
+      counts[tag] = 0;
+    });
+
+    notes.forEach((note) => {
+      counts[note.tag] = (counts[note.tag] ?? 0) + 1;
+    });
+
+    return counts;
+  }, [notes]);
+
+  const selectedNote = filteredNotes.find((note) => note.id === selectedId) ?? null;
+
+  const subtitle = useMemo(() => {
+    if (notes.length === 0) {
+      return 'You have not captured any notes yet. Write a reflection from the Fifth to see it here.';
+    }
+
+    if (filteredNotes.length === 0) {
+      return 'No notes match your filters. Clear the search or pick a different quadrant to continue.';
+    }
+
+    if (activeTag === 'ALL' && !searchTerm.trim() && filteredNotes.length === notes.length) {
+      return `Browsing all ${notes.length} saved ${pluralise(notes.length, 'note', 'notes')}.`;
+    }
+
+    return `Showing ${filteredNotes.length} of ${notes.length} saved ${pluralise(notes.length, 'note', 'notes')}.`;
+  }, [notes, filteredNotes, activeTag, searchTerm]);
 
   const handleOverlayClick = (event) => {
-    if (event.target === event.currentTarget) {
+    if (event.target === event.currentTarget && typeof onClose === 'function') {
       onClose();
     }
   };
 
+  const handleRefresh = () => {
+    setNotes(loadStoredNotes());
+  };
+
   return (
     <div className="modal-overlay" onClick={handleOverlayClick}>
-      <div
-        className="modal notes-modal notes-list-modal"
-        onClick={(event) => event.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="notes-library-title"
-      >
+      <div className="modal notes-modal notes-list-modal" onClick={(event) => event.stopPropagation()}>
         <header className="notes-header">
           <div>
-            <h3 id="notes-library-title">Notes library</h3>
-            <p className="notes-subtitle">
-              {filteredNotes.length} {filteredNotes.length === 1 ? 'entry' : 'entries'} · {notes.length} total saved
-            </p>
+            <h3>Your notes library</h3>
+            <p className="notes-subtitle">{subtitle}</p>
           </div>
           <button
             type="button"
             className="modal-close-button"
             onClick={onClose}
-            aria-label="Close notes library"
+            aria-label="Close notes list"
           >
             &times;
           </button>
         </header>
 
         <div className="notes-controls">
-          <div className="notes-search">
+          <label className="notes-search">
             <span className="notes-search__icon" aria-hidden="true">
               🔍
             </span>
             <input
               type="search"
+              placeholder="Search notes by title, content, or quadrant"
               value={searchTerm}
-              onChange={handleSearchChange}
-              placeholder="Search notes by title or keywords"
-              aria-label="Search notes"
+              onChange={(event) => setSearchTerm(event.target.value)}
             />
-            {searchTerm && (
-              <button
-                type="button"
-                className="ghost-button ghost-button--compact"
-                onClick={() => setSearchTerm('')}
-                aria-label="Clear search"
-              >
-                Clear
-              </button>
-            )}
-          </div>
+          </label>
 
           <div className="notes-filters">
             <div className="notes-filter">
               <span>Quadrant</span>
-              <div className="tag-options tag-options--filters">
-                {TAG_FILTERS.map((filter) => (
+              <div className="tag-options">
+                {TAG_OPTIONS.map((option) => (
                   <button
-                    key={filter}
+                    key={option}
                     type="button"
-                    data-tag={filter}
-                    className={`tag-chip ${tagFilter === filter ? 'is-active' : ''}`}
-                    style={{ '--tag-color': getTagColor(filter) }}
-                    onClick={() => setTagFilter(filter)}
-                    aria-pressed={tagFilter === filter}
+                    data-tag={option}
+                    className={`tag-chip ${activeTag === option ? 'is-active' : ''}`}
+                    style={{ '--tag-color': TAG_COLORS[option] }}
+                    onClick={() => setActiveTag(option)}
                   >
-                    {filter}
+                    {option}
+                    <span aria-hidden="true"> ({tagCounts[option] ?? 0})</span>
                   </button>
                 ))}
               </div>
-            </div>
-
-            <div className="notes-filter">
-              <span>Sort</span>
-              <button type="button" className="toolbar-button" onClick={handleToggleSort}>
-                {sortOrder === 'desc' ? 'Newest first' : 'Oldest first'}
-              </button>
             </div>
           </div>
         </div>
 
         <div className="notes-body">
-          <div className="notes-grid" aria-live="polite">
-            {paginatedNotes.length === 0 ? (
+          <div className="notes-grid">
+            {filteredNotes.length === 0 ? (
               <div className="notes-empty">
-                <h4>No notes match your filters</h4>
-                <p>Try adjusting your search or quadrant filters to see more results.</p>
-                {filtersActive && (
-                  <button type="button" className="ghost-button" onClick={handleResetFilters}>
-                    Reset filters
-                  </button>
-                )}
+                <h4>No notes to show</h4>
+                <p>Try clearing the search or selecting a different quadrant to continue browsing.</p>
               </div>
             ) : (
-              paginatedNotes.map((note) => (
+              filteredNotes.map((note) => (
                 <button
                   key={note.id}
                   type="button"
                   className={`notes-card ${selectedId === note.id ? 'is-selected' : ''}`}
-                  style={{ '--tag-color': getTagColor(note.tag) }}
+                  style={{ '--tag-color': TAG_COLORS[note.tag] }}
                   onClick={() => setSelectedId(note.id)}
-                  aria-pressed={selectedId === note.id}
                 >
                   <div className="notes-card__header">
                     <span className="note-card__tag" data-tag={note.tag}>
                       {note.tag}
                     </span>
-                    <span className="notes-card__date">{formatTimestamp(note.createdAt)}</span>
+                    <span className="notes-card__date">{note.createdAtLabel}</span>
                   </div>
-                  <h4 className="notes-card__title" title={note.title}>
-                    {note.title || 'Untitled note'}
-                  </h4>
-                  <p className="notes-card__preview">{previewContent(note.content)}</p>
+                  <h4 className="notes-card__title">{note.title}</h4>
+                  <p className="notes-card__preview">{note.preview}</p>
                 </button>
               ))
             )}
           </div>
 
-          <div className="notes-detail" aria-live="polite">
+          <aside className="notes-detail">
             {selectedNote ? (
-              <React.Fragment>
+              <>
                 <div className="notes-detail__header">
                   <span className="note-card__tag" data-tag={selectedNote.tag}>
                     {selectedNote.tag}
                   </span>
-                  <span className="notes-detail__date">{formatTimestamp(selectedNote.createdAt)}</span>
-                  <span className="notes-detail__meta">
-                    {selectedWordCount} {selectedWordCount === 1 ? 'word' : 'words'}
-                  </span>
+                  <div className="notes-detail__meta">
+                    <span>Created {selectedNote.createdAtLabel}</span>
+                    {selectedNote.updatedAtLabel ? (
+                      <span>Updated {selectedNote.updatedAtLabel}</span>
+                    ) : null}
+                    <span>
+                      {selectedNote.wordCount}{' '}
+                      {pluralise(selectedNote.wordCount, 'word', 'words')}
+                    </span>
+                    <span>{selectedNote.characterCount} characters</span>
+                    {selectedNote.referenceId ? (
+                      <span>Ref. {selectedNote.referenceId}</span>
+                    ) : null}
+                  </div>
                 </div>
-                <h4 className="notes-detail__title">{selectedNote.title || 'Untitled note'}</h4>
-                <pre className="note-view-content">
-                  {selectedNote.content || 'No additional context captured yet.'}
-                </pre>
-              </React.Fragment>
+                <h4 className="notes-detail__title">{selectedNote.title}</h4>
+                <div className="note-view-content">
+                  {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
+                </div>
+              </>
             ) : (
               <div className="notes-empty-detail">
-                <h4>Select a note to read it</h4>
-                <p>Your detailed view will appear here once you choose a note on the left.</p>
+                <h4>{notes.length === 0 ? 'No saved notes yet' : 'Select a note to read it'}</h4>
+                <p>
+                  {notes.length === 0
+                    ? 'Capture your reflections from the Fifth quadrant to build your personal library.'
+                    : 'Choose any note from the list to explore its full content.'}
+                </p>
               </div>
             )}
-          </div>
+          </aside>
         </div>
 
         <footer className="notes-footer">
           <div className="notes-pagination">
-            <button
-              type="button"
-              className="ghost-button"
-              onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
-              disabled={activePage <= 1}
-            >
-              Previous
-            </button>
             <span>
-              Page {displayPage} of {displayTotalPages}
+              {notes.length === 0
+                ? 'No notes stored'
+                : filteredNotes.length === notes.length && activeTag === 'ALL' && !searchTerm.trim()
+                ? `${notes.length} ${pluralise(notes.length, 'note', 'notes')}`
+                : `${filteredNotes.length} of ${notes.length} notes`}
             </span>
             <button
               type="button"
-              className="ghost-button"
-              onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))}
-              disabled={activePage >= totalPages || !filteredNotes.length}
+              className="ghost-button ghost-button--compact"
+              onClick={handleRefresh}
             >
-              Next
+              Refresh
             </button>
           </div>
         </footer>
@@ -505,3 +548,4 @@ export default function NotesListModal({ onClose }) {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- replace the notes library modal with a fresh implementation that sanitises stored entries, tolerates legacy formats, and keeps local storage access safe
- provide a spacious two-pane reader that supports search, quadrant filtering, metadata, and a manual refresh so large libraries stay manageable
- mirror the rebuilt component in the `src` copy used by the packaged build

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cbd7d501808322b8e1ed02b9e7f480