### PR TITLE
Adjust lightbox image alignment in library

### DIFF
--- a/src/library.css
+++ b/src/library.css
@@ -661,7 +661,7 @@
   width: 100%;
   height: 100%;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   align-items: center;
   overflow: auto;
 }


### PR DESCRIPTION
## Summary
- align the library lightbox image container to start so the image uses the available left-side space

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d274bba74883229558ba7f49df993f