### PR TITLE
Refocus TasteT duel view and add image lightbox

### DIFF
--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -1546,6 +1546,7 @@ function DuelCard({
   expected = 0.5,
   contextLabel,
   onResolve,
+  onViewImage,
 }) {
   if (!leftImage || !rightImage) {
     return null;
@@ -1572,6 +1573,24 @@ function DuelCard({
         </button>
         <div className="duel-actions">
           <span className="expected-label">{`Expected ${Math.round(expected * 100)}%`}</span>
+          <div className="view-buttons">
+            <button
+              type="button"
+              className="ghost view-button"
+              onClick={() => onViewImage?.(leftImage)}
+              disabled={disabled}
+            >
+              View Left
+            </button>
+            <button
+              type="button"
+              className="ghost view-button"
+              onClick={() => onViewImage?.(rightImage)}
+              disabled={disabled}
+            >
+              View Right
+            </button>
+          </div>
           <button
             type="button"
             onClick={() => onResolve("draw")}
@@ -1608,12 +1627,14 @@ function SwissMiniPanel({
   onAdvanceRound,
   onFinish,
   onCancel,
+  onViewImage,
 }) {
   if (!swiss) return null;
 
   const currentRound = swiss.rounds.find((round) => round.index === swiss.currentRound);
   const pendingPairing = currentRound?.pairings?.find((pair) => !pair.resolved && !pair.bye);
   const standings = swiss.latestStandings || computeStandings(swiss.participants).standings;
+  const showSummary = swiss.status === "awaiting-finish" || swiss.status === "completed";
 
   const renderPairingStatus = (pair) => {
     if (pair.bye) {
@@ -1665,6 +1686,7 @@ function SwissMiniPanel({
           expected={pendingPairing.expected}
           contextLabel={`Round ${swiss.currentRound}`}
           onResolve={(result) => onResolvePairing(pendingPairing.id, result)}
+          onViewImage={onViewImage}
         />
       ) : (
         <div className="panel-placeholder">
@@ -1673,51 +1695,53 @@ function SwissMiniPanel({
             : "Awaiting next pairing..."}
         </div>
       )}
-      <div className="panel-body">
-        <div>
-          <h3>Round Pairings</h3>
-          <ul className="pairing-list">
-            {currentRound?.pairings?.map((pair) => (
-              <li key={pair.id}>{renderPairingStatus(pair)}</li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h3>Standings</h3>
-          <table className="standings-table">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Name</th>
-                <th>Points</th>
-                <th>Record</th>
-                <th>Buchholz</th>
-              </tr>
-            </thead>
-            <tbody>
-              {standings.map((entry) => (
-                <tr key={entry.id}>
-                  <td>{entry.rank}</td>
-                  <td>
-                    <div className="standings-name">
-                      <TierBadge tierKey={entry.tierKey || imagesById[entry.id]?.tierKey} />
-                      <span>{imagesById[entry.id]?.name || entry.name}</span>
-                    </div>
-                  </td>
-                  <td>{entry.points}</td>
-                  <td>{formatRecord(entry.wins, entry.losses, entry.draws)}</td>
-                  <td>{roundTo(entry.buchholz, 1)}</td>
+      {showSummary ? (
+        <div className="panel-body final-standings">
+          <div>
+            <h3>Final Standings</h3>
+            <table className="standings-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Name</th>
+                  <th>Points</th>
+                  <th>Record</th>
+                  <th>Buchholz</th>
                 </tr>
+              </thead>
+              <tbody>
+                {standings.map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{entry.rank}</td>
+                    <td>
+                      <div className="standings-name">
+                        <TierBadge tierKey={entry.tierKey || imagesById[entry.id]?.tierKey} />
+                        <span>{imagesById[entry.id]?.name || entry.name}</span>
+                      </div>
+                    </td>
+                    <td>{entry.points}</td>
+                    <td>{formatRecord(entry.wins, entry.losses, entry.draws)}</td>
+                    <td>{roundTo(entry.buchholz, 1)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <h3>Latest Round</h3>
+            <ul className="pairing-list">
+              {currentRound?.pairings?.map((pair) => (
+                <li key={pair.id}>{renderPairingStatus(pair)}</li>
               ))}
-            </tbody>
-          </table>
+            </ul>
+          </div>
         </div>
-      </div>
+      ) : null}
     </section>
   );
 }
 
-function PlacementPanel({ queue, imagesById, onResolve, onCancel }) {
+function PlacementPanel({ queue, imagesById, onResolve, onCancel, onViewImage }) {
   if (!queue) return null;
 
   const image = imagesById[queue.imageId];
@@ -1749,6 +1773,7 @@ function PlacementPanel({ queue, imagesById, onResolve, onCancel }) {
           expected={expectedScore(image.rating, opponent.rating)}
           contextLabel="Placement"
           onResolve={onResolve}
+          onViewImage={onViewImage}
         />
       ) : (
         <div className="panel-placeholder">Placement complete!</div>
@@ -1789,6 +1814,7 @@ function TasteT() {
     return "lobby";
   });
   const pendingPreviewRef = useRef(new Set());
+  const [expandedImage, setExpandedImage] = useState(null);
 
   const imagesById = useMemo(() => {
     const map = {};
@@ -1808,6 +1834,29 @@ function TasteT() {
     : 0;
   const showPlacementCallout =
     mode === "lobby" && placementQueue && placementImage && pendingPlacementRounds > 0;
+  const isPlaying = mode === "swiss" || mode === "placement";
+
+  const handleViewImage = useCallback((image) => {
+    if (!image) return;
+    setExpandedImage(image);
+  }, []);
+
+  const handleCloseExpanded = useCallback(() => {
+    setExpandedImage(null);
+  }, []);
+
+  useEffect(() => {
+    if (!expandedImage || typeof window === "undefined") return undefined;
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        setExpandedImage(null);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expandedImage]);
 
   const refreshLibrary = useCallback(() => {
     if (typeof window === "undefined") return;
@@ -2160,8 +2209,10 @@ function TasteT() {
   const hasActiveSwiss = mode === "swiss" && activeSwiss;
   const hasPlacement = mode === "placement" && placementQueue;
 
+  const expandedImageSrc = expandedImage?.dataUrl || expandedImage?.imageUrl;
+
   return (
-    <div className="taste-t-app">
+    <div className={`taste-t-app${isPlaying ? " is-playing" : ""}`}>
       <div className="taste-t-frame">
         {hasActiveSwiss ? (
           <div className="taste-t-game">
@@ -2172,6 +2223,7 @@ function TasteT() {
               onAdvanceRound={handleAdvanceRound}
               onFinish={handleFinishSwiss}
               onCancel={handleCancelSwiss}
+              onViewImage={handleViewImage}
             />
           </div>
         ) : hasPlacement ? (
@@ -2181,6 +2233,7 @@ function TasteT() {
               imagesById={imagesById}
               onResolve={handleResolvePlacement}
               onCancel={handleCancelPlacement}
+              onViewImage={handleViewImage}
             />
           </div>
         ) : (
@@ -2385,6 +2438,23 @@ function TasteT() {
           </div>
         )}
       </div>
+      {expandedImageSrc ? (
+        <div className="taste-t-lightbox" role="dialog" aria-modal="true">
+          <div className="lightbox-backdrop" onClick={handleCloseExpanded} />
+          <div className="lightbox-content" role="document">
+            <button type="button" className="ghost lightbox-close" onClick={handleCloseExpanded}>
+              Close
+            </button>
+            <figure className="lightbox-figure">
+              <img src={expandedImageSrc} alt={expandedImage?.name || "Selected image"} />
+              <figcaption>
+                <strong>{expandedImage?.name}</strong>
+                <span>#{expandedImage?.tierKey}</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -11,6 +11,54 @@
   overflow-x: hidden;
 }
 
+.taste-t-app.is-playing {
+  padding: clamp(16px, 4vw, 32px);
+}
+
+.taste-t-app.is-playing .taste-t-frame {
+  align-items: center;
+}
+
+.taste-t-app.is-playing .taste-t-game {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+}
+
+.taste-t-app.is-playing .taste-t-panel {
+  padding: clamp(24px, 4vw, 44px);
+  min-height: clamp(420px, 70vh, 720px);
+}
+
+.taste-t-app.is-playing .duel-card {
+  padding: clamp(24px, 4vw, 48px);
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.taste-t-app.is-playing .duel-context {
+  font-size: clamp(0.85rem, 1.6vw, 1rem);
+}
+
+.taste-t-app.is-playing .duel-combatants {
+  grid-template-columns: minmax(0, 1fr) minmax(150px, 18vw) minmax(0, 1fr);
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.taste-t-app.is-playing .combatant-art {
+  height: clamp(320px, 60vh, 520px);
+}
+
+.taste-t-app.is-playing .combatant-meta h3 {
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+}
+
+.taste-t-app.is-playing .combatant-meta p {
+  font-size: clamp(0.9rem, 1.6vw, 1.05rem);
+}
+
+.taste-t-app.is-playing .duel-actions {
+  gap: clamp(16px, 3vw, 24px);
+}
+
 .taste-t-frame {
   flex: 1 0 auto;
   width: 100%;
@@ -163,7 +211,7 @@
   color: rgba(238, 241, 255, 0.75);
 }
 
-button {
+.taste-t-app button {
   font: inherit;
   border: none;
   border-radius: 14px;
@@ -175,19 +223,19 @@ button {
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-button:hover {
+.taste-t-app button:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(255, 144, 171, 0.35);
 }
 
-button:disabled {
+.taste-t-app button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   box-shadow: none;
   transform: none;
 }
 
-button.ghost {
+.taste-t-app button.ghost {
   background: transparent;
   color: rgba(238, 241, 255, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.15);
@@ -278,7 +326,7 @@ button.ghost {
 
 .duel-combatants {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr)) 110px;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) 140px;
   gap: 16px;
   align-items: stretch;
 }
@@ -292,6 +340,9 @@ button.ghost {
   overflow: hidden;
   background: rgba(8, 11, 25, 0.9);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  width: 100%;
+  justify-self: stretch;
+  min-width: 0;
 }
 
 .combatant .combatant-callout {
@@ -311,6 +362,7 @@ button.ghost {
 
 .combatant-art {
   height: 160px;
+  width: 100%;
   background-size: cover;
   background-position: center;
 }
@@ -346,6 +398,7 @@ button.ghost {
   align-items: center;
   gap: 12px;
   padding: 12px 0;
+  width: 100%;
 }
 
 .expected-label {
@@ -353,6 +406,18 @@ button.ghost {
   color: rgba(238, 241, 255, 0.65);
   letter-spacing: 0.1em;
   text-transform: uppercase;
+}
+
+.view-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.view-button {
+  font-size: 0.8rem;
+  padding: 8px 12px;
 }
 
 .draw-button {
@@ -365,6 +430,28 @@ button.ghost {
 .panel-body {
   display: grid;
   gap: 16px;
+}
+
+.final-standings {
+  margin-top: 24px;
+  padding: clamp(16px, 3vw, 24px);
+  border-radius: 18px;
+  background: rgba(12, 16, 32, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.final-standings > div {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.final-standings h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(238, 241, 255, 0.8);
 }
 
 .pairing-list {
@@ -521,6 +608,63 @@ button.ghost {
   display: flex;
   justify-content: space-between;
   color: rgba(238, 241, 255, 0.75);
+}
+
+.taste-t-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 8, 20, 0.85);
+  backdrop-filter: blur(4px);
+}
+
+.lightbox-content {
+  position: relative;
+  z-index: 1;
+  width: min(1200px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.lightbox-close {
+  align-self: flex-end;
+}
+
+.lightbox-figure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.lightbox-figure img {
+  max-width: 100%;
+  max-height: 80vh;
+  border-radius: 20px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+}
+
+.lightbox-figure figcaption {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 1rem;
+  color: rgba(238, 241, 255, 0.9);
+}
+
+.lightbox-figure figcaption strong {
+  font-size: 1.1rem;
 }
 
 .tier-card li.empty {


### PR DESCRIPTION
## Summary
- expand the TasteT playing layout so duels dominate the screen and round details stay hidden until the mini finishes
- add view controls and a modal lightbox so each combatant image can be opened at full size while ranking
- tune the playing styles to stretch combatant art, center the duel card, and present a compact final standings summary

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d53b591e1c8322879162c042b6abe9