### PR TITLE
Improve quadrant combos UI and add Trinities tool

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import ToolsBlog from './ToolsBlog.jsx';
 import MomentoMori from '../MomentoMori.jsx';
 import Watchdog from './Watchdog.jsx';
 import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
+import Trinities from './Trinities.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -76,6 +77,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showAnima, setShowAnima] = useState(false);
   const [showBlog, setShowBlog] = useState(false);
   const [showQuadrantComb, setShowQuadrantComb] = useState(false);
+  const [showTrinities, setShowTrinities] = useState(false);
   const [showTodoGoals, setShowTodoGoals] = useState(false);
   const [showActivity, setShowActivity] = useState(false);
   const [showCharacterEvolve, setShowCharacterEvolve] = useState(false);
@@ -109,6 +111,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       moodtracker: 'Form',
       momentoMori: 'Form',
       quadrantComb: 'Form',
+      trinities: 'Form',
       anima: 'Form',
       blog: 'Form',
       todoGoals: 'Form',
@@ -177,6 +180,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showMoodtracker ||
     showMomentoMori ||
     showQuadrantComb ||
+    showTrinities ||
     showAnima ||
     showBlog ||
     showTodoGoals ||
@@ -206,6 +210,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowMoodtracker(false);
     setShowMomentoMori(false);
     setShowQuadrantComb(false);
+    setShowTrinities(false);
     setShowAnima(false);
     setShowBlog(false);
     setShowTodoGoals(false);
