### PR TITLE
Expand TasteT layout to fill available width

### DIFF
--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -13,8 +13,8 @@
 
 .taste-t-frame {
   flex: 1 0 auto;
-  width: min(1240px, 100%);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   display: flex;
   flex-direction: column;
   gap: 32px;
@@ -143,8 +143,7 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
-  width: min(960px, 100%);
-  margin: 0 auto;
+  width: 100%;
 }
 
 .taste-t-placement-callout {

--- a/src/world.css
+++ b/src/world.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   align-items: center;
   overflow: hidden;
+  width: 100%;
 }
 
 .resource-box {
@@ -267,4 +268,15 @@
   align-items: stretch;
   justify-content: flex-start;
   padding: 0;
+  width: 100%;
+}
+
+.world-tastet-container .taste-t-app {
+  flex: 1 1 auto;
+  align-self: stretch;
+  width: 100%;
+}
+
+.world-tastet-container .taste-t-frame {
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- stretch the world container and embedded TasteT wrapper to occupy the full content width
- allow the TasteT frame and game panels to grow across the available viewport instead of staying centered at a fixed width

## Testing
- npm test -- --runTestsByPath src/TasteT.test.js
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d45c98d02483229ed0a53cd8284a11