### PR TITLE
Persist library media to disk

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -2,7 +2,127 @@ const { app, BrowserWindow, Menu, ipcMain } = require('electron');
 const activeWindow = require('active-win');
 const path = require('path');
 const fs = require('fs');
+const fsp = fs.promises;
 let mainWindow;
+
+const LIBRARY_DIR_NAME = 'LibraryStorage';
+const LIBRARY_IMAGES_SUBDIR = 'images';
+const MIME_EXTENSION_MAP = {
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+  'image/bmp': 'bmp',
+  'image/tiff': 'tiff',
+};
+
+const extensionForMime = (mime) => {
+  if (!mime || typeof mime !== 'string') {
+    return 'bin';
+  }
+  const lower = mime.toLowerCase();
+  if (MIME_EXTENSION_MAP[lower]) {
+    return MIME_EXTENSION_MAP[lower];
+  }
+  const slash = lower.lastIndexOf('/');
+  if (slash !== -1 && slash < lower.length - 1) {
+    const subtype = lower.slice(slash + 1);
+    if (subtype.includes('+')) {
+      const [base] = subtype.split('+');
+      if (base) return base.replace(/[^a-z0-9]/g, '') || 'bin';
+    }
+    return subtype.replace(/[^a-z0-9]/g, '') || 'bin';
+  }
+  return 'bin';
+};
+
+const parseDataUrlForSave = (dataUrl, hintedMime) => {
+  if (typeof dataUrl !== 'string') {
+    return null;
+  }
+  const match = /^data:([^;]+);base64,(.+)$/is.exec(dataUrl);
+  if (match) {
+    const [, mime, base64] = match;
+    const mimeType = mime || hintedMime || 'application/octet-stream';
+    const buffer = Buffer.from(base64, 'base64');
+    return {
+      encoding: 'base64',
+      mimeType,
+      extension: extensionForMime(mimeType),
+      buffer,
+    };
+  }
+  return {
+    encoding: 'data-url',
+    mimeType: hintedMime || 'text/plain',
+    extension: 'txt',
+    raw: dataUrl,
+  };
+};
+
+const getLibraryBaseDir = () =>
+  path.join(app.getPath('userData'), LIBRARY_DIR_NAME);
+const getImagesDir = () =>
+  path.join(getLibraryBaseDir(), LIBRARY_IMAGES_SUBDIR);
+const getImageDir = (id) => path.join(getImagesDir(), String(id));
+const getImageMetaPath = (id) => path.join(getImageDir(id), 'meta.json');
+
+const ensureImagesDir = async () => {
+  await fsp.mkdir(getImagesDir(), { recursive: true });
+};
+
+const removeDirectory = async (dir) => {
+  try {
+    if (fsp.rm) {
+      await fsp.rm(dir, { recursive: true, force: true });
+    } else {
+      await fsp.rmdir(dir, { recursive: true });
+    }
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+};
+
+const readJsonSafe = async (filePath) => {
+  try {
+    const text = await fsp.readFile(filePath, 'utf8');
+    return JSON.parse(text);
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      console.error('Failed to read library image metadata', err);
+    }
+    return null;
+  }
+};
+
+const findFallbackImageData = async (dir) => {
+  try {
+    const files = await fsp.readdir(dir);
+    for (const name of files) {
+      const filePath = path.join(dir, name);
+      if (name.endsWith('.txt')) {
+        return await fsp.readFile(filePath, 'utf8');
+      }
+      const buffer = await fsp.readFile(filePath);
+      const ext = path.extname(name).slice(1).toLowerCase();
+      const mimeType =
+        Object.keys(MIME_EXTENSION_MAP).find(
+          (key) => MIME_EXTENSION_MAP[key] === ext
+        ) || `image/${ext || 'png'}`;
+      const base64 = buffer.toString('base64');
+      return `data:${mimeType};base64,${base64}`;
+    }
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      console.error('Failed to read legacy library image', err);
+    }
+  }
+  return null;
+};
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -121,6 +241,104 @@ ipcMain.handle('write-palette', async (_e, colors) => {
     );
     return true;
   } catch {
+    return false;
+  }
+});
+
+ipcMain.removeHandler('library-save-image');
+ipcMain.handle('library-save-image', async (_event, payload) => {
+  const { id, dataUrl, mimeType } = payload || {};
+  if (typeof id === 'undefined') {
+    return false;
+  }
+  try {
+    await ensureImagesDir();
+    const targetDir = getImageDir(id);
+
+    if (!dataUrl) {
+      await removeDirectory(targetDir);
+      return true;
+    }
+
+    const parsed = parseDataUrlForSave(dataUrl, mimeType);
+    if (!parsed) {
+      return false;
+    }
+
+    await removeDirectory(targetDir);
+    await fsp.mkdir(targetDir, { recursive: true });
+
+    let fileName;
+    if (parsed.encoding === 'base64') {
+      fileName = `image.${parsed.extension}`;
+      await fsp.writeFile(path.join(targetDir, fileName), parsed.buffer);
+    } else {
+      fileName = 'image.txt';
+      await fsp.writeFile(path.join(targetDir, fileName), parsed.raw, 'utf8');
+    }
+
+    const meta = {
+      mimeType: parsed.mimeType,
+      encoding: parsed.encoding,
+      extension: parsed.extension,
+      fileName,
+      savedAt: Date.now(),
+    };
+
+    await fsp.writeFile(
+      getImageMetaPath(id),
+      JSON.stringify(meta, null, 2) + '\n',
+      'utf8'
+    );
+    return true;
+  } catch (err) {
+    console.error('Failed to save library image', err);
+    return false;
+  }
+});
+
+ipcMain.removeHandler('library-load-image');
+ipcMain.handle('library-load-image', async (_event, id) => {
+  if (typeof id === 'undefined') {
+    return null;
+  }
+  try {
+    const dir = getImageDir(id);
+    const meta = await readJsonSafe(getImageMetaPath(id));
+    if (!meta) {
+      return await findFallbackImageData(dir);
+    }
+
+    const fileName = meta.fileName || `image.${meta.extension || 'bin'}`;
+    const filePath = path.join(dir, fileName);
+
+    if (meta.encoding === 'data-url') {
+      return await fsp.readFile(filePath, 'utf8');
+    }
+
+    const buffer = await fsp.readFile(filePath);
+    const type = meta.mimeType || 'application/octet-stream';
+    const base64 = buffer.toString('base64');
+    return `data:${type};base64,${base64}`;
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      console.error('Failed to load library image', err);
+    }
+    return null;
+  }
+});
+
+ipcMain.removeHandler('library-delete-image');
+ipcMain.handle('library-delete-image', async (_event, id) => {
+  if (typeof id === 'undefined') {
+    return false;
+  }
+  try {
+    const dir = getImageDir(id);
+    await removeDirectory(dir);
+    return true;
+  } catch (err) {
+    console.error('Failed to delete library image', err);
     return false;
   }
 });