@@ -669,6 +674,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <MomentoMori onBack={() => setShowMomentoMori(false)} />
             ) : showQuadrantComb ? (
               <QuadrantCombinaisons onBack={() => setShowQuadrantComb(false)} />
+            ) : showTrinities ? (
+              <Trinities onBack={() => setShowTrinities(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : showBlog ? (
@@ -847,6 +854,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">🔀</div>
                     <span>Quadrant combinaisons</span>
+                  </div>
+                )}
+                {appLayers.trinities === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowTrinities(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'trinities')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'trinities')}
+                  >
+                    <div className="star-icon">🔺</div>
+                    <span>Trinities</span>
                   </div>
                 )}
                 {appLayers.anima === activeLayer && (

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -24,6 +24,7 @@ import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import MomentoMori from './MomentoMori.jsx';
 import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
+import Trinities from './Trinities.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './ToolsBlog.jsx';
 import TodoGoals from './TodoGoals.jsx';
@@ -221,6 +222,7 @@ export default function PageRouter() {
       moodtracker: <Moodtracker {...props} />,
       momentoMori: <MomentoMori {...props} />,
       quadrantComb: <QuadrantCombinaisons onBack={goBack} />,
+      trinities: <Trinities onBack={goBack} />,
       anima: <Anima onBack={goBack} />,
       blog: <ToolsBlog onBack={goBack} />,
       todoGoals: <TodoGoals onBack={goBack} />,

--- a/src/QuadrantCombinaisons.jsx
+++ b/src/QuadrantCombinaisons.jsx
@@ -16,23 +16,52 @@ export default function QuadrantCombinaisons({ onBack }) {
   const addCombo = (c) => setCombos([...combos, c]);
   const removeCombo = (id) => setCombos(combos.filter((c) => c.id !== id));
 
+  const formatValue = (value) => {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed ? trimmed : '—';
+    }
+    if (value === 0) {
+      return '0';
+    }
+    return value ? String(value) : '—';
+  };
+
   return (
     <div className="version-rating">
       <button className="back-button" onClick={onBack}>Back</button>
       <div className="rating-list">
+        {combos.length === 0 && (
+          <div className="empty-state">
+            Start capturing quadrant combinaisons to track how each energy shows up
+            across your projects.
+          </div>
+        )}
         {combos.map((c) => (
           <div key={c.id} className="version-card">
             <div className="version-header">
               <div className="version-name">{c.name}</div>
-              <button className="delete-button" onClick={() => removeCombo(c.id)}>
+              <button
+                className="delete-button"
+                onClick={() => removeCombo(c.id)}
+                aria-label={`Delete ${c.name}`}
+              >
                 ✖
               </button>
             </div>
             <div className="quadrant-notes">
-              <div><strong>II:</strong> {c.quadrants?.II}</div>
-              <div><strong>IE:</strong> {c.quadrants?.IE}</div>
-              <div><strong>EI:</strong> {c.quadrants?.EI}</div>
-              <div><strong>EE:</strong> {c.quadrants?.EE}</div>
+              <div>
+                <strong>II:</strong> {formatValue(c.quadrants?.II)}
+              </div>
+              <div>
+                <strong>IE:</strong> {formatValue(c.quadrants?.IE)}
+              </div>
+              <div>
+                <strong>EI:</strong> {formatValue(c.quadrants?.EI)}
+              </div>
+              <div>
+                <strong>EE:</strong> {formatValue(c.quadrants?.EE)}
+              </div>
             </div>
             {c.notes && <div className="extra-notes">{c.notes}</div>}
           </div>

--- a/src/Trinities.jsx
+++ b/src/Trinities.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import TrinityModal from './TrinityModal.jsx';
+import './version-rating.css';
+
+export default function Trinities({ onBack }) {
+  const [trinities, setTrinities] = useState(() => {
+    const stored = localStorage.getItem('trinities');
+    return stored ? JSON.parse(stored) : [];
+  });
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    localStorage.setItem('trinities', JSON.stringify(trinities));
+  }, [trinities]);
+
+  const addTrinity = (entry) => {
+    setTrinities((prev) => [...prev, entry]);
+  };
+
+  const removeTrinity = (id) => {
+    setTrinities((prev) => prev.filter((entry) => entry.id !== id));
+  };
+
+  const formatValue = (value) => {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed ? trimmed : '—';
+    }
+    if (value === 0) {
+      return '0';
+    }
+    return value ? String(value) : '—';
+  };
+
+  return (
+    <div className="version-rating">
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
+      <div className="rating-list">
+        {trinities.length === 0 && (
+          <div className="empty-state">
+            Map your inspirations across Form, Semi-formless, and Formless spaces to
+            see how your ideas echo through each realm.
+          </div>
+        )}
+        {trinities.map((entry) => (
+          <div key={entry.id} className="version-card">
+            <div className="version-header">
+              <div className="version-name">{entry.name}</div>
+              <button
+                className="delete-button"
+                onClick={() => removeTrinity(entry.id)}
+                aria-label={`Delete ${entry.name}`}
+              >
+                ✖
+              </button>
+            </div>
+            <div className="quadrant-notes">
+              <div>
+                <strong>Form:</strong> {formatValue(entry.categories?.form)}
+              </div>
+              <div>
+                <strong>Semi-formless:</strong>{' '}
+                {formatValue(entry.categories?.semiFormless)}
+              </div>
+              <div>
+                <strong>Formless:</strong> {formatValue(entry.categories?.formless)}
+              </div>
+            </div>
+            {entry.notes && <div className="extra-notes">{entry.notes}</div>}
+          </div>
+        ))}
+      </div>
+      <button className="action-button" onClick={() => setShowModal(true)}>
+        Add Trinity
+      </button>
+      {showModal && (
+        <TrinityModal
+          onAdd={addTrinity}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/Trinities.test.js
+++ b/src/Trinities.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Trinities from './Trinities.jsx';
+
+test('shows add trinity button', () => {
+  render(<Trinities onBack={() => {}} />);
+  expect(screen.getByText(/add trinity/i)).toBeInTheDocument();
+});

--- a/src/TrinityModal.jsx
+++ b/src/TrinityModal.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import './note-modal.css';
+
+export default function TrinityModal({ onAdd, onClose }) {
+  const [name, setName] = useState('');
+  const [notes, setNotes] = useState('');
+  const [form, setForm] = useState('');
+  const [semiFormless, setSemiFormless] = useState('');
+  const [formless, setFormless] = useState('');
+
+  const handleSave = () => {
+    onAdd({
+      id: Date.now(),
+      name: name || 'Untitled Trinity',
+      notes,
+      categories: {
+        form,
+        semiFormless,
+        formless,
+      },
+    });
+    onClose();
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <input
+          className="note-title"
+          placeholder="Trinity name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Form"
+          value={form}
+          onChange={(e) => setForm(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Semi-formless"
+          value={semiFormless}
+          onChange={(e) => setSemiFormless(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Formless"
+          value={formless}
+          onChange={(e) => setFormless(e.target.value)}
+        />
+        <textarea
+          className="note-content"
+          placeholder="Notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+        />
+        <div className="actions">
+          <button className="save-button" onClick={handleSave}>
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/version-rating.css
+++ b/src/version-rating.css
@@ -1,46 +1,126 @@
 .version-rating {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  align-items: center;
+  gap: 16px;
+  align-items: stretch;
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px 24px 24px;
+  box-sizing: border-box;
+}
+
+.version-rating .back-button {
+  align-self: flex-start;
 }
 
 .rating-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
   width: 100%;
-  max-width: 400px;
+  max-height: 60vh;
+  min-height: 160px;
+  overflow-y: auto;
+  padding-right: 8px;
+  box-sizing: border-box;
+}
+
+.rating-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.rating-list::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+}
+
+.rating-list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
 }
 
 .version-card {
-  background: #333;
-  padding: 8px 12px;
-  border-radius: 8px;
-  color: white;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #2b2d36;
+  padding: 16px;
+  border-radius: 12px;
+  color: #f3f4ff;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
 }
 
 .version-header {
   display: flex;
-  gap: 8px;
   align-items: center;
+  gap: 12px;
+}
+
+.version-name {
+  font-weight: 600;
+  font-size: 1.05em;
+}
+
+.version-score {
+  margin-left: auto;
 }
 
 .delete-button {
-  margin-left: auto;
+  margin-left: 4px;
   background: none;
   border: none;
-  color: #ff6666;
+  color: #ff7b7b;
   cursor: pointer;
-  font-size: 1em;
+  font-size: 1.1em;
+  transition: transform 0.2s ease;
+}
+
+.delete-button:hover {
+  transform: scale(1.05);
 }
 
 .quadrant-notes {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
   font-size: 0.85em;
-  margin-top: 4px;
+  color: #d6d8ec;
 }
 
 .extra-notes {
   font-size: 0.85em;
-  margin-top: 4px;
+  line-height: 1.4;
+  color: #c5c7de;
+}
+
+.version-rating .action-button {
+  align-self: flex-end;
+  padding: 10px 22px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.version-rating .action-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.35);
+}
+
+.version-rating .empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: #aeb2cc;
+  background: rgba(43, 45, 54, 0.8);
+  border: 1px dashed rgba(174, 178, 204, 0.3);
+  border-radius: 12px;
+  padding: 32px 24px;
+  font-size: 0.95em;
+  line-height: 1.5;
 }


### PR DESCRIPTION
## Summary
- refresh the Quadrant Combinaisons layout with a scrollable grid, empty state, and updated styling so entries remain accessible
- add the Trinities companion app with creation modal, persistent storage, and coverage for the Form/Semi-formless/Formless categories
- wire the new tool into the tools hub and router alongside updated styles shared by the rating views

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d175d824888322b361cdb113ba21cc