### PR TITLE
Adjust library lightbox layout

### DIFF
--- a/src/library.css
+++ b/src/library.css
@@ -631,16 +631,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.lightbox-inner {
-  flex: 0 0 auto;
-}
-
-.lightbox-inner img {
-  display: block;
-  max-width: none;
-  max-height: none;
+  padding: 40px;
+  box-sizing: border-box;
 }
 
 .zoom-indicator {
@@ -656,21 +648,44 @@
 }
 
 .lightbox-content {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 32px;
+  width: min(1200px, calc(100vw - 80px));
+  max-width: calc(100vw - 80px);
+  max-height: calc(100vh - 80px);
+  align-items: stretch;
+}
+
+.lightbox-inner {
+  width: 100%;
+  height: 100%;
   display: flex;
-  gap: 20px;
+  justify-content: flex-end;
   align-items: center;
+  overflow: auto;
+}
+
+.lightbox-inner img {
+  display: block;
+  max-width: none;
+  max-height: none;
 }
 
 .lightbox-info {
-  width: 300px;
+  width: 100%;
+  max-width: 100%;
   background: var(--library-modal-bg);
   border: 1px solid var(--library-modal-border);
-  padding: 20px;
+  padding: 28px;
   border-radius: 12px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
   box-shadow: var(--library-shadow);
+  height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
 }
 
 .lightbox-info h1 {
@@ -695,6 +710,31 @@
   border-radius: 6px;
   resize: vertical;
   min-height: 80px;
+}
+
+@media (max-width: 900px) {
+  .lightbox {
+    padding: 20px;
+  }
+
+  .lightbox-content {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 100%;
+    max-height: none;
+    gap: 20px;
+  }
+
+  .lightbox-inner {
+    justify-content: center;
+    overflow: auto;
+  }
+
+  .lightbox-info {
+    height: auto;
+    padding: 24px;
+  }
 }
 
 .quad-section {


### PR DESCRIPTION
## Summary
- split the library lightbox into balanced image and edit columns so the photo hugs the center edge with breathing room
- stretch the edit panel across the full right half, add scrolling support, and keep a stacked layout on smaller screens

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d1a706c7a483229434830d2dfebf6a