### PR TITLE
Add keyboard navigation to blog gallery

### DIFF
--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './tools-blog.css';
 
 const THEMES = [
@@ -752,16 +752,11 @@ export default function ToolsBlog({ onBack }) {
                   {hasMedia && (
                     <div className="blog-card-media">
                       {imageSources.length > 0 && (
-                        <div className="blog-card-gallery">
-                          {imageSources.map((source, mediaIndex) => (
-                            <div
-                              key={`${post.id}-image-${mediaIndex}`}
-                              className="blog-card-gallery-item"
-                            >
-                              <img src={source} alt="" loading="lazy" />
-                            </div>
-                          ))}
-                        </div>
+                        <BlogCardGallery
+                          images={imageSources}
+                          postId={post.id}
+                          postTitle={post.title}
+                        />
                       )}
                       {youTubeEmbedUrl ? (
                         <div className="blog-card-video">
@@ -796,6 +791,119 @@ export default function ToolsBlog({ onBack }) {
           );
         })}
       </div>
+    </div>
+  );
+}
+
+function BlogCardGallery({ images, postId, postTitle }) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const itemRefs = useRef([]);
+  const keyboardNavigationRef = useRef(false);
+  const instructionsIdRef = useRef(`blog-card-gallery-${postId}-instructions`);
+
+  useEffect(() => {
+    itemRefs.current = itemRefs.current.slice(0, images.length);
+    if (activeIndex > images.length - 1) {
+      setActiveIndex(images.length > 0 ? images.length - 1 : 0);
+    }
+  }, [images.length, activeIndex]);
+
+  useEffect(() => {
+    if (!keyboardNavigationRef.current) {
+      return;
+    }
+
+    const node = itemRefs.current[activeIndex];
+    if (node && typeof node.focus === 'function') {
+      node.focus();
+    }
+    keyboardNavigationRef.current = false;
+  }, [activeIndex]);
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  const galleryLabel = postTitle ? `Gallery for ${postTitle}` : 'Post gallery';
+
+  const handleItemClick = (index) => {
+    if (index !== activeIndex) {
+      setActiveIndex(index);
+    }
+  };
+
+  const handleItemKeyDown = (event) => {
+    if (images.length <= 1) {
+      return;
+    }
+
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      keyboardNavigationRef.current = true;
+      setActiveIndex((previousIndex) =>
+        previousIndex === images.length - 1 ? 0 : previousIndex + 1,
+      );
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      keyboardNavigationRef.current = true;
+      setActiveIndex((previousIndex) =>
+        previousIndex === 0 ? images.length - 1 : previousIndex - 1,
+      );
+    } else if (event.key === 'Home') {
+      if (activeIndex === 0) {
+        return;
+      }
+      event.preventDefault();
+      keyboardNavigationRef.current = true;
+      setActiveIndex(0);
+    } else if (event.key === 'End') {
+      if (activeIndex === images.length - 1) {
+        return;
+      }
+      event.preventDefault();
+      keyboardNavigationRef.current = true;
+      setActiveIndex(images.length - 1);
+    }
+  };
+
+  return (
+    <div
+      className="blog-card-gallery"
+      role="radiogroup"
+      aria-label={galleryLabel}
+      aria-describedby={instructionsIdRef.current}
+    >
+      <span id={instructionsIdRef.current} className="blog-card-gallery-instructions">
+        Use the left and right arrow keys to move through the gallery images.
+      </span>
+      {images.map((source, index) => {
+        const isActive = index === activeIndex;
+        return (
+          <button
+            key={`${postId}-image-${index}`}
+            type="button"
+            className={`blog-card-gallery-item ${
+              isActive ? 'blog-card-gallery-item--active' : ''
+            }`}
+            role="radio"
+            aria-checked={isActive}
+            aria-label={`Image ${index + 1} of ${images.length}`}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => handleItemClick(index)}
+            onFocus={() => {
+              if (!isActive) {
+                setActiveIndex(index);
+              }
+            }}
+            onKeyDown={handleItemKeyDown}
+            ref={(element) => {
+              itemRefs.current[index] = element;
+            }}
+          >
+            <img src={source} alt="" loading="lazy" />
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -391,9 +391,23 @@
 }
 
 .blog-card-gallery {
+  position: relative;
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.blog-card-gallery-instructions {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .blog-card-gallery-item {
@@ -404,6 +418,16 @@
   background: rgba(255, 255, 255, 0.04);
   min-height: 180px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  cursor: pointer;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.blog-card-gallery-item:focus {
+  outline: none;
 }
 
 .blog-card-gallery-item img {
@@ -411,6 +435,17 @@
   height: 100%;
   object-fit: cover;
   display: block;
+  transition: transform 200ms ease;
+}
+
+.blog-card-gallery-item--active,
+.blog-card-gallery-item:focus-visible {
+  border-color: rgba(136, 164, 255, 0.6);
+  box-shadow: 0 0 0 2px rgba(136, 164, 255, 0.28);
+}
+
+.blog-card-gallery-item--active img {
+  transform: scale(1.02);
 }
 
 .blog-card--grid .blog-card-gallery-item {


### PR DESCRIPTION
## Summary
- replace the static blog gallery rendering with a focus-managed component that listens for arrow, home, and end keys to move between images
- update the gallery styling to support focus states and visually highlight the selected image while keeping screen reader instructions hidden from view

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68d2fcee071483229654cb4c9158def7