--- a/preload.js
+++ b/preload.js
@@ -9,4 +9,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   closeWindow: () => ipcRenderer.invoke('close-window'),
   readPalette: () => ipcRenderer.invoke('read-palette'),
   writePalette: (colors) => ipcRenderer.invoke('write-palette', colors),
+  saveLibraryImage: (id, dataUrl, mimeType) =>
+    ipcRenderer.invoke('library-save-image', { id, dataUrl, mimeType }),
+  loadLibraryImage: (id) => ipcRenderer.invoke('library-load-image', id),
+  deleteLibraryImage: (id) => ipcRenderer.invoke('library-delete-image', id),
 });

--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -1,9 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './library.css';
 import { DEFAULT_COLORS, loadPalette } from './colorConfig.js';
 import { extractDominantColor } from './dominantColor.js';
 import { colorDiff } from './colorUtils.js';
 import namer from 'color-namer';
+import {
+  deleteImageData,
+  extractMimeType,
+  loadImageData,
+  storeImageData,
+} from './assets/LibraryStorage';
 import {
   deleteSoundData,
   loadSoundData,
@@ -163,6 +169,8 @@ export default function Library({ onBack }) {
   const [originalImages, setOriginalImages] = useState([]);
   const [draggedId, setDraggedId] = useState(null);
 
+  const saveSequenceRef = useRef(0);
+
   const [zoom, setZoom] = useState(
     () => parseFloat(localStorage.getItem('libraryZoom')) || 0.5
   );
@@ -201,31 +209,85 @@ export default function Library({ onBack }) {
 
   // Restore masonry spans by normalizing stored images to their natural size
   useEffect(() => {
-    const saved = localStorage.getItem('mazedImages');
-    if (saved) {
+    if (typeof window === 'undefined') {
+      return () => {};
+    }
+
+    let cancelled = false;
+
+    const readDimensions = (dataUrl) =>
+      new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+          resolve({ width: img.naturalWidth, height: img.naturalHeight });
+        };
+        img.onerror = () => resolve({ width: undefined, height: undefined });
+        img.src = dataUrl;
+      });
+
+    const hydrateImages = async () => {
+      const saved = localStorage.getItem('mazedImages');
+      if (!saved) return;
+
+      let parsed;
       try {
-        const parsed = JSON.parse(saved);
-        if (Array.isArray(parsed)) {
-          Promise.all(
-            parsed.map(
-              (img) =>
-                new Promise((resolve) => {
-                  const i = new Image();
-                  i.onload = () =>
-                    resolve({
-                      ...img,
-                      width: i.naturalWidth,
-                      height: i.naturalHeight,
-                    });
-                  i.src = img.dataUrl;
-                })
-            )
-          ).then(saveImages);
-        }
+        parsed = JSON.parse(saved);
       } catch (e) {
         console.error('Failed to parse saved images', e);
+        return;
       }
-    }
+
+      if (!Array.isArray(parsed)) return;
+
+      const hydrated = await Promise.all(
+        parsed.map(async (entry) => {
+          if (!entry || typeof entry.id === 'undefined') {
+            return null;
+          }
+
+          const base = { ...entry };
+          const normalizedTags = normalizeImageTags(base.tags);
+          base.tags = normalizedTags;
+
+          let dataUrl = entry.dataUrl;
+          if (!dataUrl) {
+            dataUrl = await loadImageData(entry.id);
+          }
+
+          if (!dataUrl) {
+            return null;
+          }
+
+          const mimeType = base.mimeType || extractMimeType(dataUrl) || null;
+          base.mimeType = mimeType;
+
+          delete base.dataUrl;
+
+          if (!base.width || !base.height) {
+            const { width, height } = await readDimensions(dataUrl);
+            if (width && height) {
+              base.width = width;
+              base.height = height;
+            }
+          }
+
+          return { ...base, dataUrl };
+        })
+      );
+
+      if (cancelled) return;
+
+      const valid = hydrated.filter(Boolean);
+      if (!valid.length) return;
+
+      saveImages(valid);
+    };
+
+    hydrateImages();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Load saved words and sounds from localStorage on mount
@@ -304,12 +366,58 @@ export default function Library({ onBack }) {
   }, []);
 
   const saveImages = (imgs) => {
-    const normalized = imgs.map((img) => ({
-      ...img,
-      tags: normalizeImageTags(img.tags),
-    }));
+    const normalized = imgs.map((img) => {
+      const normalizedTags = normalizeImageTags(img.tags);
+      const mimeType = img.mimeType || extractMimeType(img.dataUrl) || null;
+      return {
+        ...img,
+        tags: normalizedTags,
+        mimeType,
+      };
+    });
     setImages(normalized);
-    localStorage.setItem('mazedImages', JSON.stringify(normalized));
+
+    if (typeof window !== 'undefined') {
+      const sequence = (saveSequenceRef.current += 1);
+      (async () => {
+        try {
+          if (!normalized.length) {
+            if (saveSequenceRef.current === sequence) {
+              localStorage.setItem('mazedImages', JSON.stringify([]));
+            }
+            return;
+          }
+
+          const results = await Promise.all(
+            normalized.map((img) =>
+              storeImageData(img.id, img.dataUrl, img.mimeType)
+            )
+          );
+
+          const metadata = normalized.map((img, idx) => {
+            const { dataUrl, ...meta } = img;
+            const stored = results[idx];
+            return stored || typeof stored === 'undefined'
+              ? meta
+              : { ...meta, dataUrl };
+          });
+
+          if (saveSequenceRef.current === sequence) {
+            localStorage.setItem('mazedImages', JSON.stringify(metadata));
+          }
+        } catch (err) {
+          console.error('Failed to save images metadata', err);
+          if (saveSequenceRef.current === sequence) {
+            try {
+              localStorage.setItem('mazedImages', JSON.stringify(normalized));
+            } catch (fallbackErr) {
+              console.error('Failed to fallback save images', fallbackErr);
+            }
+          }
+        }
+      })();
+    }
+
     return normalized;
   };
 
@@ -434,6 +542,9 @@ export default function Library({ onBack }) {
   const deleteImage = (id) => {
     const updated = images.filter((img) => img.id !== id);
     saveImages(updated);
+    if (typeof window !== 'undefined') {
+      deleteImageData(id);
+    }
   };
 
   const deleteSound = async (id) => {
@@ -458,8 +569,15 @@ export default function Library({ onBack }) {
   };
 
   const updateImage = (id, updates) => {
+    let payload = updates;
+    if (updates && typeof updates === 'object' && 'dataUrl' in updates) {
+      const mimeType =
+        updates.mimeType || extractMimeType(updates.dataUrl) || null;
+      payload = { ...updates, mimeType };
+    }
+
     const updated = images.map((img) =>
-      img.id === id ? { ...img, ...updates } : img
+      img.id === id ? { ...img, ...payload } : img
     );
 
     const normalized = saveImages(updated);
@@ -600,6 +718,7 @@ export default function Library({ onBack }) {
           quadrants: [],
           color: hex,
           dataUrl: result,
+          mimeType: extractMimeType(result) || null,
           width: imgEl.naturalWidth,
           height: imgEl.naturalHeight,
         };

--- a/src/assets/LibraryStorage/index.js
+++ b/src/assets/LibraryStorage/index.js
@@ -1,0 +1,199 @@
+const DB_NAME = 'mazed-library-images';
+const STORE_NAME = 'images';
+let dbPromise = null;
+
+const DATA_URL_REGEX = /^data:([^;]+);base64,/i;
+
+const getElectronAPI = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const api = window.electronAPI;
+  if (!api) {
+    return null;
+  }
+  const { saveLibraryImage, loadLibraryImage, deleteLibraryImage } = api;
+  if (
+    typeof saveLibraryImage === 'function' &&
+    typeof loadLibraryImage === 'function' &&
+    typeof deleteLibraryImage === 'function'
+  ) {
+    return { saveLibraryImage, loadLibraryImage, deleteLibraryImage };
+  }
+  return null;
+};
+
+const openDatabase = () => {
+  if (typeof window === 'undefined' || !window.indexedDB) {
+    return Promise.resolve(null);
+  }
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve) => {
+      let request;
+      try {
+        request = window.indexedDB.open(DB_NAME, 1);
+      } catch (err) {
+        console.error('Image storage open threw', err);
+        resolve(null);
+        return;
+      }
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+      request.onsuccess = () => {
+        resolve(request.result);
+      };
+      request.onerror = () => {
+        console.error('Image storage open failed', request.error);
+        resolve(null);
+      };
+    });
+  }
+  return dbPromise;
+};
+
+const storeWithIndexedDB = async (id, dataUrl) => {
+  const db = await openDatabase();
+  if (!db) return false;
+  if (!dataUrl) {
+    return deleteWithIndexedDB(id);
+  }
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => {
+        console.error('Failed to store image data', tx.error);
+        resolve(false);
+      };
+      store.put(dataUrl, String(id));
+    } catch (err) {
+      console.error('Image storage put failed', err);
+      resolve(false);
+    }
+  });
+};
+
+const loadWithIndexedDB = async (id) => {
+  const db = await openDatabase();
+  if (!db) return null;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      const request = store.get(String(id));
+      request.onsuccess = () => {
+        resolve(request.result || null);
+      };
+      request.onerror = () => {
+        console.error('Failed to load image data', request.error);
+        resolve(null);
+      };
+    } catch (err) {
+      console.error('Image storage read failed', err);
+      resolve(null);
+    }
+  });
+};
+
+const deleteWithIndexedDB = async (id) => {
+  const db = await openDatabase();
+  if (!db) return false;
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => {
+        console.error('Failed to delete image data', tx.error);
+        resolve(false);
+      };
+      store.delete(String(id));
+    } catch (err) {
+      console.error('Image storage delete failed', err);
+      resolve(false);
+    }
+  });
+};
+
+const storeWithElectron = async (id, dataUrl, mimeType) => {
+  const api = getElectronAPI();
+  if (!api) return undefined;
+  try {
+    const result = await api.saveLibraryImage(id, dataUrl ?? null, mimeType ?? null);
+    return result;
+  } catch (err) {
+    console.error('Electron image save failed', err);
+    return false;
+  }
+};
+
+const loadWithElectron = async (id) => {
+  const api = getElectronAPI();
+  if (!api) return undefined;
+  try {
+    return await api.loadLibraryImage(id);
+  } catch (err) {
+    console.error('Electron image load failed', err);
+    return null;
+  }
+};
+
+const deleteWithElectron = async (id) => {
+  const api = getElectronAPI();
+  if (!api) return undefined;
+  try {
+    return await api.deleteLibraryImage(id);
+  } catch (err) {
+    console.error('Electron image delete failed', err);
+    return false;
+  }
+};
+
+export const extractMimeType = (dataUrl) => {
+  if (typeof dataUrl !== 'string') return null;
+  const match = DATA_URL_REGEX.exec(dataUrl);
+  return match ? match[1] : null;
+};
+
+export async function storeImageData(id, dataUrl, mimeType) {
+  if (typeof id === 'undefined') return false;
+  const electronResult = await storeWithElectron(id, dataUrl, mimeType);
+  if (typeof electronResult === 'boolean') {
+    if (electronResult) {
+      return true;
+    }
+    // fall back to IndexedDB if electron storage failed
+  } else if (electronResult) {
+    return true;
+  }
+  return storeWithIndexedDB(id, dataUrl);
+}
+
+export async function loadImageData(id) {
+  if (typeof id === 'undefined') return null;
+  const electronResult = await loadWithElectron(id);
+  if (typeof electronResult === 'string') {
+    return electronResult;
+  }
+  if (electronResult === null) {
+    return null;
+  }
+  return loadWithIndexedDB(id);
+}
+
+export async function deleteImageData(id) {
+  if (typeof id === 'undefined') return false;
+  const electronResult = await deleteWithElectron(id);
+  if (typeof electronResult === 'boolean') {
+    if (electronResult) {
+      return true;
+    }
+    // fallback to IndexedDB if electron deletion failed
+  }
+  return deleteWithIndexedDB(id);
+}


### PR DESCRIPTION
## Summary
- add an Electron-aware library storage helper that saves blobs to disk and falls back to IndexedDB when native APIs are unavailable
- wire up preload and main-process IPC so the Electron build writes, reads, and deletes image files under the user data folder
- track image MIME types in the library view so metadata stays light while blobs are persisted externally

## Testing
- npm test -- --runTestsByPath src/Library.jsx --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d274fd11c48322ba4710a977693bb2