### PR TITLE
Refine shadow tag toggle label

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -119,6 +119,20 @@ export default function Library({ onBack }) {
   const [soundMenu, setSoundMenu] = useState(null);
   const [editingSoundId, setEditingSoundId] = useState(null);
   const [soundThumbPreview, setSoundThumbPreview] = useState(null);
+  const [hideShadowImages, setHideShadowImages] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('hideShadowImages') === 'true';
+    }
+    return false;
+  });
+
+  const hasShadowTag = (tags) =>
+    Array.isArray(tags) &&
+    tags.some((tag) => typeof tag === 'string' && tag.toLowerCase() === 'shadow');
+
+  const filteredImages = hideShadowImages
+    ? images.filter((img) => !hasShadowTag(img.tags))
+    : images;
 
   // Restore masonry spans by normalizing stored images to their natural size
   useEffect(() => {
@@ -308,6 +322,15 @@ export default function Library({ onBack }) {
       setEditingTitle(false);
     }
   }, [lightbox?.id]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('hideShadowImages', hideShadowImages ? 'true' : 'false');
+    }
+    if (hideShadowImages && lightbox && hasShadowTag(lightbox.tags)) {
+      setLightbox(null);
+    }
+  }, [hideShadowImages, lightbox]);
 
   useEffect(() => {
     loadPalette().then(setPalette);
@@ -775,6 +798,8 @@ export default function Library({ onBack }) {
     );
   };
 
+  const lightboxHasShadow = hasShadowTag(lightbox?.tags);
+
   return (
     <div
       className={`library-container ${
@@ -856,6 +881,21 @@ export default function Library({ onBack }) {
                   >
                     <span>Dark mode</span>
                     {libraryTheme === 'dark' && (
+                      <span
+                        className="library-settings-check"
+                        aria-hidden="true"
+                      >
+                        ✓
+                      </span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    className={hideShadowImages ? 'active' : ''}
+                    onClick={() => setHideShadowImages((prev) => !prev)}
+                  >
+                    <span>Hide shadow images</span>
+                    {hideShadowImages && (
                       <span
                         className="library-settings-check"
                         aria-hidden="true"
@@ -951,7 +991,7 @@ export default function Library({ onBack }) {
           sortMode === 'color' ? (
             <div className="color-groups">
               {palette.map((c) => {
-                const groupImgs = images.filter((img) => img.color === c);
+                const groupImgs = filteredImages.filter((img) => img.color === c);
                 const groupSounds = sounds.filter((s) => s.color === c);
                 if (!groupImgs.length && !groupSounds.length) return null;
                 return (
@@ -1066,15 +1106,20 @@ export default function Library({ onBack }) {
                 >
                   {(
                     activeTab === 'all'
-                      ? [...images.map((img) => ({ type: 'image', item: img })),
-                        ...sounds.map((s) => ({ type: 'sound', item: s }))]
-                        .sort((a, b) => a.item.id - b.item.id)
-                        .map(({ type, item }) =>
-                          type === 'image'
-                            ? renderImageCard(item)
-                            : renderSoundCard(item)
-                        )
-                      : images.map((img) => renderImageCard(img))
+                      ? [
+                          ...filteredImages.map((img) => ({
+                            type: 'image',
+                            item: img,
+                          })),
+                          ...sounds.map((s) => ({ type: 'sound', item: s })),
+                        ]
+                          .sort((a, b) => a.item.id - b.item.id)
+                          .map(({ type, item }) =>
+                            type === 'image'
+                              ? renderImageCard(item)
+                              : renderSoundCard(item)
+                          )
+                      : filteredImages.map((img) => renderImageCard(img))
                   )}
                 </div>
             ))}
@@ -1315,20 +1360,51 @@ export default function Library({ onBack }) {
                       ))}
                     </div>
                   </div>
-                    <div className="tag-list">
-                      {lightbox.tags?.map((tag, idx) => (
-                        <span
-                          key={idx}
-                          className="tag"
-                          onClick={() => {
-                            const nt = lightbox.tags.filter((_, i) => i !== idx);
-                            updateImage(lightbox.id, { tags: nt });
-                          }}
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                      <input
+                  <div className="tag-list">
+                    {lightbox.tags?.map((tag, idx) => (
+                      <span
+                        key={idx}
+                        className="tag"
+                        onClick={() => {
+                          const nt = lightbox.tags.filter((_, i) => i !== idx);
+                          updateImage(lightbox.id, { tags: nt });
+                        }}
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                    <button
+                      type="button"
+                      className={`shadow-tag-button${
+                        lightboxHasShadow ? ' active' : ''
+                      }`}
+                      aria-label={
+                        lightboxHasShadow ? 'Remove shadow tag' : 'Add shadow tag'
+                      }
+                      title={
+                        lightboxHasShadow ? 'Remove shadow tag' : 'Add shadow tag'
+                      }
+                      aria-pressed={lightboxHasShadow}
+                      onClick={() => {
+                        const currentTags = Array.isArray(lightbox.tags)
+                          ? lightbox.tags
+                          : [];
+                        const withoutShadow = currentTags.filter(
+                          (tag) =>
+                            !(
+                              typeof tag === 'string' &&
+                              tag.toLowerCase() === 'shadow'
+                            )
+                        );
+                        const nextTags = lightboxHasShadow
+                          ? withoutShadow
+                          : [...withoutShadow, 'shadow'];
+                        updateImage(lightbox.id, { tags: nextTags });
+                      }}
+                    >
+                      {lightboxHasShadow ? 'Shadow tag ✓' : '⮟'}
+                    </button>
+                    <input
                       type="text"
                       value={tagInput}
                       placeholder="Add tag"

--- a/src/library.css
+++ b/src/library.css
@@ -692,12 +692,42 @@
   border-radius: 6px;
 }
 
-.tag {
+.tag { 
   background: var(--library-accent);
   color: var(--library-accent-contrast);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 0.8rem;
   cursor: pointer;
+}
+
+.shadow-tag-button {
+  flex: 0 0 auto;
+  background: var(--library-button-bg);
+  border: 1px solid var(--library-button-border);
+  color: var(--library-text);
+  padding: 4px 10px;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease, box-shadow 0.3s ease;
+  font: inherit;
+}
+
+.shadow-tag-button:hover {
+  background: var(--library-soft-highlight);
+  color: var(--library-accent);
+  border-color: var(--library-accent);
+}
+
+.shadow-tag-button.active {
+  background: var(--library-accent);
+  color: var(--library-accent-contrast);
+  border-color: transparent;
+}
+
+.shadow-tag-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--library-ring);
 }
 


### PR DESCRIPTION
## Summary
- replace the lightbox shadow tag button label with an arrow icon for a cleaner look
- add accessible labeling and pressed state metadata to the shadow tag toggle

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d181b3e45c83228f13bea4db4c63a9