### PR TITLE
Introduce TasteT to Semi-Formless world layer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -998,7 +998,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
             )}
           </div>
         )}
-        {activeTab === 'World' && <World />}
+        {activeTab === 'World' && <World activeLayer={activeLayer} />}
         {activeTab === 'Friends' && <FriendsList />}
       </div>
       <div className="bottom-nav">

--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -1,0 +1,144 @@
+import React from "react";
+import "./taste-t.css";
+
+const roadmap = [
+  {
+    stage: "Now",
+    title: "Palette Calibration",
+    detail: "Capture the signature mood, color stories, and textures that TasteT will revolve around.",
+  },
+  {
+    stage: "Next",
+    title: "Experience Flow",
+    detail: "Sketch the journey from inspiration to tasting notes so we can choreograph each interaction.",
+  },
+  {
+    stage: "Later",
+    title: "Sensory Library",
+    detail: "Collect audio, visual, and aromatic references that will anchor our experiments.",
+  },
+];
+
+const tastingMoments = [
+  {
+    label: "Dawn",
+    description: "Bright, crisp openings that wake up curiosity.",
+  },
+  {
+    label: "Noon",
+    description: "Balanced harmonies where the rhythm settles in.",
+  },
+  {
+    label: "Dusk",
+    description: "Velvet transitions carrying warmth into the night.",
+  },
+];
+
+const experimentIdeas = [
+  {
+    title: "Atmosphere Sequencer",
+    note: "Layer ambient soundscapes with palette cues to reinforce the tasting arc.",
+  },
+  {
+    title: "Texture Sampler",
+    note: "Prototype tactile prompts that respond to progress and choices.",
+  },
+  {
+    title: "Memory Anchor",
+    note: "Design rituals that let guests capture a single vivid note from each session.",
+  },
+];
+
+export default function TasteT() {
+  return (
+    <div className="tastet-shell">
+      <div className="tastet-frame">
+        <header className="tastet-header">
+          <div className="tastet-title-block">
+            <span className="tastet-badge">Semi-Formless · Layer 1 Prototype</span>
+            <h1>TasteT</h1>
+            <p>
+              A generous canvas for cultivating sensory-driven worlds. We begin by
+              mapping moods, textures, and rituals so the experience can bloom
+              deliberately.
+            </p>
+            <button type="button" className="tastet-primary-action">
+              Enter Studio
+            </button>
+          </div>
+          <div className="tastet-flavor-panel">
+            <div className="tastet-flavor-wheel">
+              <span className="tastet-wheel-label">flavor<br />intention</span>
+            </div>
+            <ul className="tastet-flavor-legend">
+              <li>
+                <span className="tastet-legend-dot tastet-legend-dot--base" />
+                Base Notes
+              </li>
+              <li>
+                <span className="tastet-legend-dot tastet-legend-dot--accent" />
+                Accents
+              </li>
+              <li>
+                <span className="tastet-legend-dot tastet-legend-dot--spark" />
+                Spark
+              </li>
+            </ul>
+          </div>
+        </header>
+
+        <div className="tastet-layout">
+          <section className="tastet-panel tastet-roadmap">
+            <h2>Flavor Roadmap</h2>
+            <ol className="tastet-roadmap-list">
+              {roadmap.map((item) => (
+                <li key={item.stage}>
+                  <span className="tastet-roadmap-stage">{item.stage}</span>
+                  <div className="tastet-roadmap-content">
+                    <h3>{item.title}</h3>
+                    <p>{item.detail}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="tastet-panel tastet-moments">
+            <h2>Moments to Craft</h2>
+            <div className="tastet-moments-grid">
+              {tastingMoments.map((moment) => (
+                <article key={moment.label}>
+                  <h3>{moment.label}</h3>
+                  <p>{moment.description}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="tastet-panel tastet-experiments">
+            <h2>Experiment Bench</h2>
+            <div className="tastet-experiment-list">
+              {experimentIdeas.map((idea) => (
+                <div key={idea.title} className="tastet-experiment-card">
+                  <h3>{idea.title}</h3>
+                  <p>{idea.note}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="tastet-panel tastet-journal">
+            <h2>Studio Notes</h2>
+            <p>
+              Leave space for sketches, tasting logs, and future collaborators.
+              We will weave them in as TasteT evolves.
+            </p>
+            <div className="tastet-note-placeholder">
+              <span>Tap to begin composing the first entry…</span>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -4,9 +4,10 @@ import QuestModal from "./QuestModal.jsx";
 import MainQuestModal from "./MainQuestModal.jsx";
 import { supabaseClient } from "./supabaseClient";
 import { useQuests } from "./QuestContext.jsx";
+import TasteT from "./TasteT.jsx";
 import "./world.css";
 
-export default function World() {
+export default function World({ activeLayer = "Form" }) {
   const [resource, setResource] = useState(() => {
     const stored = localStorage.getItem("resourceR");
     return stored ? parseInt(stored, 10) : 0;
@@ -23,6 +24,7 @@ export default function World() {
   const [needsMainQuest, setNeedsMainQuest] = useState(false);
   const [showMainQuest, setShowMainQuest] = useState(false);
   const [showPublished, setShowPublished] = useState(false);
+  const isSemiFormless = activeLayer === "Semi-Formless";
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -32,6 +34,7 @@ export default function World() {
   }, []);
 
   useEffect(() => {
+    if (isSemiFormless) return;
     const load = async () => {
       if (!navigator.onLine) return;
       const {
@@ -54,7 +57,7 @@ export default function World() {
       // quests are loaded via QuestProvider
     };
     load();
-  }, []);
+  }, [isSemiFormless]);
 
   useEffect(() => {
     const handler = (e) => {
@@ -94,6 +97,14 @@ export default function World() {
   };
 
   // quests are managed via QuestProvider
+
+  if (isSemiFormless) {
+    return (
+      <div className="world-container world-tastet-container">
+        <TasteT />
+      </div>
+    );
+  }
 
   return (
     <div className="world-container">

--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -1,0 +1,415 @@
+.tastet-shell {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 64px 32px 96px;
+  box-sizing: border-box;
+}
+
+.tastet-frame {
+  position: relative;
+  width: min(1200px, 100%);
+  min-height: 70vh;
+  padding: 48px;
+  border-radius: 32px;
+  color: #fdf9f6;
+  background: linear-gradient(160deg, rgba(28, 13, 48, 0.94), rgba(16, 58, 80, 0.88));
+  overflow: hidden;
+  box-shadow: 0 48px 120px rgba(0, 0, 0, 0.48);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(16px);
+}
+
+.tastet-frame::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 28px;
+  background: linear-gradient(125deg, rgba(255, 199, 125, 0.1), rgba(120, 213, 255, 0.08));
+  z-index: 0;
+  pointer-events: none;
+}
+
+.tastet-frame > * {
+  position: relative;
+  z-index: 1;
+}
+
+.tastet-header {
+  display: flex;
+  align-items: stretch;
+  gap: 40px;
+}
+
+.tastet-title-block {
+  flex: 1.2;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 520px;
+}
+
+.tastet-title-block h1 {
+  font-size: clamp(3rem, 6vw, 4.5rem);
+  margin: 0;
+  letter-spacing: 0.05em;
+}
+
+.tastet-title-block p {
+  margin: 0;
+  line-height: 1.7;
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.tastet-badge {
+  align-self: flex-start;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.15);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+}
+
+.tastet-primary-action {
+  align-self: flex-start;
+  padding: 14px 28px;
+  border-radius: 18px;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1b1b27;
+  background: linear-gradient(120deg, #f8d678, #fcb195);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 18px 40px rgba(255, 215, 160, 0.35);
+}
+
+.tastet-primary-action:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 44px rgba(255, 215, 160, 0.45);
+}
+
+.tastet-primary-action:active {
+  transform: translateY(0);
+}
+
+.tastet-flavor-panel {
+  flex: 1;
+  padding: 32px;
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(11, 79, 96, 0.55), rgba(105, 64, 132, 0.4));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.tastet-flavor-wheel {
+  width: min(240px, 80%);
+  aspect-ratio: 1 / 1;
+  border-radius: 48px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 214, 186, 0.85), rgba(255, 142, 105, 0.4) 45%, rgba(64, 118, 207, 0.45) 70%, rgba(15, 23, 45, 0.9) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.tastet-flavor-wheel::before,
+.tastet-flavor-wheel::after {
+  content: "";
+  position: absolute;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.tastet-flavor-wheel::before {
+  inset: 12%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+}
+
+.tastet-flavor-wheel::after {
+  inset: 32%;
+  border: 1px dashed rgba(255, 255, 255, 0.25);
+}
+
+.tastet-wheel-label {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-size: 0.75rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.tastet-flavor-legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.tastet-flavor-legend li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.tastet-legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-flex;
+}
+
+.tastet-legend-dot--base {
+  background: linear-gradient(120deg, #ffd6ba, #fcb195);
+}
+
+.tastet-legend-dot--accent {
+  background: linear-gradient(120deg, #9ad0f5, #6fb3ff);
+}
+
+.tastet-legend-dot--spark {
+  background: linear-gradient(120deg, #f7e476, #f8b661);
+}
+
+.tastet-layout {
+  display: grid;
+  grid-template-columns: minmax(360px, 1.7fr) minmax(280px, 1fr);
+  grid-auto-rows: minmax(220px, auto);
+  grid-auto-flow: dense;
+  gap: 32px;
+}
+
+.tastet-panel {
+  position: relative;
+  padding: 28px;
+  border-radius: 26px;
+  background: linear-gradient(150deg, rgba(13, 20, 35, 0.7), rgba(255, 255, 255, 0.06));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.36);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.tastet-panel h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tastet-panel p {
+  margin: 0;
+  color: rgba(235, 239, 255, 0.8);
+  line-height: 1.6;
+}
+
+.tastet-roadmap {
+  grid-row: span 2;
+  padding-bottom: 36px;
+}
+
+.tastet-roadmap-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.tastet-roadmap-list li {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(7, 12, 21, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  position: relative;
+  overflow: hidden;
+}
+
+.tastet-roadmap-list li::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 214, 186, 0.12), rgba(124, 200, 255, 0.1));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.tastet-roadmap-list li:hover::after {
+  opacity: 1;
+}
+
+.tastet-roadmap-stage {
+  align-self: center;
+  justify-self: center;
+  padding: 8px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  font-size: 0.85rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.07);
+  z-index: 1;
+}
+
+.tastet-roadmap-content h3 {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+}
+
+.tastet-moments-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 16px;
+}
+
+.tastet-moments-grid article {
+  padding: 18px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  min-height: 130px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tastet-moments-grid h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tastet-experiment-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.tastet-experiment-card {
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: rgba(6, 13, 26, 0.62);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tastet-experiment-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 36px rgba(0, 0, 0, 0.4);
+}
+
+.tastet-experiment-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.1rem;
+}
+
+.tastet-experiment-card p {
+  font-size: 0.95rem;
+}
+
+.tastet-journal {
+  grid-column: 1 / -1;
+}
+
+.tastet-note-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  margin-top: auto;
+  border-radius: 18px;
+  border: 2px dashed rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1100px) {
+  .tastet-shell {
+    padding: 48px 24px 80px;
+  }
+
+  .tastet-frame {
+    padding: 36px;
+  }
+
+  .tastet-header {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .tastet-title-block {
+    max-width: 100%;
+    text-align: center;
+    align-items: center;
+  }
+
+  .tastet-title-block p {
+    max-width: 680px;
+  }
+
+  .tastet-title-block .tastet-badge,
+  .tastet-primary-action {
+    align-self: center;
+  }
+
+  .tastet-flavor-panel {
+    width: 100%;
+  }
+
+  .tastet-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .tastet-roadmap {
+    grid-row: auto;
+  }
+
+  .tastet-journal {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .tastet-shell {
+    padding: 32px 16px 64px;
+  }
+
+  .tastet-frame {
+    padding: 28px 20px;
+    border-radius: 24px;
+  }
+
+  .tastet-panel {
+    padding: 22px;
+  }
+
+  .tastet-roadmap-list li {
+    grid-template-columns: 1fr;
+  }
+
+  .tastet-roadmap-stage {
+    justify-self: flex-start;
+  }
+}

--- a/src/world.css
+++ b/src/world.css
@@ -260,3 +260,8 @@
 #contract-center {
   /* positioned via .contract-box.circle */
 }
+
+.world-tastet-container {
+  overflow: visible;
+  align-items: stretch;
+}


### PR DESCRIPTION
## Summary
- pass the current layer into the World view so it can adapt to different floors
- introduce the TasteT experience on the Semi-Formless layer, replacing the placeholder with a large hero layout
- craft dedicated styling for TasteT so it feels distinct from standard world apps

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68d3f7e584388322b33159b28cba31b1