### PR TITLE
Refine TierT flow and layout

### DIFF
--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -1,144 +1,2392 @@
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./taste-t.css";
+import { loadImageData } from "./assets/LibraryStorage";
 
-const roadmap = [
+const STORAGE_KEY = "tastet-state-v2";
+const LIBRARY_STORAGE_KEY = "mazedImages";
+const DEFAULT_VOLATILITY = 0.06;
+const MAX_RD = 350;
+const MIN_RD = 35;
+const HOURS_PER_PERIOD = 36;
+const PROMOTION_RD_CAP = 125;
+const LOG_LIMIT = 120;
+const HISTORY_LIMIT = 6;
+const RECENT_MATCHES_LIMIT = 6;
+
+const TIER_RULES = [
   {
-    stage: "Now",
-    title: "Palette Calibration",
-    detail: "Capture the signature mood, color stories, and textures that TasteT will revolve around.",
+    key: "Div2",
+    label: "Division 2",
+    color: "#5c73ff",
+    floor: -Infinity,
+    demoteBelow: -Infinity,
+    promoteAt: 1580,
+    tagline: "New challengers finding their footing.",
   },
   {
-    stage: "Next",
-    title: "Experience Flow",
-    detail: "Sketch the journey from inspiration to tasting notes so we can choreograph each interaction.",
+    key: "Div1",
+    label: "Division 1",
+    color: "#00b3ff",
+    floor: 1500,
+    demoteBelow: 1475,
+    promoteAt: 1700,
+    tagline: "Consistent performers ready for a climb.",
   },
   {
-    stage: "Later",
-    title: "Sensory Library",
-    detail: "Collect audio, visual, and aromatic references that will anchor our experiments.",
+    key: "LFL",
+    label: "LFL",
+    color: "#8a60ff",
+    floor: 1640,
+    demoteBelow: 1610,
+    promoteAt: 1830,
+    tagline: "Regional elite shaping the meta.",
+  },
+  {
+    key: "LEC",
+    label: "LEC",
+    color: "#ff7a59",
+    floor: 1780,
+    demoteBelow: 1750,
+    promoteAt: 1950,
+    tagline: "Major league powerhouses.",
+  },
+  {
+    key: "Worlds",
+    label: "Worlds",
+    color: "#f9c846",
+    floor: 1920,
+    demoteBelow: 1890,
+    promoteAt: Infinity,
+    tagline: "Final stage icons and legends.",
   },
 ];
 
-const tastingMoments = [
-  {
-    label: "Dawn",
-    description: "Bright, crisp openings that wake up curiosity.",
-  },
-  {
-    label: "Noon",
-    description: "Balanced harmonies where the rhythm settles in.",
-  },
-  {
-    label: "Dusk",
-    description: "Velvet transitions carrying warmth into the night.",
-  },
-];
+const TIER_LOOKUP = TIER_RULES.reduce((acc, tier, index) => {
+  acc[tier.key] = { ...tier, index };
+  return acc;
+}, {});
 
-const experimentIdeas = [
-  {
-    title: "Atmosphere Sequencer",
-    note: "Layer ambient soundscapes with palette cues to reinforce the tasting arc.",
-  },
-  {
-    title: "Texture Sampler",
-    note: "Prototype tactile prompts that respond to progress and choices.",
-  },
-  {
-    title: "Memory Anchor",
-    note: "Design rituals that let guests capture a single vivid note from each session.",
-  },
-];
+const MINI_SIZE_OPTIONS = [4, 6, 8, 10, 12, 16];
 
-export default function TasteT() {
+function coerceLibraryId(value) {
+  if (value == null) return null;
+  return String(value);
+}
+
+function sanitizeText(value, fallback = "") {
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : fallback;
+}
+
+function normalizeLibraryTags(tags) {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .map((tag) => sanitizeText(typeof tag === "string" ? tag : ""))
+    .filter((tag) => tag.length > 0);
+}
+
+function arraysEqual(a = [], b = []) {
+  if (a === b) return true;
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function loadLibraryCatalog() {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = localStorage.getItem(LIBRARY_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((entry, index) => {
+        const id = coerceLibraryId(entry?.id ?? index);
+        if (!id) return null;
+        const tags = normalizeLibraryTags(entry?.tags);
+        const dataUrl = typeof entry?.dataUrl === "string" && entry.dataUrl.length ? entry.dataUrl : null;
+        const mimeType = sanitizeText(entry?.mimeType || "", null);
+        const createdAt =
+          typeof entry?.createdAt === "number"
+            ? entry.createdAt
+            : typeof entry?.addedAt === "number"
+            ? entry.addedAt
+            : typeof entry?.timestamp === "number"
+            ? entry.timestamp
+            : null;
+
+        return {
+          id,
+          title: sanitizeText(entry?.title || "", "Untitled"),
+          tags,
+          dataUrl,
+          mimeType,
+          width: typeof entry?.width === "number" ? entry.width : null,
+          height: typeof entry?.height === "number" ? entry.height : null,
+          color: sanitizeText(entry?.color || "", null),
+          createdAt,
+        };
+      })
+      .filter(Boolean);
+  } catch (error) {
+    console.warn('TierT: unable to read library catalog', error);
+    return [];
+  }
+}
+
+function synchronizeImagesWithLibrary(savedImages, libraryEntries) {
+  const savedMap = new Map(savedImages.map((image) => [String(image.id), image]));
+  const merged = [];
+  const newIds = [];
+  let changed = false;
+  const now = Date.now();
+
+  libraryEntries.forEach((entry, index) => {
+    const id = String(entry.id);
+    const existing = savedMap.get(id);
+    const tags = normalizeLibraryTags(entry.tags);
+    const baseName = sanitizeText(entry.title, existing?.name || `Image ${index + 1}`);
+    const dataUrl = entry.dataUrl || existing?.dataUrl || null;
+    const imageUrl = dataUrl || existing?.imageUrl || null;
+    const mimeType = entry.mimeType || existing?.mimeType || null;
+    const createdAt = existing?.createdAt || entry.createdAt || now - index * 1000;
+
+    if (existing) {
+      let next = existing;
+      if (
+        existing.name !== baseName ||
+        !arraysEqual(existing.tags, tags) ||
+        (dataUrl && existing.dataUrl !== dataUrl) ||
+        (imageUrl && existing.imageUrl !== imageUrl) ||
+        (mimeType && existing.mimeType !== mimeType) ||
+        (entry.color && existing.libraryColor !== entry.color) ||
+        (entry.width && existing.libraryWidth !== entry.width) ||
+        (entry.height && existing.libraryHeight !== entry.height) ||
+        (!existing.createdAt && createdAt)
+      ) {
+        next = {
+          ...existing,
+          name: baseName,
+          tags,
+          dataUrl,
+          imageUrl,
+          mimeType,
+          libraryColor: entry.color || existing.libraryColor || null,
+          libraryWidth: entry.width || existing.libraryWidth || null,
+          libraryHeight: entry.height || existing.libraryHeight || null,
+          createdAt,
+        };
+        changed = true;
+      }
+      merged.push(next);
+      savedMap.delete(id);
+    } else {
+      const record = createImageRecord({
+        id,
+        name: baseName,
+        imageUrl,
+        dataUrl,
+        tags,
+        rating: 1500,
+        rd: 300,
+        volatility: DEFAULT_VOLATILITY,
+        createdAt,
+      });
+      record.mimeType = mimeType;
+      record.libraryColor = entry.color || null;
+      record.libraryWidth = entry.width || null;
+      record.libraryHeight = entry.height || null;
+      merged.push(record);
+      newIds.push(id);
+      changed = true;
+    }
+  });
+
+  if (savedMap.size > 0) {
+    changed = true;
+  }
+
+  return { images: changed ? merged : savedImages, newIds, changed };
+}
+
+function buildPlacementQueueForImage(imageId, images, count = 5) {
+  if (!imageId) return null;
+  const opponents = createPlacementOpponents(imageId, images, count).map((entry) => entry.id);
+  if (!opponents.length) {
+    return null;
+  }
+  return {
+    imageId,
+    opponents,
+    currentIndex: 0,
+    history: [],
+    createdAt: Date.now(),
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function roundTo(value, decimals = 2) {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function formatDelta(value) {
+  const rounded = roundTo(value, 1);
+  if (!rounded) {
+    return "±0";
+  }
+  return `${rounded > 0 ? "+" : ""}${rounded}`;
+}
+
+function formatRecord(wins = 0, losses = 0, draws = 0) {
+  return draws ? `${wins}-${losses}-${draws}` : `${wins}-${losses}`;
+}
+
+function formatRelativeTime(timestamp) {
+  if (!timestamp) return "never";
+  const diff = Date.now() - timestamp;
+  if (diff < 0) return "just now";
+  const minutes = Math.round(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 90) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  if (months < 24) return `${months}mo ago`;
+  const years = Math.round(days / 365);
+  return `${years}y ago`;
+}
+
+function scoreToPoints(score) {
+  if (score === 1) return 2;
+  if (score === 0.5) return 1;
+  return 0;
+}
+
+function expectedScore(ratingA, ratingB) {
+  return 1 / (1 + 10 ** ((ratingB - ratingA) / 400));
+}
+
+function colorFromString(input) {
+  const str = input || "tier";
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 70%, 55%)`;
+}
+
+function hexToRgb(color) {
+  if (!color) {
+    return { r: 120, g: 160, b: 255 };
+  }
+  let hex = color.replace("#", "");
+  if (hex.length === 3) {
+    hex = hex
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+  const num = parseInt(hex, 16);
+  if (Number.isNaN(num)) {
+    return { r: 120, g: 160, b: 255 };
+  }
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255,
+  };
+}
+
+function applyAlpha(color, alpha) {
+  const { r, g, b } = hexToRgb(color);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function createTierGradient(color) {
+  return `linear-gradient(135deg, ${applyAlpha(color, 0.85)}, ${applyAlpha(color, 0.45)})`;
+}
+
+function getTierIndex(tierKey) {
+  return TIER_LOOKUP[tierKey]?.index ?? 0;
+}
+
+function getTierByRating(rating) {
+  let tierKey = TIER_RULES[0].key;
+  for (const tier of TIER_RULES) {
+    const floor = tier.floor === -Infinity ? -Infinity : tier.floor;
+    if (rating >= floor) {
+      tierKey = tier.key;
+    }
+  }
+  return tierKey;
+}
+
+function resolveTierChange(currentTierKey, rating, rd) {
+  const currentIndex = currentTierKey ? getTierIndex(currentTierKey) : 0;
+  let index = currentIndex;
+
+  while (index < TIER_RULES.length - 1) {
+    const tier = TIER_RULES[index];
+    if (rating >= tier.promoteAt && rd <= PROMOTION_RD_CAP) {
+      index += 1;
+    } else {
+      break;
+    }
+  }
+
+  while (index > 0) {
+    const tier = TIER_RULES[index];
+    if (rating < tier.demoteBelow) {
+      index -= 1;
+    } else {
+      break;
+    }
+  }
+
+  const tier = TIER_RULES[index];
+  return {
+    key: tier.key,
+    index,
+    tier,
+    changed: tier.key !== currentTierKey,
+    direction: tier.key === currentTierKey ? null : index > currentIndex ? "promotion" : "demotion",
+  };
+}
+
+function computeStreak(recentMatches) {
+  if (!recentMatches || !recentMatches.length) return "—";
+  const first = recentMatches[0].result;
+  if (first === "D") {
+    const drawStreak = recentMatches.findIndex((match) => match.result !== "D");
+    const count = drawStreak === -1 ? recentMatches.length : drawStreak;
+    return `D${count}`;
+  }
+  let count = 0;
+  for (const match of recentMatches) {
+    if (match.result !== first) break;
+    count += 1;
+  }
+  return `${first}${count}`;
+}
+
+function updateImageStats(image, score, context, newRating, timestamp, tierChange) {
+  const stats = {
+    wins: image.stats?.wins ?? 0,
+    losses: image.stats?.losses ?? 0,
+    draws: image.stats?.draws ?? 0,
+    totalDuels: image.stats?.totalDuels ?? 0,
+    minisEntered: image.stats?.minisEntered ?? 0,
+    placementDuels: image.stats?.placementDuels ?? 0,
+    promotions: image.stats?.promotions ?? 0,
+    demotions: image.stats?.demotions ?? 0,
+    bestFinish: image.stats?.bestFinish ?? null,
+    highestRating: image.stats?.highestRating ?? image.rating,
+    lowestRating: image.stats?.lowestRating ?? image.rating,
+    currentStreak: image.stats?.currentStreak ?? "—",
+    lastMode: image.stats?.lastMode ?? "duel",
+    lastSwissId: image.stats?.lastSwissId ?? null,
+    lastOutcome: image.stats?.lastOutcome ?? null,
+    lastRating: image.stats?.lastRating ?? image.rating,
+    lastRD: image.stats?.lastRD ?? image.rd,
+    lastOpponentId: image.stats?.lastOpponentId ?? null,
+    lastUpdatedAt: image.stats?.lastUpdatedAt ?? image.updatedAt ?? image.createdAt ?? timestamp,
+  };
+
+  if (score === 1) stats.wins += 1;
+  else if (score === 0) stats.losses += 1;
+  else stats.draws += 1;
+
+  stats.totalDuels += 1;
+
+  if (context.mode === "placement") {
+    stats.placementDuels += 1;
+  }
+
+  if (tierChange?.direction === "promotion") {
+    stats.promotions += 1;
+  } else if (tierChange?.direction === "demotion") {
+    stats.demotions += 1;
+  }
+
+  stats.highestRating = Math.max(stats.highestRating, newRating);
+  stats.lowestRating = Math.min(stats.lowestRating, newRating);
+  stats.lastMode = context.mode || "duel";
+  if (context.swissId) {
+    stats.lastSwissId = context.swissId;
+  }
+  stats.lastUpdatedAt = timestamp;
+
+  const outcomeLabel = score === 1 ? "win" : score === 0 ? "loss" : "draw";
+  stats.lastOutcome = outcomeLabel;
+  stats.lastRating = newRating;
+  if (typeof context.newRd === "number") {
+    stats.lastRD = context.newRd;
+  }
+  if (context.opponentId) {
+    stats.lastOpponentId = context.opponentId;
+  }
+
+  const streakCode = outcomeLabel === "win" ? "W" : outcomeLabel === "loss" ? "L" : "D";
+  const prevStreak = image.stats?.currentStreak || "";
+  const prevCode = prevStreak.charAt(0);
+  const prevCount = Number.parseInt(prevStreak.slice(1), 10);
+  if (prevCode === streakCode && Number.isFinite(prevCount)) {
+    stats.currentStreak = `${streakCode}${prevCount + 1}`;
+  } else {
+    stats.currentStreak = `${streakCode}1`;
+  }
+
+  return stats;
+}
+
+function computePeriodsElapsed(lastPlayedAt, now = Date.now()) {
+  if (!lastPlayedAt) return 1;
+  const diff = now - lastPlayedAt;
+  if (diff <= 0) return 1;
+  const hours = diff / (1000 * 60 * 60);
+  if (hours <= HOURS_PER_PERIOD) {
+    return 1;
+  }
+  return Math.min(8, Math.round(hours / HOURS_PER_PERIOD));
+}
+
+function updateGlickoPlayer(player, matches, periods = 1) {
+  const rating = typeof player.rating === "number" ? player.rating : 1500;
+  const rd = typeof player.rd === "number" ? player.rd : 350;
+  const sigma = typeof player.volatility === "number" ? player.volatility : DEFAULT_VOLATILITY;
+
+  const scale = 173.7178;
+  const mu = (rating - 1500) / scale;
+  const phi = rd / scale;
+  const phiStar = Math.sqrt(phi * phi + sigma * sigma * periods);
+
+  if (!matches || !matches.length) {
+    return {
+      rating,
+      rd: roundTo(clamp(phiStar * scale, MIN_RD, MAX_RD), 2),
+      volatility: sigma,
+    };
+  }
+
+  let vDenom = 0;
+  let deltaSum = 0;
+
+  matches.forEach((match) => {
+    const oppMu = ((match.rating ?? 1500) - 1500) / scale;
+    const oppPhi = (match.rd ?? 350) / scale;
+    const gPhi = 1 / Math.sqrt(1 + (3 * oppPhi * oppPhi) / (Math.PI * Math.PI));
+    const expected = 1 / (1 + Math.exp(-gPhi * (mu - oppMu)));
+    const score = typeof match.score === "number" ? match.score : 0.5;
+    vDenom += gPhi * gPhi * expected * (1 - expected);
+    deltaSum += gPhi * (score - expected);
+  });
+
+  const v = 1 / vDenom;
+  const delta = v * deltaSum;
+  const tau = 0.5;
+  const a = Math.log(sigma * sigma);
+
+  const f = (x) => {
+    const expX = Math.exp(x);
+    const num = expX * (delta * delta - phiStar * phiStar - v - expX);
+    const den = 2 * (phiStar * phiStar + v + expX) ** 2;
+    return num / den - (x - a) / (tau * tau);
+  };
+
+  let A = a;
+  let B;
+  if (delta * delta > phiStar * phiStar + v) {
+    B = Math.log(delta * delta - phiStar * phiStar - v);
+  } else {
+    let k = 1;
+    do {
+      B = a - k * tau;
+      k += 1;
+    } while (f(B) < 0);
+  }
+
+  let fA = f(A);
+  let fB = f(B);
+  while (Math.abs(B - A) > 1e-6) {
+    const C = A + (A - B) * (fA / (fB - fA));
+    const fC = f(C);
+    if (fC * fB < 0) {
+      A = B;
+      fA = fB;
+    } else {
+      fA /= 2;
+    }
+    B = C;
+    fB = fC;
+  }
+
+  const newSigma = Math.exp(A / 2);
+  const phiPrime = 1 / Math.sqrt(1 / (phiStar * phiStar) + 1 / v);
+  const muPrime = mu + phiPrime * phiPrime * deltaSum;
+
+  return {
+    rating: roundTo(muPrime * scale + 1500, 2),
+    rd: roundTo(clamp(phiPrime * scale, MIN_RD, MAX_RD), 2),
+    volatility: clamp(newSigma, 0.02, 1.2),
+  };
+}
+
+function createImageRecord({
+  id,
+  name,
+  imageUrl,
+  dataUrl = null,
+  mimeType = null,
+  tags = [],
+  rating = 1500,
+  rd = 260,
+  volatility = DEFAULT_VOLATILITY,
+  tierKey,
+  stats = {},
+  createdAt = Date.now(),
+  lastPlayedAt = null,
+  recentMatches = [],
+  tierLog,
+}) {
+  const normalizedTags = Array.isArray(tags) ? tags : [];
+  const normalizedStats = {
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    totalDuels: 0,
+    minisEntered: 0,
+    placementDuels: 0,
+    promotions: 0,
+    demotions: 0,
+    bestFinish: null,
+    highestRating: rating,
+    lowestRating: rating,
+    currentStreak: "—",
+    lastMode: "duel",
+    lastSwissId: null,
+    lastOutcome: null,
+    lastRating: rating,
+    lastRD: rd,
+    lastOpponentId: null,
+    lastUpdatedAt: createdAt,
+    ...stats,
+  };
+
+  if (!normalizedStats.totalDuels) {
+    normalizedStats.totalDuels =
+      (normalizedStats.wins || 0) + (normalizedStats.losses || 0) + (normalizedStats.draws || 0);
+  }
+  if (normalizedStats.highestRating == null) normalizedStats.highestRating = rating;
+  if (normalizedStats.lowestRating == null) normalizedStats.lowestRating = rating;
+
+  const resolvedTierKey = tierKey || getTierByRating(rating);
+  const baseTierLog =
+    Array.isArray(tierLog) && tierLog.length
+      ? tierLog
+      : [
+          {
+            timestamp: createdAt,
+            tier: resolvedTierKey,
+            direction: "init",
+            rating,
+          },
+        ];
+
+  return {
+    id,
+    name,
+    imageUrl: imageUrl || null,
+    dataUrl,
+    mimeType,
+    tags: normalizedTags,
+    rating,
+    rd,
+    volatility,
+    tierKey: resolvedTierKey,
+    tierIndex: getTierIndex(resolvedTierKey),
+    stats: normalizedStats,
+    createdAt,
+    updatedAt: createdAt,
+    lastPlayedAt,
+    tierLog: baseTierLog,
+    recentMatches: Array.isArray(recentMatches)
+      ? recentMatches.slice(0, RECENT_MATCHES_LIMIT)
+      : [],
+  };
+}
+
+
+function normalizeImage(raw) {
+  if (!raw || !raw.id) return null;
+  return {
+    ...createImageRecord({
+      id: raw.id,
+      name: raw.name || raw.title || "Untitled",
+      imageUrl: raw.imageUrl || raw.dataUrl || null,
+      dataUrl: typeof raw.dataUrl === "string" ? raw.dataUrl : null,
+      mimeType: raw.mimeType || null,
+      tags: Array.isArray(raw.tags) ? raw.tags : [],
+      rating: typeof raw.rating === "number" ? raw.rating : 1500,
+      rd: typeof raw.rd === "number" ? raw.rd : 260,
+      volatility: typeof raw.volatility === "number" ? raw.volatility : DEFAULT_VOLATILITY,
+      tierKey: raw.tierKey || raw.tier || getTierByRating(raw.rating || 1500),
+      stats: raw.stats || {},
+      createdAt: raw.createdAt || Date.now(),
+      lastPlayedAt: raw.lastPlayedAt || null,
+      recentMatches: raw.recentMatches || [],
+      tierLog: raw.tierLog || [],
+    }),
+    updatedAt: raw.updatedAt || raw.createdAt || Date.now(),
+  };
+}
+
+function normalizeSwiss(raw) {
+  if (!raw || !Array.isArray(raw.participants) || !Array.isArray(raw.rounds)) {
+    return null;
+  }
+  const participants = raw.participants.map((participant) => ({
+    id: participant.id,
+    name: participant.name,
+    seed: participant.seed || 0,
+    seedRating: typeof participant.seedRating === "number" ? participant.seedRating : 1500,
+    currentRating:
+      typeof participant.currentRating === "number"
+        ? participant.currentRating
+        : participant.seedRating || 1500,
+    rd: typeof participant.rd === "number" ? participant.rd : 260,
+    tierKey: participant.tierKey || getTierByRating(participant.currentRating || 1500),
+    wins: participant.wins || 0,
+    losses: participant.losses || 0,
+    draws: participant.draws || 0,
+    points: participant.points || 0,
+    opponents: Array.isArray(participant.opponents) ? participant.opponents : [],
+    history: Array.isArray(participant.history) ? participant.history : [],
+    hasBye: Boolean(participant.hasBye),
+    buchholz: participant.buchholz || 0,
+  }));
+
+  const rounds = raw.rounds.map((round) => ({
+    index: round.index,
+    pairings: Array.isArray(round.pairings)
+      ? round.pairings.map((pair) => ({
+          id: pair.id,
+          leftId: pair.leftId,
+          rightId: pair.rightId ?? null,
+          bye: Boolean(pair.bye),
+          resolved: Boolean(pair.resolved || pair.bye),
+          result: pair.result || (pair.bye ? "bye" : null),
+          winnerId: pair.winnerId ?? (pair.bye ? pair.leftId : null),
+          preRatings: pair.preRatings || null,
+          expected: typeof pair.expected === "number" ? pair.expected : 0.5,
+          ratingChange: pair.ratingChange || null,
+          outcome: pair.outcome || null,
+          tierChanges: pair.tierChanges || null,
+          logId: pair.logId || null,
+          timestamp: pair.timestamp || null,
+        }))
+      : [],
+    standings: Array.isArray(round.standings) ? round.standings : null,
+    completedAt: round.completedAt || null,
+  }));
+
+  const normalized = {
+    id: raw.id || `swiss-${Date.now()}`,
+    createdAt: raw.createdAt || Date.now(),
+    status: raw.status || "in-progress",
+    participants,
+    rounds,
+    currentRound: raw.currentRound || (rounds.length ? rounds[rounds.length - 1].index : 1),
+    totalRounds: raw.totalRounds || Math.max(rounds.length, 3),
+    awaitingAdvance: Boolean(raw.awaitingAdvance),
+    latestStandings: raw.latestStandings || null,
+    finalStandings: raw.finalStandings || null,
+    completedAt: raw.completedAt || null,
+  };
+
+  if (!normalized.latestStandings) {
+    normalized.latestStandings = computeStandings(participants).standings;
+  }
+
+  return normalized;
+}
+
+function loadInitialState() {
+  const libraryEntries = loadLibraryCatalog();
+  const baseline = synchronizeImagesWithLibrary([], libraryEntries);
+  const baseImages = baseline.images;
+  const basePlacement = buildPlacementQueueForImage(baseline.newIds[0], baseImages);
+
+  const base = {
+    images: baseImages,
+    duelLog: [],
+    swissHistory: [],
+    activeSwiss: null,
+    placementQueue: basePlacement,
+    placementQueueRestored: false,
+    selectedTag: "",
+    miniSize: 8,
+    libraryEntries,
+  };
+
+  if (typeof window === "undefined") {
+    return base;
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return base;
+    }
+
+    const parsed = JSON.parse(raw);
+    const savedImages = Array.isArray(parsed.images)
+      ? parsed.images.map(normalizeImage).filter(Boolean)
+      : [];
+    const mergeResult = synchronizeImagesWithLibrary(savedImages, libraryEntries);
+    const images = mergeResult.images;
+
+    const duelLog = Array.isArray(parsed.duelLog)
+      ? parsed.duelLog.slice(0, LOG_LIMIT)
+      : base.duelLog;
+    const swissHistory = Array.isArray(parsed.swissHistory)
+      ? parsed.swissHistory.slice(0, HISTORY_LIMIT)
+      : base.swissHistory;
+    const activeSwiss = parsed.activeSwiss ? normalizeSwiss(parsed.activeSwiss) : null;
+
+    const imageIds = new Set(images.map((image) => image.id));
+    let placementQueue = null;
+    let placementQueueRestored = false;
+
+    if (parsed.placementQueue && parsed.placementQueue.imageId && imageIds.has(parsed.placementQueue.imageId)) {
+      const opponents = Array.isArray(parsed.placementQueue.opponents)
+        ? parsed.placementQueue.opponents.filter(
+            (id) => id && imageIds.has(id) && id !== parsed.placementQueue.imageId,
+          )
+        : [];
+      if (opponents.length) {
+        placementQueue = {
+          imageId: parsed.placementQueue.imageId,
+          opponents,
+          currentIndex: Math.min(parsed.placementQueue.currentIndex || 0, opponents.length - 1),
+          history: Array.isArray(parsed.placementQueue.history)
+            ? parsed.placementQueue.history
+            : [],
+          createdAt: parsed.placementQueue.createdAt || Date.now(),
+        };
+        placementQueueRestored = true;
+      }
+    }
+
+    if (!placementQueue && mergeResult.newIds.length) {
+      placementQueue = buildPlacementQueueForImage(mergeResult.newIds[0], images);
+      placementQueueRestored = false;
+    }
+
+    return {
+      images,
+      duelLog,
+      swissHistory,
+      activeSwiss,
+      placementQueue,
+      placementQueueRestored,
+      selectedTag: parsed.selectedTag || base.selectedTag,
+      miniSize: parsed.miniSize || base.miniSize,
+      libraryEntries,
+    };
+  } catch (error) {
+    console.warn("TierT: unable to restore saved state", error);
+    return base;
+  }
+}
+
+function selectSwissParticipants(images, size) {
+  if (images.length <= size) {
+    return images.slice();
+  }
+  const now = Date.now();
+  const scored = images.map((image) => {
+    const lastPlayed = image.lastPlayedAt ? (now - image.lastPlayedAt) / (1000 * 60 * 60) : 999;
+    const uncertainty = image.rd || 0;
+    const totalDuels = image.stats?.totalDuels || 0;
+    const weight =
+      (12 - Math.min(totalDuels, 12)) * 4 +
+      Math.min(lastPlayed, 168) * 0.3 +
+      uncertainty * 0.4 +
+      (image.rating - 1500) / 80 +
+      Math.random() * 5;
+    return { image, weight };
+  });
+
+  scored.sort((a, b) => b.weight - a.weight);
+  const selected = [];
+  const used = new Set();
+
+  for (const entry of scored) {
+    if (selected.length >= size) break;
+    selected.push(entry.image);
+    used.add(entry.image.id);
+  }
+
+  const topRated = images.slice().sort((a, b) => b.rating - a.rating).slice(0, 3);
+  for (const candidate of topRated) {
+    if (selected.length >= size) break;
+    if (!used.has(candidate.id)) {
+      selected.push(candidate);
+      used.add(candidate.id);
+    }
+  }
+
+  const fallback = images.slice().sort((a, b) => b.rating - a.rating);
+  let index = 0;
+  while (selected.length < size && index < fallback.length) {
+    const candidate = fallback[index];
+    if (!used.has(candidate.id)) {
+      selected.push(candidate);
+      used.add(candidate.id);
+    }
+    index += 1;
+  }
+
+  return selected;
+}
+
+function generatePairings(participants, roundNumber) {
+  const sorted = participants
+    .slice()
+    .sort((a, b) => {
+      if (b.points !== a.points) return b.points - a.points;
+      const aDiff = (a.wins || 0) - (a.losses || 0);
+      const bDiff = (b.wins || 0) - (b.losses || 0);
+      if (bDiff !== aDiff) return bDiff - aDiff;
+      if ((a.rd ?? 0) !== (b.rd ?? 0)) return (a.rd ?? 0) - (b.rd ?? 0);
+      return a.seed - b.seed;
+    });
+
+  const used = new Set();
+  const pairings = [];
+
+  if (sorted.length % 2 === 1) {
+    let byeCandidate = null;
+    let bestScore = -Infinity;
+    for (const player of sorted) {
+      if (player.hasBye) continue;
+      const candidateScore = -(player.points || 0) * 4 + (player.rd || 0);
+      if (candidateScore > bestScore) {
+        bestScore = candidateScore;
+        byeCandidate = player;
+      }
+    }
+    if (!byeCandidate) {
+      byeCandidate = sorted[sorted.length - 1];
+    }
+    if (byeCandidate) {
+      pairings.push({
+        id: `bye-${roundNumber}-${byeCandidate.id}`,
+        leftId: byeCandidate.id,
+        bye: true,
+      });
+      used.add(byeCandidate.id);
+    }
+  }
+
+  for (const player of sorted) {
+    if (used.has(player.id)) continue;
+    let bestIndex = -1;
+    let bestScore = Infinity;
+    for (let i = 0; i < sorted.length; i += 1) {
+      const opponent = sorted[i];
+      if (used.has(opponent.id) || opponent.id === player.id) continue;
+      const alreadyPlayed = Array.isArray(player.opponents)
+        ? player.opponents.includes(opponent.id)
+        : false;
+      const recordGap = Math.abs((player.points || 0) - (opponent.points || 0));
+      const ratingGap = Math.abs(
+        (player.currentRating ?? player.seedRating ?? 1500) -
+          (opponent.currentRating ?? opponent.seedRating ?? 1500)
+      );
+      const rdFactor = ((player.rd ?? 0) + (opponent.rd ?? 0)) / 2;
+      const rematchPenalty = alreadyPlayed ? 400 : 0;
+      const byePenalty = opponent.hasBye ? 300 : 0;
+      const score =
+        ratingGap - rdFactor * 0.35 + recordGap * 220 + rematchPenalty + byePenalty;
+      if (score < bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+    if (bestIndex === -1) continue;
+    const opponent = sorted[bestIndex];
+    used.add(player.id);
+    used.add(opponent.id);
+    const leftFirst = Math.random() > 0.5;
+    const leftId = leftFirst ? player.id : opponent.id;
+    const rightId = leftFirst ? opponent.id : player.id;
+    pairings.push({
+      id: `pair-${roundNumber}-${player.id}-${opponent.id}-${Math.random()
+        .toString(36)
+        .slice(2, 6)}`,
+      leftId,
+      rightId,
+      bye: false,
+    });
+  }
+
+  return pairings;
+}
+
+function prepareRound(participants, roundNumber, imagesById) {
+  const clones = participants.map((participant) => ({
+    ...participant,
+    opponents: Array.isArray(participant.opponents)
+      ? [...participant.opponents]
+      : [],
+    history: Array.isArray(participant.history)
+      ? [...participant.history]
+      : [],
+  }));
+
+  const pairings = generatePairings(clones, roundNumber);
+  const participantMap = new Map(clones.map((participant) => [participant.id, participant]));
+
+  const finalPairings = pairings.map((pair) => {
+    if (pair.bye) {
+      const player = participantMap.get(pair.leftId);
+      if (player) {
+        player.hasBye = true;
+        player.wins += 1;
+        player.points += 2;
+        player.history = [
+          ...player.history,
+          {
+            round: roundNumber,
+            opponentId: null,
+            result: "BYE",
+            points: 2,
+            ratingDelta: 0,
+          },
+        ];
+      }
+      return {
+        ...pair,
+        resolved: true,
+        result: "bye",
+        winnerId: pair.leftId,
+      };
+    }
+
+    const left = participantMap.get(pair.leftId);
+    const right = participantMap.get(pair.rightId);
+
+    if (left && !left.opponents.includes(pair.rightId)) {
+      left.opponents.push(pair.rightId);
+    }
+    if (right && !right.opponents.includes(pair.leftId)) {
+      right.opponents.push(pair.leftId);
+    }
+
+    const leftImage = imagesById[pair.leftId];
+    const rightImage = imagesById[pair.rightId];
+
+    return {
+      ...pair,
+      resolved: false,
+      result: null,
+      preRatings:
+        leftImage && rightImage
+          ? {
+              left: leftImage.rating,
+              right: rightImage.rating,
+              leftRd: leftImage.rd,
+              rightRd: rightImage.rd,
+            }
+          : null,
+      expected:
+        leftImage && rightImage ? expectedScore(leftImage.rating, rightImage.rating) : 0.5,
+    };
+  });
+
+  return { participants: clones, pairings: finalPairings };
+}
+
+function computeStandings(participants) {
+  const map = new Map(participants.map((participant) => [participant.id, participant]));
+  const computed = participants.map((participant) => {
+    const buchholz = (participant.opponents || []).reduce((total, opponentId) => {
+      const opponent = map.get(opponentId);
+      return total + (opponent ? opponent.points || 0 : 0);
+    }, 0);
+    return {
+      ...participant,
+      buchholz,
+    };
+  });
+
+  computed.sort((a, b) => {
+    if (b.points !== a.points) return b.points - a.points;
+    if ((b.buchholz || 0) !== (a.buchholz || 0)) return (b.buchholz || 0) - (a.buchholz || 0);
+    if ((b.currentRating || 0) !== (a.currentRating || 0))
+      return (b.currentRating || 0) - (a.currentRating || 0);
+    return a.seed - b.seed;
+  });
+
+  const buchholzMap = {};
+  computed.forEach((entry, index) => {
+    entry.rank = index + 1;
+    buchholzMap[entry.id] = entry.buchholz || 0;
+  });
+
+  return { standings: computed, buchholzMap };
+}
+
+function applySwissParticipantResult(participant, opponentId, score, resultData, roundNumber, logId) {
+  const resultLabel = score === 1 ? "W" : score === 0 ? "L" : "D";
+  const historyEntry = {
+    round: roundNumber,
+    opponentId,
+    result: resultLabel,
+    points: scoreToPoints(score),
+    ratingDelta: roundTo(resultData.deltaRating, 2),
+    tierChange: resultData.tierChange
+      ? { key: resultData.tierChange.key, direction: resultData.tierChange.direction }
+      : null,
+    logId,
+  };
+
+  return {
+    ...participant,
+    wins: participant.wins + (score === 1 ? 1 : 0),
+    losses: participant.losses + (score === 0 ? 1 : 0),
+    draws: participant.draws + (score === 0.5 ? 1 : 0),
+    points: participant.points + scoreToPoints(score),
+    currentRating: resultData.image.rating,
+    rd: resultData.image.rd,
+    tierKey: resultData.image.tierKey,
+    history: [...(participant.history || []), historyEntry].slice(-12),
+  };
+}
+
+function updateSwissWithResult(prevSwiss, pairingId, resolution) {
+  if (!prevSwiss) return prevSwiss;
+  const roundIndex = prevSwiss.rounds.findIndex((round) => round.index === prevSwiss.currentRound);
+  if (roundIndex === -1) return prevSwiss;
+  const round = prevSwiss.rounds[roundIndex];
+  const pairingIndex = round.pairings.findIndex((pair) => pair.id === pairingId);
+  if (pairingIndex === -1) return prevSwiss;
+  const pairing = round.pairings[pairingIndex];
+  if (!pairing || pairing.resolved) return prevSwiss;
+
+  const participants = prevSwiss.participants.map((participant) => {
+    if (participant.id === pairing.leftId) {
+      return applySwissParticipantResult(
+        participant,
+        pairing.rightId,
+        resolution.leftOutcome,
+        resolution.left,
+        prevSwiss.currentRound,
+        resolution.duelEntry.id,
+      );
+    }
+    if (participant.id === pairing.rightId) {
+      return applySwissParticipantResult(
+        participant,
+        pairing.leftId,
+        resolution.rightOutcome,
+        resolution.right,
+        prevSwiss.currentRound,
+        resolution.duelEntry.id,
+      );
+    }
+    return participant;
+  });
+
+  const { standings, buchholzMap } = computeStandings(participants);
+  const participantsWithBuchholz = participants.map((participant) => ({
+    ...participant,
+    buchholz: buchholzMap[participant.id] || 0,
+  }));
+
+  const updatedPairings = round.pairings.map((pair, index) => {
+    if (index !== pairingIndex) return pair;
+    return {
+      ...pair,
+      resolved: true,
+      result: resolution.outcome,
+      winnerId: resolution.winnerId,
+      ratingChange: {
+        left: resolution.left.deltaRating,
+        right: resolution.right.deltaRating,
+      },
+      outcome: {
+        left: resolution.leftOutcome,
+        right: resolution.rightOutcome,
+      },
+      tierChanges: {
+        left: resolution.left.tierChange,
+        right: resolution.right.tierChange,
+      },
+      logId: resolution.duelEntry.id,
+      timestamp: resolution.timestamp,
+    };
+  });
+
+  const updatedRound = {
+    ...round,
+    pairings: updatedPairings,
+  };
+
+  let awaitingAdvance = prevSwiss.awaitingAdvance;
+  let status = prevSwiss.status;
+  let latestStandings = prevSwiss.latestStandings;
+
+  const allResolved = updatedPairings.every((pair) => pair.resolved);
+  if (allResolved) {
+    awaitingAdvance = true;
+    latestStandings = standings;
+    updatedRound.completedAt = resolution.timestamp;
+    updatedRound.standings = standings;
+    status = prevSwiss.currentRound >= prevSwiss.totalRounds ? "awaiting-finish" : "between-rounds";
+  }
+
+  const rounds = prevSwiss.rounds.map((entry, index) => (index === roundIndex ? updatedRound : entry));
+
+  return {
+    ...prevSwiss,
+    participants: participantsWithBuchholz,
+    rounds,
+    awaitingAdvance,
+    status,
+    latestStandings,
+  };
+}
+
+function createPlacementOpponents(newImageId, images, count = 5) {
+  const pool = images.filter((image) => image.id !== newImageId);
+  if (!pool.length) return [];
+
+  const sortedByRating = pool.slice().sort((a, b) => b.rating - a.rating);
+  const sortedByUncertainty = pool.slice().sort((a, b) => b.rd - a.rd);
+  const picks = [];
+
+  const pushCandidate = (candidate) => {
+    if (!candidate) return;
+    if (picks.some((entry) => entry.id === candidate.id)) return;
+    picks.push(candidate);
+  };
+
+  pushCandidate(sortedByRating[0]);
+  pushCandidate(sortedByRating[Math.floor(sortedByRating.length / 3)]);
+  pushCandidate(sortedByRating[Math.floor((sortedByRating.length * 2) / 3)]);
+  pushCandidate(sortedByRating[sortedByRating.length - 1]);
+  pushCandidate(sortedByUncertainty[0]);
+
+  let index = 1;
+  while (picks.length < Math.min(count, pool.length) && index < sortedByUncertainty.length) {
+    pushCandidate(sortedByUncertainty[index]);
+    index += 1;
+  }
+
+  index = 0;
+  while (picks.length < Math.min(count, pool.length) && index < sortedByRating.length) {
+    pushCandidate(sortedByRating[index]);
+    index += 1;
+  }
+
+  return picks.slice(0, Math.min(count, picks.length));
+}
+
+function determineTotalRounds(size) {
+  if (size <= 4) return 3;
+  if (size <= 8) return 4;
+  if (size <= 16) return 5;
+  return 5;
+}
+
+function createSwissMini(images, size, imagesById) {
+  const trimmedSize = Math.max(2, Math.min(size, images.length));
+  if (trimmedSize < 2) return null;
+
+  const selected = selectSwissParticipants(images, trimmedSize);
+  if (!selected.length) return null;
+
+  const participants = selected.map((image, index) => ({
+    id: image.id,
+    name: image.name,
+    seed: index + 1,
+    seedRating: image.rating,
+    currentRating: image.rating,
+    rd: image.rd,
+    tierKey: image.tierKey,
+    wins: 0,
+    losses: 0,
+    draws: 0,
+    points: 0,
+    opponents: [],
+    history: [],
+    hasBye: false,
+    buchholz: 0,
+  }));
+
+  const totalRounds = determineTotalRounds(participants.length);
+  const { participants: seededParticipants, pairings } = prepareRound(participants, 1, imagesById);
+  const { standings } = computeStandings(seededParticipants);
+  const awaitingAdvance = pairings.every((pair) => pair.resolved);
+  const status = awaitingAdvance
+    ? totalRounds <= 1
+      ? "awaiting-finish"
+      : "between-rounds"
+    : "in-progress";
+
+  return {
+    id: `swiss-${Date.now()}`,
+    createdAt: Date.now(),
+    status,
+    totalRounds,
+    currentRound: 1,
+    awaitingAdvance,
+    participants: seededParticipants,
+    rounds: [
+      {
+        index: 1,
+        pairings,
+        standings: awaitingAdvance ? standings : null,
+        completedAt: awaitingAdvance ? Date.now() : null,
+      },
+    ],
+    latestStandings: standings,
+    finalStandings: null,
+  };
+}
+
+
+function resolveDuelForImages(leftImage, rightImage, outcome, context = {}) {
+  if (!leftImage || !rightImage) {
+    return null;
+  }
+
+  const timestamp = Date.now();
+  const normalizedOutcome = outcome === "left" || outcome === "right" ? outcome : "draw";
+  const leftScore = normalizedOutcome === "left" ? 1 : normalizedOutcome === "right" ? 0 : 0.5;
+  const rightScore = normalizedOutcome === "left" ? 0 : normalizedOutcome === "right" ? 1 : 0.5;
+
+  const baseContext = {
+    mode: context.mode || "duel",
+    swissId: context.swissId || null,
+    round: context.round ?? null,
+    pairingId: context.pairingId || null,
+  };
+
+  const leftPeriods = computePeriodsElapsed(leftImage.lastPlayedAt, timestamp);
+  const rightPeriods = computePeriodsElapsed(rightImage.lastPlayedAt, timestamp);
+
+  const leftUpdate = updateGlickoPlayer(
+    leftImage,
+    [
+      {
+        rating: rightImage.rating,
+        rd: rightImage.rd,
+        score: leftScore,
+      },
+    ],
+    leftPeriods,
+  );
+
+  const rightUpdate = updateGlickoPlayer(
+    rightImage,
+    [
+      {
+        rating: leftImage.rating,
+        rd: leftImage.rd,
+        score: rightScore,
+      },
+    ],
+    rightPeriods,
+  );
+
+  const leftTierChange = resolveTierChange(leftImage.tierKey, leftUpdate.rating, leftUpdate.rd);
+  const rightTierChange = resolveTierChange(rightImage.tierKey, rightUpdate.rating, rightUpdate.rd);
+
+  const leftStats = updateImageStats(
+    leftImage,
+    leftScore,
+    { ...baseContext, opponentId: rightImage.id, newRd: leftUpdate.rd },
+    leftUpdate.rating,
+    timestamp,
+    leftTierChange,
+  );
+  const rightStats = updateImageStats(
+    rightImage,
+    rightScore,
+    { ...baseContext, opponentId: leftImage.id, newRd: rightUpdate.rd },
+    rightUpdate.rating,
+    timestamp,
+    rightTierChange,
+  );
+
+  const leftDelta = roundTo(leftUpdate.rating - leftImage.rating, 2);
+  const rightDelta = roundTo(rightUpdate.rating - rightImage.rating, 2);
+
+  const leftRecentEntry = {
+    opponentId: rightImage.id,
+    opponentName: rightImage.name,
+    result: leftScore === 1 ? "W" : leftScore === 0 ? "L" : "D",
+    delta: leftDelta,
+    timestamp,
+    mode: baseContext.mode,
+    swissId: baseContext.swissId,
+    round: baseContext.round,
+  };
+  const rightRecentEntry = {
+    opponentId: leftImage.id,
+    opponentName: leftImage.name,
+    result: rightScore === 1 ? "W" : rightScore === 0 ? "L" : "D",
+    delta: rightDelta,
+    timestamp,
+    mode: baseContext.mode,
+    swissId: baseContext.swissId,
+    round: baseContext.round,
+  };
+
+  const leftTierLog = leftTierChange.changed
+    ? [...(leftImage.tierLog || []), {
+        timestamp,
+        tier: leftTierChange.key,
+        direction: leftTierChange.direction,
+        rating: leftUpdate.rating,
+      }].slice(-10)
+    : [...(leftImage.tierLog || [])];
+  const rightTierLog = rightTierChange.changed
+    ? [...(rightImage.tierLog || []), {
+        timestamp,
+        tier: rightTierChange.key,
+        direction: rightTierChange.direction,
+        rating: rightUpdate.rating,
+      }].slice(-10)
+    : [...(rightImage.tierLog || [])];
+
+  const updatedLeft = {
+    ...leftImage,
+    rating: leftUpdate.rating,
+    rd: leftUpdate.rd,
+    volatility: leftUpdate.volatility,
+    tierKey: leftTierChange.key,
+    tierIndex: leftTierChange.index,
+    stats: leftStats,
+    updatedAt: timestamp,
+    lastPlayedAt: timestamp,
+    tierLog: leftTierLog,
+    recentMatches: [leftRecentEntry, ...(leftImage.recentMatches || [])].slice(0, RECENT_MATCHES_LIMIT),
+  };
+  const updatedRight = {
+    ...rightImage,
+    rating: rightUpdate.rating,
+    rd: rightUpdate.rd,
+    volatility: rightUpdate.volatility,
+    tierKey: rightTierChange.key,
+    tierIndex: rightTierChange.index,
+    stats: rightStats,
+    updatedAt: timestamp,
+    lastPlayedAt: timestamp,
+    tierLog: rightTierLog,
+    recentMatches: [rightRecentEntry, ...(rightImage.recentMatches || [])].slice(0, RECENT_MATCHES_LIMIT),
+  };
+
+  const winnerId = normalizedOutcome === "left" ? leftImage.id : normalizedOutcome === "right" ? rightImage.id : null;
+
+  const duelEntry = {
+    id: `duel-${timestamp}-${Math.random().toString(36).slice(2, 6)}`,
+    timestamp,
+    leftId: leftImage.id,
+    rightId: rightImage.id,
+    leftName: leftImage.name,
+    rightName: rightImage.name,
+    leftScore,
+    rightScore,
+    outcome: normalizedOutcome,
+    winnerId,
+    leftDelta,
+    rightDelta,
+    leftRatingAfter: leftUpdate.rating,
+    rightRatingAfter: rightUpdate.rating,
+    context: baseContext,
+    tierChanges: {
+      left: leftTierChange.changed ? leftTierChange.direction : null,
+      right: rightTierChange.changed ? rightTierChange.direction : null,
+    },
+  };
+
+  return {
+    timestamp,
+    outcome: normalizedOutcome,
+    winnerId,
+    leftOutcome: leftScore,
+    rightOutcome: rightScore,
+    left: {
+      image: updatedLeft,
+      deltaRating: leftDelta,
+      tierChange: leftTierChange.changed ? leftTierChange : null,
+    },
+    right: {
+      image: updatedRight,
+      deltaRating: rightDelta,
+      tierChange: rightTierChange.changed ? rightTierChange : null,
+    },
+    duelEntry,
+  };
+}
+
+function createSwissSummary(swiss, imagesById) {
+  if (!swiss) return null;
+
+  const standings = swiss.finalStandings || swiss.latestStandings || [];
+  const enriched = standings.map((entry) => {
+    const image = imagesById[entry.id];
+    return {
+      id: entry.id,
+      name: image?.name || entry.name,
+      rating: image?.rating ?? entry.currentRating ?? entry.seedRating ?? 1500,
+      tierKey: image?.tierKey || entry.tierKey || getTierByRating(entry.currentRating ?? 1500),
+      wins: entry.wins,
+      losses: entry.losses,
+      draws: entry.draws,
+      points: entry.points,
+      buchholz: entry.buchholz || 0,
+      rank: entry.rank,
+    };
+  });
+
+  return {
+    id: swiss.id,
+    createdAt: swiss.createdAt,
+    completedAt: swiss.completedAt || Date.now(),
+    totalRounds: swiss.totalRounds,
+    participants: enriched,
+  };
+}
+
+function buildRankingData(images, selectedTag) {
+  const global = images.slice().sort((a, b) => b.rating - a.rating);
+  const tagsSet = new Set();
+  global.forEach((image) => {
+    (image.tags || []).forEach((tag) => tagsSet.add(tag));
+  });
+
+  const tags = Array.from(tagsSet).sort((a, b) => a.localeCompare(b));
+  const filtered = selectedTag ? global.filter((image) => image.tags.includes(selectedTag)) : global;
+  const perTier = TIER_RULES.map((tier) => ({
+    tier,
+    images: global.filter((image) => image.tierKey === tier.key),
+  }));
+  const tagLeaders = tags.map((tag) => ({
+    tag,
+    leaders: global.filter((image) => image.tags.includes(tag)).slice(0, 5),
+  }));
+
+  return {
+    global,
+    filtered,
+    perTier,
+    tags,
+    tagLeaders,
+  };
+}
+
+function getPreviewStyle(image) {
+  if (!image) return {};
+  if (image.dataUrl) {
+    return {
+      backgroundImage: `linear-gradient(180deg, rgba(8, 12, 28, 0.2), rgba(8, 12, 28, 0.85)), url(${image.dataUrl})`,
+    };
+  }
+  if (image.imageUrl) {
+    return {
+      backgroundImage: `linear-gradient(180deg, rgba(8, 12, 28, 0.2), rgba(8, 12, 28, 0.85)), url(${image.imageUrl})`,
+    };
+  }
+  const tierColor = TIER_LOOKUP[image.tierKey]?.color || colorFromString(image.id);
+  return {
+    background: createTierGradient(tierColor),
+  };
+}
+
+function TierBadge({ tierKey }) {
+  const tier = TIER_LOOKUP[tierKey] || TIER_RULES[0];
   return (
-    <div className="tastet-shell">
-      <div className="tastet-frame">
-        <header className="tastet-header">
-          <div className="tastet-title-block">
-            <span className="tastet-badge">Semi-Formless · Layer 1 Prototype</span>
-            <h1>TasteT</h1>
-            <p>
-              A generous canvas for cultivating sensory-driven worlds. We begin by
-              mapping moods, textures, and rituals so the experience can bloom
-              deliberately.
-            </p>
-            <button type="button" className="tastet-primary-action">
-              Enter Studio
-            </button>
+    <span className="tier-badge" style={{ backgroundColor: tier.color }}>
+      {tier.label}
+    </span>
+  );
+}
+
+function DuelCard({
+  leftImage,
+  rightImage,
+  disabled = false,
+  expected = 0.5,
+  contextLabel,
+  onResolve,
+}) {
+  if (!leftImage || !rightImage) {
+    return null;
+  }
+
+  return (
+    <div className="duel-card">
+      {contextLabel ? <div className="duel-context">{contextLabel}</div> : null}
+      <div className="duel-combatants">
+        <button
+          type="button"
+          className="combatant"
+          onClick={() => onResolve("left")}
+          disabled={disabled}
+        >
+          <div className="combatant-art" style={getPreviewStyle(leftImage)} />
+          <div className="combatant-meta">
+            <TierBadge tierKey={leftImage.tierKey} />
+            <h3>{leftImage.name}</h3>
+            <p>{`Rating ${Math.round(leftImage.rating)} · RD ${Math.round(leftImage.rd)}`}</p>
+            <p className="combatant-tags">{leftImage.tags.slice(0, 3).join(" · ")}</p>
           </div>
-          <div className="tastet-flavor-panel">
-            <div className="tastet-flavor-wheel">
-              <span className="tastet-wheel-label">flavor<br />intention</span>
-            </div>
-            <ul className="tastet-flavor-legend">
-              <li>
-                <span className="tastet-legend-dot tastet-legend-dot--base" />
-                Base Notes
-              </li>
-              <li>
-                <span className="tastet-legend-dot tastet-legend-dot--accent" />
-                Accents
-              </li>
-              <li>
-                <span className="tastet-legend-dot tastet-legend-dot--spark" />
-                Spark
-              </li>
-            </ul>
-          </div>
-        </header>
-
-        <div className="tastet-layout">
-          <section className="tastet-panel tastet-roadmap">
-            <h2>Flavor Roadmap</h2>
-            <ol className="tastet-roadmap-list">
-              {roadmap.map((item) => (
-                <li key={item.stage}>
-                  <span className="tastet-roadmap-stage">{item.stage}</span>
-                  <div className="tastet-roadmap-content">
-                    <h3>{item.title}</h3>
-                    <p>{item.detail}</p>
-                  </div>
-                </li>
-              ))}
-            </ol>
-          </section>
-
-          <section className="tastet-panel tastet-moments">
-            <h2>Moments to Craft</h2>
-            <div className="tastet-moments-grid">
-              {tastingMoments.map((moment) => (
-                <article key={moment.label}>
-                  <h3>{moment.label}</h3>
-                  <p>{moment.description}</p>
-                </article>
-              ))}
-            </div>
-          </section>
-
-          <section className="tastet-panel tastet-experiments">
-            <h2>Experiment Bench</h2>
-            <div className="tastet-experiment-list">
-              {experimentIdeas.map((idea) => (
-                <div key={idea.title} className="tastet-experiment-card">
-                  <h3>{idea.title}</h3>
-                  <p>{idea.note}</p>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="tastet-panel tastet-journal">
-            <h2>Studio Notes</h2>
-            <p>
-              Leave space for sketches, tasting logs, and future collaborators.
-              We will weave them in as TasteT evolves.
-            </p>
-            <div className="tastet-note-placeholder">
-              <span>Tap to begin composing the first entry…</span>
-            </div>
-          </section>
+          <span className="combatant-callout">Win</span>
+        </button>
+        <div className="duel-actions">
+          <span className="expected-label">{`Expected ${Math.round(expected * 100)}%`}</span>
+          <button
+            type="button"
+            onClick={() => onResolve("draw")}
+            className="draw-button"
+            disabled={disabled}
+          >
+            Draw
+          </button>
         </div>
+        <button
+          type="button"
+          className="combatant"
+          onClick={() => onResolve("right")}
+          disabled={disabled}
+        >
+          <div className="combatant-art" style={getPreviewStyle(rightImage)} />
+          <div className="combatant-meta">
+            <TierBadge tierKey={rightImage.tierKey} />
+            <h3>{rightImage.name}</h3>
+            <p>{`Rating ${Math.round(rightImage.rating)} · RD ${Math.round(rightImage.rd)}`}</p>
+            <p className="combatant-tags">{rightImage.tags.slice(0, 3).join(" · ")}</p>
+          </div>
+          <span className="combatant-callout">Win</span>
+        </button>
       </div>
     </div>
   );
 }
+
+function SwissMiniPanel({
+  swiss,
+  imagesById,
+  onResolvePairing,
+  onAdvanceRound,
+  onFinish,
+  onCancel,
+}) {
+  if (!swiss) return null;
+
+  const currentRound = swiss.rounds.find((round) => round.index === swiss.currentRound);
+  const pendingPairing = currentRound?.pairings?.find((pair) => !pair.resolved && !pair.bye);
+  const standings = swiss.latestStandings || computeStandings(swiss.participants).standings;
+
+  const renderPairingStatus = (pair) => {
+    if (pair.bye) {
+      const byeImage = imagesById[pair.leftId];
+      return `${byeImage?.name || "Unknown"} receives a bye`;
+    }
+    const left = imagesById[pair.leftId];
+    const right = imagesById[pair.rightId];
+    const label = `${left?.name || "?"} vs ${right?.name || "?"}`;
+    if (!pair.resolved) {
+      return `${label} · pending`;
+    }
+    if (pair.outcome?.left === 0.5) {
+      return `${label} · draw`;
+    }
+    const winner = pair.winnerId === pair.leftId ? left?.name : right?.name;
+    return `${label} · ${winner || "winner"}`;
+  };
+
+  return (
+    <section className="taste-t-panel swiss-panel">
+      <header className="panel-header">
+        <div>
+          <h2>Swiss Mini · Round {swiss.currentRound}</h2>
+          <p className="panel-subtitle">
+            {`${standings.length} images · ${swiss.totalRounds} rounds · ${swiss.status}`}
+          </p>
+        </div>
+        <div className="panel-actions">
+          <button type="button" className="ghost" onClick={onCancel}>
+            Abandon
+          </button>
+          {swiss.awaitingAdvance && swiss.status === "between-rounds" ? (
+            <button type="button" onClick={onAdvanceRound}>
+              Start Round {swiss.currentRound + 1}
+            </button>
+          ) : null}
+          {swiss.awaitingAdvance && swiss.status === "awaiting-finish" ? (
+            <button type="button" onClick={onFinish}>
+              Finalize Mini
+            </button>
+          ) : null}
+        </div>
+      </header>
+      {pendingPairing ? (
+        <DuelCard
+          leftImage={imagesById[pendingPairing.leftId]}
+          rightImage={imagesById[pendingPairing.rightId]}
+          expected={pendingPairing.expected}
+          contextLabel={`Round ${swiss.currentRound}`}
+          onResolve={(result) => onResolvePairing(pendingPairing.id, result)}
+        />
+      ) : (
+        <div className="panel-placeholder">
+          {swiss.awaitingAdvance
+            ? "All pairings resolved. Continue when ready."
+            : "Awaiting next pairing..."}
+        </div>
+      )}
+      <div className="panel-body">
+        <div>
+          <h3>Round Pairings</h3>
+          <ul className="pairing-list">
+            {currentRound?.pairings?.map((pair) => (
+              <li key={pair.id}>{renderPairingStatus(pair)}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3>Standings</h3>
+          <table className="standings-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Name</th>
+                <th>Points</th>
+                <th>Record</th>
+                <th>Buchholz</th>
+              </tr>
+            </thead>
+            <tbody>
+              {standings.map((entry) => (
+                <tr key={entry.id}>
+                  <td>{entry.rank}</td>
+                  <td>
+                    <div className="standings-name">
+                      <TierBadge tierKey={entry.tierKey || imagesById[entry.id]?.tierKey} />
+                      <span>{imagesById[entry.id]?.name || entry.name}</span>
+                    </div>
+                  </td>
+                  <td>{entry.points}</td>
+                  <td>{formatRecord(entry.wins, entry.losses, entry.draws)}</td>
+                  <td>{roundTo(entry.buchholz, 1)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PlacementPanel({ queue, imagesById, onResolve, onCancel }) {
+  if (!queue) return null;
+
+  const image = imagesById[queue.imageId];
+  const opponentId = queue.opponents[queue.currentIndex];
+  const opponent = imagesById[opponentId];
+  const progress = queue.opponents.length
+    ? ((queue.currentIndex + (opponent ? 0 : 1)) / queue.opponents.length) * 100
+    : 100;
+
+  return (
+    <section className="taste-t-panel placement-panel">
+      <header className="panel-header">
+        <div>
+          <h2>Placement Duels</h2>
+          <p className="panel-subtitle">
+            {image ? image.name : "New image"} · {queue.currentIndex + 1} of {queue.opponents.length}
+          </p>
+        </div>
+        <div className="panel-actions">
+          <button type="button" className="ghost" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </header>
+      {image && opponent ? (
+        <DuelCard
+          leftImage={image}
+          rightImage={opponent}
+          expected={expectedScore(image.rating, opponent.rating)}
+          contextLabel="Placement"
+          onResolve={onResolve}
+        />
+      ) : (
+        <div className="panel-placeholder">Placement complete!</div>
+      )}
+      <div className="placement-progress">
+        <div className="placement-progress-bar" style={{ width: `${Math.min(progress, 100)}%` }} />
+      </div>
+      <ul className="placement-history">
+        {queue.history.map((entry) => {
+          const opp = imagesById[entry.opponentId];
+          return (
+            <li key={entry.id}>
+              <span>{opp?.name || "Opponent"}</span>
+              <span>{entry.outcome}</span>
+              <span>{formatDelta(entry.delta)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+
+function TasteT() {
+  const initialState = useMemo(() => loadInitialState(), []);
+  const [images, setImages] = useState(initialState.images);
+  const [duelLog, setDuelLog] = useState(initialState.duelLog);
+  const [swissHistory, setSwissHistory] = useState(initialState.swissHistory);
+  const [activeSwiss, setActiveSwiss] = useState(initialState.activeSwiss);
+  const [placementQueue, setPlacementQueue] = useState(initialState.placementQueue);
+  const [selectedTag, setSelectedTag] = useState(initialState.selectedTag);
+  const [miniSize, setMiniSize] = useState(initialState.miniSize || 8);
+  const [libraryEntries, setLibraryEntries] = useState(initialState.libraryEntries);
+  const [mode, setMode] = useState(() => {
+    if (initialState.activeSwiss) return "swiss";
+    if (initialState.placementQueue && initialState.placementQueueRestored) return "placement";
+    return "lobby";
+  });
+  const pendingPreviewRef = useRef(new Set());
+
+  const imagesById = useMemo(() => {
+    const map = {};
+    images.forEach((image) => {
+      map[image.id] = image;
+    });
+    return map;
+  }, [images]);
+
+  const rankingData = useMemo(() => buildRankingData(images, selectedTag), [images, selectedTag]);
+  const availableTags = rankingData.tags;
+  const hasImages = images.length > 0;
+  const canStartSwiss = hasImages && images.length >= 2;
+  const placementImage = placementQueue ? imagesById[placementQueue.imageId] : null;
+  const pendingPlacementRounds = placementQueue
+    ? Math.max(placementQueue.opponents.length - placementQueue.currentIndex, 0)
+    : 0;
+  const showPlacementCallout =
+    mode === "lobby" && placementQueue && placementImage && pendingPlacementRounds > 0;
+
+  const refreshLibrary = useCallback(() => {
+    if (typeof window === "undefined") return;
+    setLibraryEntries(loadLibraryCatalog());
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    let cancelled = false;
+    const pending = pendingPreviewRef.current;
+    const missing = images.filter((image) => !image.dataUrl && !pending.has(image.id));
+
+    missing.forEach((image) => {
+      pending.add(image.id);
+      loadImageData(image.id)
+        .then((dataUrl) => {
+          pending.delete(image.id);
+          if (!dataUrl || cancelled) return;
+          setImages((current) => {
+            const index = current.findIndex((img) => img.id === image.id);
+            if (index === -1) return current;
+            if (current[index].dataUrl === dataUrl) return current;
+            const next = current.slice();
+            next[index] = { ...current[index], dataUrl };
+            return next;
+          });
+        })
+        .catch(() => {
+          pending.delete(image.id);
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [images]);
+
+  useEffect(() => {
+    const result = synchronizeImagesWithLibrary(images, libraryEntries);
+    if (result.changed) {
+      setImages(result.images);
+    }
+    const effectiveImages = result.changed ? result.images : images;
+    const availableIds = new Set(effectiveImages.map((image) => image.id));
+
+    if (
+      result.newIds.length &&
+      (!placementQueue || !placementQueue.opponents.length || !availableIds.has(placementQueue.imageId))
+    ) {
+      const queue = buildPlacementQueueForImage(result.newIds[0], effectiveImages);
+      if (queue) {
+        setPlacementQueue(queue);
+      }
+    }
+  }, [libraryEntries]);
+
+  useEffect(() => {
+    if (!placementQueue) return;
+    const availableIds = new Set(images.map((image) => image.id));
+    if (!availableIds.has(placementQueue.imageId)) {
+      setPlacementQueue(null);
+      if (mode === "placement") {
+        setMode("lobby");
+      }
+      return;
+    }
+
+    const filteredOpponents = placementQueue.opponents.filter(
+      (id) => id !== placementQueue.imageId && availableIds.has(id),
+    );
+
+    if (!filteredOpponents.length) {
+      setPlacementQueue(null);
+      if (mode === "placement") {
+        setMode("lobby");
+      }
+      return;
+    }
+
+    if (
+      filteredOpponents.length !== placementQueue.opponents.length ||
+      placementQueue.currentIndex >= filteredOpponents.length
+    ) {
+      setPlacementQueue((current) => {
+        if (!current) return current;
+        const nextIndex = Math.min(current.currentIndex, filteredOpponents.length - 1);
+        return {
+          ...current,
+          opponents: filteredOpponents,
+          currentIndex: Math.max(0, nextIndex),
+        };
+      });
+    }
+  }, [images, placementQueue, mode]);
+
+  useEffect(() => {
+    if (!activeSwiss) return;
+    const availableIds = new Set(images.map((image) => image.id));
+    const missingParticipant = activeSwiss.participants.some(
+      (participant) => !availableIds.has(participant.id),
+    );
+    if (missingParticipant) {
+      setActiveSwiss(null);
+      if (mode === "swiss") {
+        setMode("lobby");
+      }
+    }
+  }, [images, activeSwiss, mode]);
+
+  useEffect(() => {
+    if (!selectedTag) return;
+    if (!availableTags.includes(selectedTag)) {
+      setSelectedTag("");
+    }
+  }, [availableTags, selectedTag]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const payload = {
+        images,
+        duelLog,
+        swissHistory,
+        activeSwiss,
+        placementQueue,
+        selectedTag,
+        miniSize,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch (error) {
+      console.warn("TierT: unable to persist state", error);
+    }
+  }, [images, duelLog, swissHistory, activeSwiss, placementQueue, selectedTag, miniSize]);
+
+  const applyResolution = useCallback(
+    (resolution) => {
+      if (!resolution) {
+        return;
+      }
+
+      setImages((current) => {
+        let changed = false;
+        const next = current.map((image) => {
+          if (image.id === resolution.left.image.id) {
+            changed = true;
+            return resolution.left.image;
+          }
+          if (image.id === resolution.right.image.id) {
+            changed = true;
+            return resolution.right.image;
+          }
+          return image;
+        });
+        return changed ? next : current;
+      });
+
+      setDuelLog((current) => [resolution.duelEntry, ...current].slice(0, LOG_LIMIT));
+    },
+    [setImages, setDuelLog],
+  );
+
+  const handleStartSwiss = useCallback(() => {
+    if (!canStartSwiss || mode !== "lobby") return;
+    const size = Math.min(miniSize, images.length);
+    const swiss = createSwissMini(images, size, imagesById);
+    if (!swiss) return;
+
+    const participantIds = new Set(swiss.participants.map((participant) => participant.id));
+    setImages((current) =>
+      current.map((image) => {
+        if (!participantIds.has(image.id)) return image;
+        const stats = {
+          ...image.stats,
+          minisEntered: (image.stats?.minisEntered || 0) + 1,
+          lastMode: "swiss",
+        };
+        return { ...image, stats };
+      }),
+    );
+
+    setActiveSwiss(swiss);
+    setMode("swiss");
+  }, [canStartSwiss, mode, miniSize, images, imagesById]);
+
+  const handleResolvePairing = useCallback(
+    (pairingId, outcome) => {
+      setActiveSwiss((current) => {
+        if (!current) return current;
+        const round = current.rounds.find((entry) => entry.index === current.currentRound);
+        if (!round) return current;
+        const pairing = round.pairings.find((pair) => pair.id === pairingId);
+        if (!pairing || pairing.bye || pairing.resolved) return current;
+
+        const leftImage = imagesById[pairing.leftId];
+        const rightImage = imagesById[pairing.rightId];
+        if (!leftImage || !rightImage) {
+          return current;
+        }
+
+        const resolution = resolveDuelForImages(leftImage, rightImage, outcome, {
+          mode: "swiss",
+          swissId: current.id,
+          round: current.currentRound,
+          pairingId,
+        });
+        applyResolution(resolution);
+        return updateSwissWithResult(current, pairingId, resolution);
+      });
+    },
+    [imagesById, applyResolution],
+  );
+
+  const handleAdvanceRound = useCallback(() => {
+    setActiveSwiss((current) => {
+      if (!current) return current;
+      if (!current.awaitingAdvance) return current;
+
+      const nextRoundNumber = current.currentRound + 1;
+      if (nextRoundNumber > current.totalRounds) {
+        return {
+          ...current,
+          status: "awaiting-finish",
+        };
+      }
+
+      const { participants: nextParticipants, pairings } = prepareRound(
+        current.participants,
+        nextRoundNumber,
+        imagesById,
+      );
+      const { standings } = computeStandings(nextParticipants);
+      const awaitingAdvance = pairings.every((pair) => pair.resolved);
+      const status = awaitingAdvance
+        ? nextRoundNumber >= current.totalRounds
+          ? "awaiting-finish"
+          : "between-rounds"
+        : "in-progress";
+
+      return {
+        ...current,
+        participants: nextParticipants,
+        rounds: [
+          ...current.rounds,
+          {
+            index: nextRoundNumber,
+            pairings,
+            standings: awaitingAdvance ? standings : null,
+            completedAt: awaitingAdvance ? Date.now() : null,
+          },
+        ],
+        currentRound: nextRoundNumber,
+        awaitingAdvance,
+        status,
+        latestStandings: standings,
+      };
+    });
+  }, [imagesById]);
+
+  const handleFinishSwiss = useCallback(() => {
+    let summary = null;
+    setActiveSwiss((current) => {
+      if (!current) return current;
+      const { standings } = computeStandings(current.participants);
+      const completed = {
+        ...current,
+        status: "completed",
+        completedAt: Date.now(),
+        finalStandings: standings,
+        latestStandings: standings,
+      };
+      summary = createSwissSummary(completed, imagesById);
+      return null;
+    });
+    if (summary) {
+      setSwissHistory((current) => [summary, ...current].slice(0, HISTORY_LIMIT));
+    }
+    setMode("lobby");
+  }, [imagesById]);
+
+  const handleCancelSwiss = useCallback(() => {
+    setActiveSwiss(null);
+    setMode("lobby");
+  }, []);
+
+  const handleEnterPlacement = useCallback(() => {
+    if (!placementQueue) return;
+    setMode("placement");
+  }, [placementQueue]);
+
+  const handleCancelPlacement = useCallback(() => {
+    setMode("lobby");
+  }, []);
+
+  const handleResolvePlacement = useCallback(
+    (outcome) => {
+      if (!placementQueue) return;
+
+      const queueImage = imagesById[placementQueue.imageId];
+      const opponentId = placementQueue.opponents[placementQueue.currentIndex];
+      const opponent = imagesById[opponentId];
+      let completed = false;
+      let historyEntry = null;
+
+      if (queueImage && opponent) {
+        const resolution = resolveDuelForImages(queueImage, opponent, outcome, {
+          mode: "placement",
+        });
+        applyResolution(resolution);
+        const delta =
+          resolution.left.image.id === queueImage.id
+            ? resolution.left.deltaRating
+            : resolution.right.deltaRating;
+        historyEntry = {
+          id: resolution.duelEntry.id,
+          opponentId,
+          outcome: outcome === "left" ? "Win" : outcome === "right" ? "Loss" : "Draw",
+          delta,
+        };
+      } else {
+        historyEntry = {
+          id: `placement-${Date.now()}`,
+          opponentId,
+          outcome: "Skipped",
+          delta: 0,
+        };
+      }
+
+      setPlacementQueue((current) => {
+        if (!current) return current;
+        const nextHistory = historyEntry ? [...current.history, historyEntry].slice(-10) : current.history;
+        const nextIndex = current.currentIndex + 1;
+        if (nextIndex >= current.opponents.length) {
+          completed = true;
+          return null;
+        }
+        return {
+          ...current,
+          currentIndex: nextIndex,
+          history: nextHistory,
+        };
+      });
+
+      if (completed) {
+        setMode("lobby");
+      }
+    },
+    [placementQueue, imagesById, applyResolution],
+  );
+
+  const hasActiveSwiss = mode === "swiss" && activeSwiss;
+  const hasPlacement = mode === "placement" && placementQueue;
+
+  return (
+    <div className="taste-t-app">
+      <div className="taste-t-frame">
+        {hasActiveSwiss ? (
+          <div className="taste-t-game">
+            <SwissMiniPanel
+              swiss={activeSwiss}
+              imagesById={imagesById}
+              onResolvePairing={handleResolvePairing}
+              onAdvanceRound={handleAdvanceRound}
+              onFinish={handleFinishSwiss}
+              onCancel={handleCancelSwiss}
+            />
+          </div>
+        ) : hasPlacement ? (
+          <div className="taste-t-game">
+            <PlacementPanel
+              queue={placementQueue}
+              imagesById={imagesById}
+              onResolve={handleResolvePlacement}
+              onCancel={handleCancelPlacement}
+            />
+          </div>
+        ) : (
+          <div className="taste-t-lobby">
+            <section className="taste-t-hero">
+              <div className="taste-t-hero-top">
+                <div>
+                  <h1>TierT</h1>
+                  <p>
+                    {hasImages
+                      ? "Queue a Swiss mini to keep refining your favourites."
+                      : "Add images in your Library to start ranking them."}
+                  </p>
+                </div>
+                <div className="taste-t-hero-actions">
+                  <label className="mini-size-control">
+                    <span>Mini size</span>
+                    <select value={miniSize} onChange={(event) => setMiniSize(Number(event.target.value))}>
+                      {MINI_SIZE_OPTIONS.map((size) => (
+                        <option key={size} value={size}>
+                          {size}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    className="taste-t-play-button"
+                    onClick={handleStartSwiss}
+                    disabled={!canStartSwiss || mode !== "lobby"}
+                  >
+                    Play
+                  </button>
+                  <button type="button" className="ghost" onClick={refreshLibrary}>
+                    Refresh Library
+                  </button>
+                </div>
+              </div>
+              <div className="taste-t-hero-stats">
+                <div className="taste-t-stat-card">
+                  <span className="stat-label">Library images</span>
+                  <strong>{images.length}</strong>
+                  <p>{hasImages ? "Ready to rank" : "Visit the Library to add images."}</p>
+                </div>
+                <div className="taste-t-stat-card">
+                  <span className="stat-label">Placements</span>
+                  <strong>{pendingPlacementRounds}</strong>
+                  <p>{placementQueue ? "Duels to settle your newest image." : "All images are placed."}</p>
+                </div>
+                <div className="taste-t-stat-card">
+                  <span className="stat-label">Recent duels</span>
+                  <strong>{duelLog.length}</strong>
+                  <p>{duelLog.length ? "Tracked below in your duel log." : "Play a mini to build history."}</p>
+                </div>
+              </div>
+              {!canStartSwiss ? (
+                <p className="taste-t-hero-note">Add at least two images to start a Swiss mini.</p>
+              ) : null}
+            </section>
+
+            {showPlacementCallout ? (
+              <section className="taste-t-panel taste-t-placement-callout">
+                <div>
+                  <h2>Placement ready</h2>
+                  <p>
+                    {placementImage ? placementImage.name : "New image"} has {pendingPlacementRounds} duels remaining.
+                  </p>
+                </div>
+                <div className="panel-actions">
+                  <button type="button" onClick={handleEnterPlacement}>
+                    Start placement
+                  </button>
+                </div>
+              </section>
+            ) : null}
+
+            <div className="taste-t-lobby-grid">
+              <section className="taste-t-panel">
+                <header className="panel-header">
+                  <div>
+                    <h2>Global Order</h2>
+                    <p className="panel-subtitle">
+                      {selectedTag
+                        ? `Filtering by ${selectedTag}`
+                        : hasImages
+                        ? "All images"
+                        : "No images available"}
+                    </p>
+                  </div>
+                  <div className="panel-actions">
+                    <select value={selectedTag} onChange={(event) => setSelectedTag(event.target.value)}>
+                      <option value="">All tags</option>
+                      {availableTags.map((tag) => (
+                        <option key={tag} value={tag}>
+                          {tag}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </header>
+                {rankingData.filtered.length ? (
+                  <ol className="ranking-list">
+                    {rankingData.filtered.slice(0, 12).map((image, index) => (
+                      <li key={image.id}>
+                        <span className="rank-index">#{index + 1}</span>
+                        <div className="ranking-meta">
+                          <h3>{image.name}</h3>
+                          <p>
+                            {`Rating ${Math.round(image.rating)} · RD ${Math.round(image.rd)} · ${formatRecord(
+                              image.stats?.wins,
+                              image.stats?.losses,
+                              image.stats?.draws,
+                            )}`}
+                          </p>
+                          <p className="ranking-tags">
+                            #{image.tierKey} · {image.tags.slice(0, 3).join(" · ")}
+                          </p>
+                        </div>
+                        <span className="rank-rating">{Math.round(image.rating)}</span>
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <div className="panel-placeholder">
+                    {hasImages
+                      ? "No rankings match the selected tag."
+                      : "Add images in your Library to begin ranking."}
+                  </div>
+                )}
+              </section>
+
+              <section className="taste-t-panel">
+                <h2>Tier Snapshots</h2>
+                <div className="tier-grid">
+                  {rankingData.perTier.map(({ tier, images: tierImages }) => (
+                    <div key={tier.key} className="tier-card">
+                      <header style={{ borderColor: tier.color }}>
+                        <h3>{tier.label}</h3>
+                        <p>{tier.tagline}</p>
+                      </header>
+                      <ol>
+                        {tierImages.slice(0, 5).map((image) => (
+                          <li key={image.id}>
+                            <span>{image.name}</span>
+                            <span>{Math.round(image.rating)}</span>
+                          </li>
+                        ))}
+                        {!tierImages.length ? <li className="empty">No images yet</li> : null}
+                      </ol>
+                    </div>
+                  ))}
+                </div>
+              </section>
+
+              <section className="taste-t-panel">
+                <h2>Recent Duels</h2>
+                {duelLog.length ? (
+                  <ul className="duel-log">
+                    {duelLog.map((entry) => (
+                      <li key={entry.id}>
+                        <span className="duel-log-names">
+                          {entry.leftName} vs {entry.rightName}
+                        </span>
+                        <span className="duel-log-outcome">
+                          {entry.outcome === "draw"
+                            ? "Draw"
+                            : `${entry.winnerId === entry.leftId ? entry.leftName : entry.rightName} won`}
+                        </span>
+                        <span className="duel-log-delta">
+                          {formatDelta(entry.leftDelta)} / {formatDelta(entry.rightDelta)}
+                        </span>
+                        <span className="duel-log-time">{formatRelativeTime(entry.timestamp)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="panel-placeholder">Play duels to populate your log.</div>
+                )}
+              </section>
+
+              <section className="taste-t-panel">
+                <h2>Swiss History</h2>
+                {swissHistory.length ? (
+                  <ul className="swiss-history">
+                    {swissHistory.map((entry) => (
+                      <li key={entry.id}>
+                        <div>
+                          <strong>{entry.id}</strong>
+                          <span>
+                            {entry.participants[0]?.name || "Swiss"} · {entry.totalRounds} rounds · {entry.participants.length} images
+                          </span>
+                        </div>
+                        <div>Winner: {entry.participants.find((p) => p.rank === 1)?.name || ""}</div>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="panel-placeholder">Finish a Swiss mini to see it logged here.</div>
+                )}
+              </section>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+
+export default TasteT;

--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -1,415 +1,588 @@
-.tastet-shell {
+.taste-t-app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
   width: 100%;
-  display: flex;
-  justify-content: center;
-  padding: 64px 32px 96px;
+  padding: clamp(24px, 5vw, 48px) clamp(20px, 6vw, 72px);
+  color: #f7f8ff;
+  background: radial-gradient(circle at top, #1d2240 0%, #101324 55%, #080914 100%);
   box-sizing: border-box;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
-.tastet-frame {
-  position: relative;
-  width: min(1200px, 100%);
-  min-height: 70vh;
-  padding: 48px;
-  border-radius: 32px;
-  color: #fdf9f6;
-  background: linear-gradient(160deg, rgba(28, 13, 48, 0.94), rgba(16, 58, 80, 0.88));
-  overflow: hidden;
-  box-shadow: 0 48px 120px rgba(0, 0, 0, 0.48);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(16px);
-}
-
-.tastet-frame::before {
-  content: "";
-  position: absolute;
-  inset: 12px;
-  border-radius: 28px;
-  background: linear-gradient(125deg, rgba(255, 199, 125, 0.1), rgba(120, 213, 255, 0.08));
-  z-index: 0;
-  pointer-events: none;
-}
-
-.tastet-frame > * {
-  position: relative;
-  z-index: 1;
-}
-
-.tastet-header {
-  display: flex;
-  align-items: stretch;
-  gap: 40px;
-}
-
-.tastet-title-block {
-  flex: 1.2;
+.taste-t-frame {
+  flex: 1 0 auto;
+  width: min(1240px, 100%);
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  max-width: 520px;
-}
-
-.tastet-title-block h1 {
-  font-size: clamp(3rem, 6vw, 4.5rem);
-  margin: 0;
-  letter-spacing: 0.05em;
-}
-
-.tastet-title-block p {
-  margin: 0;
-  line-height: 1.7;
-  font-size: 1.05rem;
-  color: rgba(255, 255, 255, 0.82);
-}
-
-.tastet-badge {
-  align-self: flex-start;
-  padding: 8px 16px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.15);
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.2em;
-}
-
-.tastet-primary-action {
-  align-self: flex-start;
-  padding: 14px 28px;
-  border-radius: 18px;
-  border: none;
-  font-weight: 600;
-  font-size: 1rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #1b1b27;
-  background: linear-gradient(120deg, #f8d678, #fcb195);
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 18px 40px rgba(255, 215, 160, 0.35);
-}
-
-.tastet-primary-action:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 24px 44px rgba(255, 215, 160, 0.45);
-}
-
-.tastet-primary-action:active {
-  transform: translateY(0);
-}
-
-.tastet-flavor-panel {
-  flex: 1;
-  padding: 32px;
-  border-radius: 28px;
-  background: linear-gradient(145deg, rgba(11, 79, 96, 0.55), rgba(105, 64, 132, 0.4));
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 24px;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
-}
-
-.tastet-flavor-wheel {
-  width: min(240px, 80%);
-  aspect-ratio: 1 / 1;
-  border-radius: 48px;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 214, 186, 0.85), rgba(255, 142, 105, 0.4) 45%, rgba(64, 118, 207, 0.45) 70%, rgba(15, 23, 45, 0.9) 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  overflow: hidden;
-}
-
-.tastet-flavor-wheel::before,
-.tastet-flavor-wheel::after {
-  content: "";
-  position: absolute;
-  border-radius: 999px;
-  pointer-events: none;
-}
-
-.tastet-flavor-wheel::before {
-  inset: 12%;
-  border: 2px solid rgba(255, 255, 255, 0.35);
-}
-
-.tastet-flavor-wheel::after {
-  inset: 32%;
-  border: 1px dashed rgba(255, 255, 255, 0.25);
-}
-
-.tastet-wheel-label {
-  text-transform: uppercase;
-  letter-spacing: 0.4em;
-  font-size: 0.75rem;
-  text-align: center;
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.tastet-flavor-legend {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.8);
-}
-
-.tastet-flavor-legend li {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.tastet-legend-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  display: inline-flex;
-}
-
-.tastet-legend-dot--base {
-  background: linear-gradient(120deg, #ffd6ba, #fcb195);
-}
-
-.tastet-legend-dot--accent {
-  background: linear-gradient(120deg, #9ad0f5, #6fb3ff);
-}
-
-.tastet-legend-dot--spark {
-  background: linear-gradient(120deg, #f7e476, #f8b661);
-}
-
-.tastet-layout {
-  display: grid;
-  grid-template-columns: minmax(360px, 1.7fr) minmax(280px, 1fr);
-  grid-auto-rows: minmax(220px, auto);
-  grid-auto-flow: dense;
   gap: 32px;
 }
 
-.tastet-panel {
-  position: relative;
-  padding: 28px;
-  border-radius: 26px;
-  background: linear-gradient(150deg, rgba(13, 20, 35, 0.7), rgba(255, 255, 255, 0.06));
+.taste-t-lobby {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+}
+
+.taste-t-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: clamp(20px, 4vw, 32px);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(86, 102, 236, 0.35), rgba(43, 173, 224, 0.18));
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.36);
+  box-shadow: 0 18px 64px rgba(6, 7, 19, 0.45);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.taste-t-hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(2.2rem, 3vw, 3rem);
+  letter-spacing: 0.04em;
+}
+
+.taste-t-hero p {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(238, 241, 255, 0.82);
+}
+
+.taste-t-hero-top {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.taste-t-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.mini-size-control {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  gap: 4px;
+  color: rgba(238, 241, 255, 0.75);
+}
+
+.mini-size-control select,
+.panel-actions select {
+  background: rgba(12, 16, 32, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  padding: 8px 12px;
+  color: #f7f8ff;
+  font-size: 0.95rem;
+}
+
+.taste-t-play-button {
+  padding: 12px 28px;
+  font-size: 1.05rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+}
+
+.taste-t-hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.taste-t-stat-card {
+  flex: 1 1 220px;
+  background: rgba(12, 16, 32, 0.55);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.taste-t-stat-card .stat-label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  color: rgba(238, 241, 255, 0.6);
+}
+
+.taste-t-stat-card strong {
+  font-size: 1.6rem;
+  letter-spacing: 0.05em;
+}
+
+.taste-t-stat-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(238, 241, 255, 0.72);
+}
+
+.taste-t-hero-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 186, 107, 0.9);
+}
+
+.taste-t-lobby-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  width: 100%;
+}
+
+.taste-t-game {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: min(960px, 100%);
+  margin: 0 auto;
+}
+
+.taste-t-placement-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: rgba(18, 24, 48, 0.78);
+}
+
+.taste-t-placement-callout h2 {
+  margin: 0 0 4px;
+}
+
+.taste-t-placement-callout p {
+  margin: 0;
+  color: rgba(238, 241, 255, 0.75);
+}
+
+button {
+  font: inherit;
+  border: none;
+  border-radius: 14px;
+  padding: 10px 18px;
+  background: linear-gradient(120deg, #ffba6b, #ff6e8f);
+  color: #0c0f1a;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(255, 144, 171, 0.35);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+button.ghost {
+  background: transparent;
+  color: rgba(238, 241, 255, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+.taste-t-panel {
+  background: rgba(12, 16, 32, 0.72);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 18px;
+  box-shadow: 0 12px 48px rgba(4, 6, 15, 0.6);
+  width: 100%;
+  box-sizing: border-box;
 }
 
-.tastet-panel h2 {
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.panel-header h2 {
   margin: 0;
-  font-size: 1.35rem;
-  letter-spacing: 0.08em;
+  font-size: 1.4rem;
+  letter-spacing: 0.03em;
+}
+
+.panel-subtitle {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: rgba(238, 241, 255, 0.65);
+}
+
+.panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.panel-placeholder {
+  padding: 24px;
+  border-radius: 18px;
+  background: rgba(29, 34, 64, 0.6);
+  text-align: center;
+  color: rgba(238, 241, 255, 0.7);
+}
+
+.tier-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #0c0f1a;
+  background-color: rgba(255, 255, 255, 0.75);
+}
+
+.duel-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: rgba(20, 24, 48, 0.75);
+  border-radius: 22px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.duel-context {
+  font-size: 0.85rem;
+  color: rgba(238, 241, 255, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.duel-combatants {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) 110px;
+  gap: 16px;
+  align-items: stretch;
+}
+
+.combatant {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0;
+  border-radius: 18px;
+  overflow: hidden;
+  background: rgba(8, 11, 25, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.combatant .combatant-callout {
+  align-self: stretch;
+  text-align: center;
+  padding: 10px 0;
+  background: linear-gradient(135deg, rgba(255, 205, 118, 0.8), rgba(255, 118, 159, 0.6));
+  color: #0c0f1a;
+  font-weight: 700;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
-.tastet-panel p {
+.combatant:disabled {
+  opacity: 0.45;
+}
+
+.combatant-art {
+  height: 160px;
+  background-size: cover;
+  background-position: center;
+}
+
+.combatant-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 16px 0;
+  text-align: left;
+}
+
+.combatant-meta h3 {
   margin: 0;
-  color: rgba(235, 239, 255, 0.8);
-  line-height: 1.6;
+  font-size: 1.2rem;
+  letter-spacing: 0.03em;
 }
 
-.tastet-roadmap {
-  grid-row: span 2;
-  padding-bottom: 36px;
+.combatant-meta p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(238, 241, 255, 0.7);
 }
 
-.tastet-roadmap-list {
+.combatant-tags {
+  color: rgba(238, 241, 255, 0.55);
+}
+
+.duel-actions {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.expected-label {
+  font-size: 0.75rem;
+  color: rgba(238, 241, 255, 0.65);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.draw-button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(238, 241, 255, 0.85);
+  padding: 10px 14px;
+}
+
+.panel-body {
+  display: grid;
+  gap: 16px;
+}
+
+.pairing-list {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: rgba(238, 241, 255, 0.75);
 }
 
-.tastet-roadmap-list li {
-  display: grid;
-  grid-template-columns: 92px 1fr;
-  gap: 16px;
-  padding: 20px;
-  border-radius: 20px;
-  background: rgba(7, 12, 21, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  position: relative;
+.standings-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.standings-table th,
+.standings-table td {
+  padding: 6px 8px;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.standings-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.placement-panel .duel-card {
+  background: rgba(29, 36, 68, 0.72);
+}
+
+.placement-progress {
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
   overflow: hidden;
 }
 
-.tastet-roadmap-list li::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, rgba(255, 214, 186, 0.12), rgba(124, 200, 255, 0.1));
-  opacity: 0;
-  transition: opacity 0.3s ease;
+.placement-progress-bar {
+  height: 100%;
+  background: linear-gradient(120deg, #5c73ff, #53d1ff);
 }
 
-.tastet-roadmap-list li:hover::after {
-  opacity: 1;
-}
-
-.tastet-roadmap-stage {
-  align-self: center;
-  justify-self: center;
-  padding: 8px 14px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.28);
+.placement-history {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   font-size: 0.85rem;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  background: rgba(255, 255, 255, 0.07);
-  z-index: 1;
 }
 
-.tastet-roadmap-content h3 {
-  margin: 0 0 8px;
-  font-size: 1.2rem;
+.placement-history li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: rgba(238, 241, 255, 0.75);
 }
 
-.tastet-moments-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 16px;
-}
-
-.tastet-moments-grid article {
-  padding: 18px;
-  border-radius: 20px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02));
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  min-height: 130px;
+.ranking-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.tastet-moments-grid h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.tastet-experiment-list {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.tastet-experiment-card {
-  padding: 18px 20px;
-  border-radius: 18px;
-  background: rgba(6, 13, 26, 0.62);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.tastet-experiment-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 22px 36px rgba(0, 0, 0, 0.4);
-}
-
-.tastet-experiment-card h3 {
-  margin: 0 0 8px;
-  font-size: 1.1rem;
-}
-
-.tastet-experiment-card p {
-  font-size: 0.95rem;
-}
-
-.tastet-journal {
-  grid-column: 1 / -1;
-}
-
-.tastet-note-placeholder {
+.ranking-list li {
   display: flex;
   align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(18, 21, 38, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.rank-index {
+  font-size: 1.1rem;
+  color: rgba(238, 241, 255, 0.7);
+  width: 40px;
+}
+
+.ranking-meta h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.ranking-meta p {
+  margin: 2px 0;
+  font-size: 0.85rem;
+  color: rgba(238, 241, 255, 0.65);
+}
+
+.ranking-tags {
+  color: rgba(238, 241, 255, 0.55);
+}
+
+.rank-rating {
+  margin-left: auto;
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.tier-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.tier-card {
+  background: rgba(16, 20, 38, 0.75);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.tier-card header {
+  padding: 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.tier-card header h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.tier-card header p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(238, 241, 255, 0.6);
+}
+
+.tier-card ol {
+  list-style: none;
+  margin: 0;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.tier-card li {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(238, 241, 255, 0.75);
+}
+
+.tier-card li.empty {
   justify-content: center;
-  min-height: 160px;
-  margin-top: auto;
-  border-radius: 18px;
-  border: 2px dashed rgba(255, 255, 255, 0.25);
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  color: rgba(238, 241, 255, 0.5);
 }
 
-@media (max-width: 1100px) {
-  .tastet-shell {
-    padding: 48px 24px 80px;
+.duel-log,
+.swiss-history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 0.85rem;
+}
+
+.duel-log li,
+.swiss-history li {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(15, 18, 34, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.duel-log-names {
+  font-weight: 600;
+}
+
+.duel-log-outcome {
+  color: rgba(255, 192, 147, 0.9);
+}
+
+.duel-log-delta {
+  color: rgba(150, 215, 255, 0.85);
+}
+
+.duel-log-time {
+  text-align: right;
+  color: rgba(238, 241, 255, 0.55);
+}
+
+.swiss-history li.empty {
+  justify-content: center;
+  text-align: center;
+  color: rgba(238, 241, 255, 0.55);
+}
+
+@media (max-width: 960px) {
+  .duel-combatants {
+    grid-template-columns: 1fr;
   }
 
-  .tastet-frame {
-    padding: 36px;
+  .duel-actions {
+    flex-direction: row;
   }
 
-  .tastet-header {
+  .taste-t-hero {
+    padding: 24px 20px;
+  }
+
+  .taste-t-hero-actions {
     flex-direction: column;
-    align-items: center;
-  }
-
-  .tastet-title-block {
-    max-width: 100%;
-    text-align: center;
-    align-items: center;
-  }
-
-  .tastet-title-block p {
-    max-width: 680px;
-  }
-
-  .tastet-title-block .tastet-badge,
-  .tastet-primary-action {
-    align-self: center;
-  }
-
-  .tastet-flavor-panel {
-    width: 100%;
-  }
-
-  .tastet-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .tastet-roadmap {
-    grid-row: auto;
-  }
-
-  .tastet-journal {
-    grid-column: auto;
-  }
-}
-
-@media (max-width: 640px) {
-  .tastet-shell {
-    padding: 32px 16px 64px;
-  }
-
-  .tastet-frame {
-    padding: 28px 20px;
-    border-radius: 24px;
-  }
-
-  .tastet-panel {
-    padding: 22px;
-  }
-
-  .tastet-roadmap-list li {
-    grid-template-columns: 1fr;
-  }
-
-  .tastet-roadmap-stage {
-    justify-self: flex-start;
+    align-items: flex-start;
   }
 }

--- a/src/world.css
+++ b/src/world.css
@@ -262,6 +262,9 @@
 }
 
 .world-tastet-container {
-  overflow: visible;
+  overflow-x: hidden;
+  overflow-y: auto;
   align-items: stretch;
+  justify-content: flex-start;
+  padding: 0;
 }


### PR DESCRIPTION
## Summary
- rebuild the TierT state handling so Swiss minis, placement duels, and persistence work directly with the Library images
- add placement history logging and duel resolution updates that advance queues, tournaments, and rankings cleanly
- stretch the TierT lobby/game layout to a full-width frame with responsive spacing so nothing is hidden off-screen

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d402274de48322bbeb896ccbed8589