### PR TITLE
Improve TasteT persistence and swiss summaries

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import './library.css';
 import { DEFAULT_COLORS, loadPalette } from './colorConfig.js';
 import { extractDominantColor } from './dominantColor.js';
@@ -148,7 +148,7 @@ export default function Library({ onBack }) {
   const [descInput, setDescInput] = useState('');
   const [tagInput, setTagInput] = useState('');
   const [palette, setPalette] = useState(DEFAULT_COLORS);
-  const [sortMode, setSortMode] = useState('none'); // 'none', 'color', 'title', 'date', 'random'
+  const [sortMode, setSortMode] = useState('none'); // 'none', 'color', 'title', 'date', 'rating', 'random'
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [libraryTheme, setLibraryTheme] = useState(() => {
@@ -207,6 +207,50 @@ export default function Library({ onBack }) {
         (img) => getOrientationTag(img.tags) !== hiddenOrientation
       )
     : images;
+
+  const ratingSummary = useMemo(() => {
+    if (!images.length) {
+      return new Map();
+    }
+
+    const annotated = images.map((img) => ({
+      id: img.id,
+      title: typeof img.title === 'string' ? img.title : '',
+      rating: typeof img.rating === 'number' ? img.rating : null,
+      wins: img.stats?.wins ?? 0,
+      totalDuels: img.stats?.totalDuels ?? 0,
+      lastPlayedAt: img.lastPlayedAt ?? 0,
+    }));
+
+    const rankedEntries = annotated
+      .filter((entry) => entry.rating != null)
+      .sort((a, b) => {
+        if (b.rating !== a.rating) return b.rating - a.rating;
+        if (b.totalDuels !== a.totalDuels) return b.totalDuels - a.totalDuels;
+        if (b.wins !== a.wins) return b.wins - a.wins;
+        if (b.lastPlayedAt !== a.lastPlayedAt) return b.lastPlayedAt - a.lastPlayedAt;
+        return a.title.localeCompare(b.title);
+      });
+
+    const summary = new Map();
+    rankedEntries.forEach((entry, index) => {
+      summary.set(entry.id, {
+        rank: index + 1,
+        rating: entry.rating,
+      });
+    });
+
+    annotated.forEach((entry) => {
+      if (!summary.has(entry.id)) {
+        summary.set(entry.id, {
+          rank: null,
+          rating: entry.rating,
+        });
+      }
+    });
+
+    return summary;
+  }, [images]);
 
   // Restore masonry spans by normalizing stored images to their natural size
   useEffect(() => {
@@ -949,6 +993,22 @@ export default function Library({ onBack }) {
     sortImages(sorted, 'date');
   };
 
+  const sortByRating = () => {
+    const sorted = [...images].sort((a, b) => {
+      const ratingA = typeof a.rating === 'number' ? a.rating : -Infinity;
+      const ratingB = typeof b.rating === 'number' ? b.rating : -Infinity;
+      if (ratingB !== ratingA) return ratingB - ratingA;
+      const duelsA = a.stats?.totalDuels ?? 0;
+      const duelsB = b.stats?.totalDuels ?? 0;
+      if (duelsB !== duelsA) return duelsB - duelsA;
+      const winsA = a.stats?.wins ?? 0;
+      const winsB = b.stats?.wins ?? 0;
+      if (winsB !== winsA) return winsB - winsA;
+      return String(a.title || '').localeCompare(String(b.title || ''));
+    });
+    sortImages(sorted, 'rating');
+  };
+
   const shuffleImages = () => {
     const shuffled = [...images];
     for (let i = shuffled.length - 1; i > 0; i -= 1) {
@@ -1149,24 +1209,28 @@ export default function Library({ onBack }) {
     const span = getMasonrySpan(scaledHeight);
     const isLoaded = Boolean(img.dataUrl);
     const placeholderHeight = Math.max(scaledHeight, colWidth * 0.75);
+    const ratingInfo = ratingSummary.get(img.id);
+    const hasRating = ratingInfo && typeof ratingInfo.rating === 'number';
     return (
       <div
         key={img.id}
         className={`image-card${isLoaded ? '' : ' loading'}`}
         style={{ gridRowEnd: `span ${span}` }}
-        draggable={sortMode !== 'title' && sortMode !== 'date'}
+        draggable={
+          sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
+        }
         onContextMenu={(e) => {
           e.preventDefault();
           setMenu({ id: img.id, x: e.clientX, y: e.clientY });
         }}
         onClick={isLoaded ? () => setLightbox(img) : undefined}
         onDragStart={
-          sortMode !== 'title' && sortMode !== 'date'
+          sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
             ? () => setDraggedId(img.id)
             : undefined
         }
         onDragOver={
-          sortMode !== 'title' && sortMode !== 'date'
+          sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
             ? (e) => {
                 if (e.dataTransfer.files?.length) {
                   handleDragOver(e);
@@ -1177,7 +1241,7 @@ export default function Library({ onBack }) {
             : undefined
         }
         onDrop={
-          sortMode !== 'title' && sortMode !== 'date'
+          sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
             ? (e) => {
                 if (e.dataTransfer.files?.length) {
                   handleDrop(e);
@@ -1191,7 +1255,7 @@ export default function Library({ onBack }) {
               : undefined
           }
         onDragEnd={
-          sortMode !== 'title' && sortMode !== 'date'
+          sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
             ? () => setDraggedId(null)
             : undefined
         }
@@ -1239,6 +1303,18 @@ export default function Library({ onBack }) {
             ></span>
             {img.title}
           </h3>
+          {hasRating ? (
+            <p className="image-meta">
+              {ratingInfo.rank ? (
+                <span className="image-meta-rank">#{ratingInfo.rank}</span>
+              ) : null}
+              <span className="image-meta-elo">
+                {`${Math.round(ratingInfo.rating)} Elo`}
+              </span>
+            </p>
+          ) : (
+            <p className="image-meta image-meta-unranked">Unranked</p>
+          )}
         </div>
       </div>
     );
@@ -1472,6 +1548,14 @@ export default function Library({ onBack }) {
                   </button>
                   <button
                     onClick={() => {
+                      sortByRating();
+                      setSortMenuOpen(false);
+                    }}
+                  >
+                    Elo (High → Low)
+                  </button>
+                  <button
+                    onClick={() => {
                       shuffleImages();
                       setSortMenuOpen(false);
                     }}
@@ -1592,7 +1676,7 @@ export default function Library({ onBack }) {
                 gap: `${gridGap}px`,
               }}
               onDragOver={
-                sortMode !== 'title' && sortMode !== 'date'
+                sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
                   ? (e) => {
                       if (e.dataTransfer.files?.length) {
                         handleDragOver(e);
@@ -1603,7 +1687,7 @@ export default function Library({ onBack }) {
                   : undefined
               }
                 onDrop={
-                  sortMode !== 'title' && sortMode !== 'date'
+                  sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
                     ? (e) => {
                         if (e.dataTransfer.files?.length) {
                           handleDrop(e);
@@ -1855,6 +1939,28 @@ export default function Library({ onBack }) {
                       {lightbox.title || 'Untitled'}
                     </h1>
                   )}
+                  <div className="lightbox-stats">
+                    {(() => {
+                      const info = ratingSummary.get(lightbox.id);
+                      if (!info || typeof info.rating !== 'number') {
+                        return (
+                          <span className="lightbox-unranked">
+                            Unranked in TasteT
+                          </span>
+                        );
+                      }
+                      return (
+                        <>
+                          {info.rank ? (
+                            <span className="lightbox-rank">Rank #{info.rank}</span>
+                          ) : null}
+                          <span className="lightbox-elo">
+                            {`${Math.round(info.rating)} Elo`}
+                          </span>
+                        </>
+                      );
+                    })()}
+                  </div>
                   <textarea
                     value={descInput}
                     placeholder="Description"

--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -12,6 +12,7 @@ const PROMOTION_RD_CAP = 125;
 const LOG_LIMIT = 120;
 const HISTORY_LIMIT = 6;
 const RECENT_MATCHES_LIMIT = 6;
+const UNDO_STACK_LIMIT = 8;
 
 const TIER_RULES = [
   {
@@ -98,6 +99,40 @@ function arraysEqual(a = [], b = []) {
   return true;
 }
 
+function deepClone(value) {
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+
+  if (typeof structuredClone === "function") {
+    try {
+      return structuredClone(value);
+    } catch (error) {
+      // fall back to JSON strategy
+    }
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (error) {
+    console.warn("TierT: unable to clone value", error);
+    return value;
+  }
+}
+
+function valuesEqual(a, b) {
+  if (a === b) return true;
+  if (a == null && b == null) return true;
+  if (typeof a === "object" && typeof b === "object") {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch (error) {
+      return false;
+    }
+  }
+  return false;
+}
+
 function loadLibraryCatalog() {
   if (typeof window === "undefined") {
     return [];
@@ -128,6 +163,29 @@ function loadLibraryCatalog() {
             : typeof entry?.timestamp === "number"
             ? entry.timestamp
             : null;
+        const rating = typeof entry?.rating === "number" ? entry.rating : null;
+        const rd = typeof entry?.rd === "number" ? entry.rd : null;
+        const volatility = typeof entry?.volatility === "number" ? entry.volatility : null;
+        let tierKey = sanitizeText(entry?.tierKey || entry?.tier || "", null);
+        if (!tierKey && typeof rating === "number") {
+          tierKey = getTierByRating(rating);
+        }
+        const tierIndex =
+          typeof entry?.tierIndex === "number"
+            ? entry.tierIndex
+            : tierKey
+            ? getTierIndex(tierKey)
+            : 0;
+        const stats =
+          entry?.stats && typeof entry.stats === "object" && !Array.isArray(entry.stats)
+            ? { ...entry.stats }
+            : {};
+        const lastPlayedAt = typeof entry?.lastPlayedAt === "number" ? entry.lastPlayedAt : null;
+        const updatedAt = typeof entry?.updatedAt === "number" ? entry.updatedAt : createdAt;
+        const tierLog = Array.isArray(entry?.tierLog) ? entry.tierLog.slice(-10) : [];
+        const recentMatches = Array.isArray(entry?.recentMatches)
+          ? entry.recentMatches.slice(0, RECENT_MATCHES_LIMIT)
+          : [];
 
         return {
           id,
@@ -139,6 +197,16 @@ function loadLibraryCatalog() {
           height: typeof entry?.height === "number" ? entry.height : null,
           color: sanitizeText(entry?.color || "", null),
           createdAt,
+          rating,
+          rd,
+          volatility,
+          tierKey,
+          tierIndex,
+          stats,
+          lastPlayedAt,
+          updatedAt,
+          tierLog,
+          recentMatches,
         };
       })
       .filter(Boolean);
@@ -221,6 +289,56 @@ function synchronizeImagesWithLibrary(savedImages, libraryEntries) {
   }
 
   return { images: changed ? merged : savedImages, newIds, changed };
+}
+
+function mergeLibraryMetadataWithRatings(entries = [], images = []) {
+  if (!Array.isArray(entries) || !entries.length || !Array.isArray(images) || !images.length) {
+    return { entries, changed: false };
+  }
+
+  const imageMap = new Map(images.map((image) => [coerceLibraryId(image.id), image]));
+  let changed = false;
+
+  const nextEntries = entries.map((entry) => {
+    if (!entry) return entry;
+    const id = coerceLibraryId(entry.id);
+    if (!id || !imageMap.has(id)) {
+      return entry;
+    }
+
+    const image = imageMap.get(id);
+    const updates = {
+      rating: image.rating,
+      rd: image.rd,
+      volatility: image.volatility,
+      tierKey: image.tierKey,
+      tierIndex: image.tierIndex,
+      stats: image.stats,
+      lastPlayedAt: image.lastPlayedAt,
+      updatedAt: image.updatedAt,
+      tierLog: image.tierLog,
+      recentMatches: image.recentMatches,
+    };
+
+    let entryChanged = false;
+    const nextEntry = { ...entry };
+
+    Object.entries(updates).forEach(([key, value]) => {
+      if (!valuesEqual(entry[key], value)) {
+        nextEntry[key] = value;
+        entryChanged = true;
+      }
+    });
+
+    if (entryChanged) {
+      changed = true;
+      return nextEntry;
+    }
+
+    return entry;
+  });
+
+  return changed ? { entries: nextEntries, changed: true } : { entries, changed: false };
 }
 
 function buildPlacementQueueForImage(imageId, images, count = 5) {
@@ -1459,8 +1577,9 @@ function createSwissSummary(swiss, imagesById) {
   if (!swiss) return null;
 
   const standings = swiss.finalStandings || swiss.latestStandings || [];
-  const enriched = standings.map((entry) => {
+  const enriched = standings.map((entry, index) => {
     const image = imagesById[entry.id];
+    const fallbackRank = typeof entry.rank === "number" ? entry.rank : index + 1;
     return {
       id: entry.id,
       name: image?.name || entry.name,
@@ -1471,16 +1590,29 @@ function createSwissSummary(swiss, imagesById) {
       draws: entry.draws,
       points: entry.points,
       buchholz: entry.buchholz || 0,
-      rank: entry.rank,
+      rank: fallbackRank,
     };
   });
+
+  const sorted = enriched
+    .slice()
+    .sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      if ((b.points ?? 0) !== (a.points ?? 0)) return (b.points ?? 0) - (a.points ?? 0);
+      const aDiff = (a.wins || 0) - (a.losses || 0);
+      const bDiff = (b.wins || 0) - (b.losses || 0);
+      if (bDiff !== aDiff) return bDiff - aDiff;
+      return a.name.localeCompare(b.name);
+    });
 
   return {
     id: swiss.id,
     createdAt: swiss.createdAt,
     completedAt: swiss.completedAt || Date.now(),
     totalRounds: swiss.totalRounds,
-    participants: enriched,
+    participants: sorted,
+    size: sorted.length,
+    winnerId: sorted[0]?.id || null,
   };
 }
 
@@ -1546,6 +1678,7 @@ function DuelCard({
   expected = 0.5,
   contextLabel,
   onResolve,
+  onViewImage,
 }) {
   if (!leftImage || !rightImage) {
     return null;
@@ -1572,6 +1705,24 @@ function DuelCard({
         </button>
         <div className="duel-actions">
           <span className="expected-label">{`Expected ${Math.round(expected * 100)}%`}</span>
+          <div className="view-buttons">
+            <button
+              type="button"
+              className="ghost view-button"
+              onClick={() => onViewImage?.(leftImage)}
+              disabled={disabled}
+            >
+              View Left
+            </button>
+            <button
+              type="button"
+              className="ghost view-button"
+              onClick={() => onViewImage?.(rightImage)}
+              disabled={disabled}
+            >
+              View Right
+            </button>
+          </div>
           <button
             type="button"
             onClick={() => onResolve("draw")}
@@ -1608,12 +1759,14 @@ function SwissMiniPanel({
   onAdvanceRound,
   onFinish,
   onCancel,
+  onViewImage,
 }) {
   if (!swiss) return null;
 
   const currentRound = swiss.rounds.find((round) => round.index === swiss.currentRound);
   const pendingPairing = currentRound?.pairings?.find((pair) => !pair.resolved && !pair.bye);
   const standings = swiss.latestStandings || computeStandings(swiss.participants).standings;
+  const showSummary = swiss.status === "awaiting-finish" || swiss.status === "completed";
 
   const renderPairingStatus = (pair) => {
     if (pair.bye) {
@@ -1665,6 +1818,7 @@ function SwissMiniPanel({
           expected={pendingPairing.expected}
           contextLabel={`Round ${swiss.currentRound}`}
           onResolve={(result) => onResolvePairing(pendingPairing.id, result)}
+          onViewImage={onViewImage}
         />
       ) : (
         <div className="panel-placeholder">
@@ -1673,51 +1827,53 @@ function SwissMiniPanel({
             : "Awaiting next pairing..."}
         </div>
       )}
-      <div className="panel-body">
-        <div>
-          <h3>Round Pairings</h3>
-          <ul className="pairing-list">
-            {currentRound?.pairings?.map((pair) => (
-              <li key={pair.id}>{renderPairingStatus(pair)}</li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h3>Standings</h3>
-          <table className="standings-table">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Name</th>
-                <th>Points</th>
-                <th>Record</th>
-                <th>Buchholz</th>
-              </tr>
-            </thead>
-            <tbody>
-              {standings.map((entry) => (
-                <tr key={entry.id}>
-                  <td>{entry.rank}</td>
-                  <td>
-                    <div className="standings-name">
-                      <TierBadge tierKey={entry.tierKey || imagesById[entry.id]?.tierKey} />
-                      <span>{imagesById[entry.id]?.name || entry.name}</span>
-                    </div>
-                  </td>
-                  <td>{entry.points}</td>
-                  <td>{formatRecord(entry.wins, entry.losses, entry.draws)}</td>
-                  <td>{roundTo(entry.buchholz, 1)}</td>
+      {showSummary ? (
+        <div className="panel-body final-standings">
+          <div>
+            <h3>Final Standings</h3>
+            <table className="standings-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Name</th>
+                  <th>Points</th>
+                  <th>Record</th>
+                  <th>Buchholz</th>
                 </tr>
+              </thead>
+              <tbody>
+                {standings.map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{entry.rank}</td>
+                    <td>
+                      <div className="standings-name">
+                        <TierBadge tierKey={entry.tierKey || imagesById[entry.id]?.tierKey} />
+                        <span>{imagesById[entry.id]?.name || entry.name}</span>
+                      </div>
+                    </td>
+                    <td>{entry.points}</td>
+                    <td>{formatRecord(entry.wins, entry.losses, entry.draws)}</td>
+                    <td>{roundTo(entry.buchholz, 1)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <h3>Latest Round</h3>
+            <ul className="pairing-list">
+              {currentRound?.pairings?.map((pair) => (
+                <li key={pair.id}>{renderPairingStatus(pair)}</li>
               ))}
-            </tbody>
-          </table>
+            </ul>
+          </div>
         </div>
-      </div>
+      ) : null}
     </section>
   );
 }
 
-function PlacementPanel({ queue, imagesById, onResolve, onCancel }) {
+function PlacementPanel({ queue, imagesById, onResolve, onCancel, onViewImage }) {
   if (!queue) return null;
 
   const image = imagesById[queue.imageId];
@@ -1749,6 +1905,7 @@ function PlacementPanel({ queue, imagesById, onResolve, onCancel }) {
           expected={expectedScore(image.rating, opponent.rating)}
           contextLabel="Placement"
           onResolve={onResolve}
+          onViewImage={onViewImage}
         />
       ) : (
         <div className="panel-placeholder">Placement complete!</div>
@@ -1789,6 +1946,8 @@ function TasteT() {
     return "lobby";
   });
   const pendingPreviewRef = useRef(new Set());
+  const [expandedImage, setExpandedImage] = useState(null);
+  const [undoStack, setUndoStack] = useState([]);
 
   const imagesById = useMemo(() => {
     const map = {};
@@ -1808,6 +1967,57 @@ function TasteT() {
     : 0;
   const showPlacementCallout =
     mode === "lobby" && placementQueue && placementImage && pendingPlacementRounds > 0;
+  const isPlaying = mode === "swiss" || mode === "placement";
+  const canUndo = undoStack.length > 0;
+
+  const createUndoState = useCallback(() => ({
+    images: deepClone(images),
+    duelLog: deepClone(duelLog),
+    activeSwiss: deepClone(activeSwiss),
+    placementQueue: deepClone(placementQueue),
+    mode,
+  }), [images, duelLog, activeSwiss, placementQueue, mode]);
+
+  const pushUndoState = useCallback((snapshot) => {
+    if (!snapshot) return;
+    setUndoStack((current) => [snapshot, ...current].slice(0, UNDO_STACK_LIMIT));
+  }, []);
+
+  const handleViewImage = useCallback((image) => {
+    if (!image) return;
+    setExpandedImage(image);
+  }, []);
+
+  const handleCloseExpanded = useCallback(() => {
+    setExpandedImage(null);
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    setUndoStack((current) => {
+      if (!current.length) return current;
+      const [latest, ...rest] = current;
+      setImages(latest?.images ? deepClone(latest.images) : []);
+      setDuelLog(latest?.duelLog ? deepClone(latest.duelLog) : []);
+      setActiveSwiss(latest?.activeSwiss ? deepClone(latest.activeSwiss) : null);
+      setPlacementQueue(latest?.placementQueue ? deepClone(latest.placementQueue) : null);
+      setMode(latest?.mode || "lobby");
+      return rest;
+    });
+    setExpandedImage(null);
+  }, [setImages, setDuelLog, setActiveSwiss, setPlacementQueue, setMode, setExpandedImage]);
+
+  useEffect(() => {
+    if (!expandedImage || typeof window === "undefined") return undefined;
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        setExpandedImage(null);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [expandedImage]);
 
   const refreshLibrary = useCallback(() => {
     if (typeof window === "undefined") return;
@@ -1863,6 +2073,47 @@ function TasteT() {
       }
     }
   }, [libraryEntries]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !images.length) {
+      return;
+    }
+
+    let baseEntries = libraryEntries;
+    if (!Array.isArray(baseEntries) || !baseEntries.length) {
+      try {
+        const raw = localStorage.getItem(LIBRARY_STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            baseEntries = parsed;
+          }
+        }
+      } catch (error) {
+        console.warn("TierT: unable to inspect library storage", error);
+      }
+    }
+
+    if (!Array.isArray(baseEntries) || !baseEntries.length) {
+      return;
+    }
+
+    const { entries: nextEntries, changed } = mergeLibraryMetadataWithRatings(baseEntries, images);
+    if (!changed) {
+      if (baseEntries !== libraryEntries && Array.isArray(baseEntries)) {
+        setLibraryEntries(baseEntries);
+      }
+      return;
+    }
+
+    try {
+      localStorage.setItem(LIBRARY_STORAGE_KEY, JSON.stringify(nextEntries));
+    } catch (error) {
+      console.warn("TierT: unable to sync ratings to library", error);
+    }
+
+    setLibraryEntries(nextEntries);
+  }, [images, libraryEntries]);
 
   useEffect(() => {
     if (!placementQueue) return;
@@ -1994,6 +2245,10 @@ function TasteT() {
 
   const handleResolvePairing = useCallback(
     (pairingId, outcome) => {
+      const snapshot = createUndoState();
+      let resolution = null;
+      let resolved = false;
+
       setActiveSwiss((current) => {
         if (!current) return current;
         const round = current.rounds.find((entry) => entry.index === current.currentRound);
@@ -2007,17 +2262,25 @@ function TasteT() {
           return current;
         }
 
-        const resolution = resolveDuelForImages(leftImage, rightImage, outcome, {
+        resolution = resolveDuelForImages(leftImage, rightImage, outcome, {
           mode: "swiss",
           swissId: current.id,
           round: current.currentRound,
           pairingId,
         });
-        applyResolution(resolution);
+        if (!resolution) {
+          return current;
+        }
+        resolved = true;
         return updateSwissWithResult(current, pairingId, resolution);
       });
+
+      if (resolved && resolution) {
+        pushUndoState(snapshot);
+        applyResolution(resolution);
+      }
     },
-    [imagesById, applyResolution],
+    [imagesById, applyResolution, createUndoState, pushUndoState],
   );
 
   const handleAdvanceRound = useCallback(() => {
@@ -2105,27 +2368,31 @@ function TasteT() {
     (outcome) => {
       if (!placementQueue) return;
 
+      const snapshot = createUndoState();
       const queueImage = imagesById[placementQueue.imageId];
       const opponentId = placementQueue.opponents[placementQueue.currentIndex];
       const opponent = imagesById[opponentId];
       let completed = false;
       let historyEntry = null;
+      let resolution = null;
+      let advanced = false;
 
       if (queueImage && opponent) {
-        const resolution = resolveDuelForImages(queueImage, opponent, outcome, {
+        resolution = resolveDuelForImages(queueImage, opponent, outcome, {
           mode: "placement",
         });
-        applyResolution(resolution);
-        const delta =
-          resolution.left.image.id === queueImage.id
-            ? resolution.left.deltaRating
-            : resolution.right.deltaRating;
-        historyEntry = {
-          id: resolution.duelEntry.id,
-          opponentId,
-          outcome: outcome === "left" ? "Win" : outcome === "right" ? "Loss" : "Draw",
-          delta,
-        };
+        if (resolution) {
+          const delta =
+            resolution.left.image.id === queueImage.id
+              ? resolution.left.deltaRating
+              : resolution.right.deltaRating;
+          historyEntry = {
+            id: resolution.duelEntry.id,
+            opponentId,
+            outcome: outcome === "left" ? "Win" : outcome === "right" ? "Loss" : "Draw",
+            delta,
+          };
+        }
       } else {
         historyEntry = {
           id: `placement-${Date.now()}`,
@@ -2141,8 +2408,10 @@ function TasteT() {
         const nextIndex = current.currentIndex + 1;
         if (nextIndex >= current.opponents.length) {
           completed = true;
+          advanced = true;
           return null;
         }
+        advanced = true;
         return {
           ...current,
           currentIndex: nextIndex,
@@ -2150,19 +2419,36 @@ function TasteT() {
         };
       });
 
+      if (advanced) {
+        pushUndoState(snapshot);
+      }
+
+      if (resolution) {
+        applyResolution(resolution);
+      }
+
       if (completed) {
         setMode("lobby");
       }
     },
-    [placementQueue, imagesById, applyResolution],
+    [placementQueue, imagesById, applyResolution, createUndoState, pushUndoState],
   );
 
   const hasActiveSwiss = mode === "swiss" && activeSwiss;
   const hasPlacement = mode === "placement" && placementQueue;
 
+  const expandedImageSrc = expandedImage?.dataUrl || expandedImage?.imageUrl;
+
   return (
-    <div className="taste-t-app">
+    <div className={`taste-t-app${isPlaying ? " is-playing" : ""}`}>
       <div className="taste-t-frame">
+        {canUndo ? (
+          <div className="taste-t-toolbar">
+            <button type="button" className="ghost" onClick={handleUndo} disabled={!canUndo}>
+              Undo last result
+            </button>
+          </div>
+        ) : null}
         {hasActiveSwiss ? (
           <div className="taste-t-game">
             <SwissMiniPanel
@@ -2172,6 +2458,7 @@ function TasteT() {
               onAdvanceRound={handleAdvanceRound}
               onFinish={handleFinishSwiss}
               onCancel={handleCancelSwiss}
+              onViewImage={handleViewImage}
             />
           </div>
         ) : hasPlacement ? (
@@ -2181,6 +2468,7 @@ function TasteT() {
               imagesById={imagesById}
               onResolve={handleResolvePlacement}
               onCancel={handleCancelPlacement}
+              onViewImage={handleViewImage}
             />
           </div>
         ) : (
@@ -2365,17 +2653,66 @@ function TasteT() {
                 <h2>Swiss History</h2>
                 {swissHistory.length ? (
                   <ul className="swiss-history">
-                    {swissHistory.map((entry) => (
-                      <li key={entry.id}>
-                        <div>
-                          <strong>{entry.id}</strong>
-                          <span>
-                            {entry.participants[0]?.name || "Swiss"} · {entry.totalRounds} rounds · {entry.participants.length} images
-                          </span>
-                        </div>
-                        <div>Winner: {entry.participants.find((p) => p.rank === 1)?.name || ""}</div>
-                      </li>
-                    ))}
+                    {swissHistory.map((entry) => {
+                      const winner = entry.participants[0];
+                      return (
+                        <li key={entry.id} className="swiss-history-card">
+                          <div className="swiss-history-header">
+                            <div>
+                              <h3>
+                                {entry.size || entry.participants.length} image Swiss · {entry.totalRounds} rounds
+                              </h3>
+                              <p>
+                                Finished {formatRelativeTime(entry.completedAt)} · ID {entry.id}
+                              </p>
+                            </div>
+                            <div className="swiss-history-winner">
+                              <span>Winner</span>
+                              <strong>{winner?.name || "—"}</strong>
+                              {typeof winner?.points === "number" ? (
+                                <em>{`${winner.points} pts`}</em>
+                              ) : null}
+                            </div>
+                          </div>
+                          <ol className="swiss-standings">
+                            {entry.participants.map((participant, index) => {
+                              const rank = participant.rank ?? index + 1;
+                              const ratingLabel =
+                                typeof participant.rating === "number"
+                                  ? Math.round(participant.rating)
+                                  : "—";
+                              const buchholzLabel =
+                                typeof participant.buchholz === "number" && participant.buchholz
+                                  ? ` · Buchholz ${roundTo(participant.buchholz, 1)}`
+                                  : "";
+                              return (
+                                <li key={participant.id}>
+                                  <span className="standing-rank">#{rank}</span>
+                                  <div className="standing-meta">
+                                    <span className="standing-name">{participant.name}</span>
+                                    <span className="standing-record">
+                                      {formatRecord(
+                                        participant.wins,
+                                        participant.losses,
+                                        participant.draws,
+                                      )}
+                                      {typeof participant.points === "number"
+                                        ? ` · ${participant.points} pts`
+                                        : ""}
+                                      {buchholzLabel}
+                                    </span>
+                                  </div>
+                                  <div className="standing-right">
+                                    <span className="standing-rating">{ratingLabel}</span>
+                                    <span className="standing-tier">#{participant.tierKey}</span>
+                                  </div>
+                                </li>
+                              );
+                            })}
+                          </ol>
+                        </li>
+                      );
+                    })}
                   </ul>
                 ) : (
                   <div className="panel-placeholder">Finish a Swiss mini to see it logged here.</div>
@@ -2385,6 +2722,23 @@ function TasteT() {
           </div>
         )}
       </div>
+      {expandedImageSrc ? (
+        <div className="taste-t-lightbox" role="dialog" aria-modal="true">
+          <div className="lightbox-backdrop" onClick={handleCloseExpanded} />
+          <div className="lightbox-content" role="document">
+            <button type="button" className="ghost lightbox-close" onClick={handleCloseExpanded}>
+              Close
+            </button>
+            <figure className="lightbox-figure">
+              <img src={expandedImageSrc} alt={expandedImage?.name || "Selected image"} />
+              <figcaption>
+                <strong>{expandedImage?.name}</strong>
+                <span>#{expandedImage?.tierKey}</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/library.css
+++ b/src/library.css
@@ -511,6 +511,32 @@
   align-items: center;
 }
 
+.image-meta {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--library-muted-text);
+}
+
+.image-meta-rank {
+  font-weight: 700;
+  color: var(--library-accent);
+}
+
+.image-meta-elo {
+  font-weight: 600;
+  color: var(--library-text);
+}
+
+.image-meta-unranked {
+  font-style: italic;
+  opacity: 0.75;
+}
+
 .library-tabs {
   display: flex;
   gap: 10px;
@@ -730,6 +756,32 @@
   margin: 0;
   font-size: 1.2rem;
   cursor: pointer;
+}
+
+.lightbox-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: baseline;
+  font-size: 0.95rem;
+  color: var(--library-muted-text);
+}
+
+.lightbox-rank {
+  font-weight: 700;
+  color: var(--library-accent);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.lightbox-elo {
+  font-weight: 600;
+  color: var(--library-text);
+}
+
+.lightbox-unranked {
+  font-style: italic;
+  opacity: 0.75;
 }
 
 .lightbox-info input[type='text'] {

--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -11,6 +11,54 @@
   overflow-x: hidden;
 }
 
+.taste-t-app.is-playing {
+  padding: clamp(16px, 4vw, 32px);
+}
+
+.taste-t-app.is-playing .taste-t-frame {
+  align-items: center;
+}
+
+.taste-t-app.is-playing .taste-t-game {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+}
+
+.taste-t-app.is-playing .taste-t-panel {
+  padding: clamp(24px, 4vw, 44px);
+  min-height: clamp(420px, 70vh, 720px);
+}
+
+.taste-t-app.is-playing .duel-card {
+  padding: clamp(24px, 4vw, 48px);
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.taste-t-app.is-playing .duel-context {
+  font-size: clamp(0.85rem, 1.6vw, 1rem);
+}
+
+.taste-t-app.is-playing .duel-combatants {
+  grid-template-columns: minmax(0, 1fr) minmax(150px, 18vw) minmax(0, 1fr);
+  gap: clamp(20px, 4vw, 32px);
+}
+
+.taste-t-app.is-playing .combatant-art {
+  height: clamp(320px, 60vh, 520px);
+}
+
+.taste-t-app.is-playing .combatant-meta h3 {
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+}
+
+.taste-t-app.is-playing .combatant-meta p {
+  font-size: clamp(0.9rem, 1.6vw, 1.05rem);
+}
+
+.taste-t-app.is-playing .duel-actions {
+  gap: clamp(16px, 3vw, 24px);
+}
+
 .taste-t-frame {
   flex: 1 0 auto;
   width: 100%;
@@ -18,6 +66,26 @@
   display: flex;
   flex-direction: column;
   gap: 32px;
+}
+
+.taste-t-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+}
+
+.taste-t-toolbar .ghost {
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+}
+
+.taste-t-toolbar .ghost:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .taste-t-lobby {
@@ -163,7 +231,7 @@
   color: rgba(238, 241, 255, 0.75);
 }
 
-button {
+.taste-t-app button {
   font: inherit;
   border: none;
   border-radius: 14px;
@@ -175,19 +243,19 @@ button {
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-button:hover {
+.taste-t-app button:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(255, 144, 171, 0.35);
 }
 
-button:disabled {
+.taste-t-app button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   box-shadow: none;
   transform: none;
 }
 
-button.ghost {
+.taste-t-app button.ghost {
   background: transparent;
   color: rgba(238, 241, 255, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.15);
@@ -278,7 +346,7 @@ button.ghost {
 
 .duel-combatants {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr)) 110px;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) 140px;
   gap: 16px;
   align-items: stretch;
 }
@@ -292,6 +360,9 @@ button.ghost {
   overflow: hidden;
   background: rgba(8, 11, 25, 0.9);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  width: 100%;
+  justify-self: stretch;
+  min-width: 0;
 }
 
 .combatant .combatant-callout {
@@ -311,6 +382,7 @@ button.ghost {
 
 .combatant-art {
   height: 160px;
+  width: 100%;
   background-size: cover;
   background-position: center;
 }
@@ -346,6 +418,7 @@ button.ghost {
   align-items: center;
   gap: 12px;
   padding: 12px 0;
+  width: 100%;
 }
 
 .expected-label {
@@ -353,6 +426,18 @@ button.ghost {
   color: rgba(238, 241, 255, 0.65);
   letter-spacing: 0.1em;
   text-transform: uppercase;
+}
+
+.view-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.view-button {
+  font-size: 0.8rem;
+  padding: 8px 12px;
 }
 
 .draw-button {
@@ -365,6 +450,28 @@ button.ghost {
 .panel-body {
   display: grid;
   gap: 16px;
+}
+
+.final-standings {
+  margin-top: 24px;
+  padding: clamp(16px, 3vw, 24px);
+  border-radius: 18px;
+  background: rgba(12, 16, 32, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.final-standings > div {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.final-standings h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(238, 241, 255, 0.8);
 }
 
 .pairing-list {
@@ -523,13 +630,69 @@ button.ghost {
   color: rgba(238, 241, 255, 0.75);
 }
 
+.taste-t-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 8, 20, 0.85);
+  backdrop-filter: blur(4px);
+}
+
+.lightbox-content {
+  position: relative;
+  z-index: 1;
+  width: min(1200px, 92vw);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.lightbox-close {
+  align-self: flex-end;
+}
+
+.lightbox-figure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.lightbox-figure img {
+  max-width: 100%;
+  max-height: 80vh;
+  border-radius: 20px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+}
+
+.lightbox-figure figcaption {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 1rem;
+  color: rgba(238, 241, 255, 0.9);
+}
+
+.lightbox-figure figcaption strong {
+  font-size: 1.1rem;
+}
+
 .tier-card li.empty {
   justify-content: center;
   color: rgba(238, 241, 255, 0.5);
 }
 
-.duel-log,
-.swiss-history {
+.duel-log {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -539,8 +702,7 @@ button.ghost {
   font-size: 0.85rem;
 }
 
-.duel-log li,
-.swiss-history li {
+.duel-log li {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 8px;
@@ -567,10 +729,152 @@ button.ghost {
   color: rgba(238, 241, 255, 0.55);
 }
 
-.swiss-history li.empty {
-  justify-content: center;
-  text-align: center;
+.swiss-history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  font-size: 0.85rem;
+}
+
+.swiss-history-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 16px;
+  background: rgba(15, 18, 34, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.swiss-history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.swiss-history-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+}
+
+.swiss-history-header p {
+  margin: 4px 0 0;
+  color: rgba(238, 241, 255, 0.6);
+  font-size: 0.8rem;
+}
+
+.swiss-history-winner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  text-align: right;
+}
+
+.swiss-history-winner span {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
   color: rgba(238, 241, 255, 0.55);
+}
+
+.swiss-history-winner strong {
+  font-size: 1.05rem;
+}
+
+.swiss-history-winner em {
+  font-style: normal;
+  font-size: 0.8rem;
+  color: rgba(255, 192, 147, 0.9);
+}
+
+.swiss-standings {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.swiss-standings li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(20, 24, 44, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.standing-rank {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: rgba(255, 210, 130, 0.95);
+}
+
+.standing-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.standing-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.standing-record {
+  color: rgba(238, 241, 255, 0.65);
+  font-size: 0.8rem;
+}
+
+.standing-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  font-size: 0.75rem;
+}
+
+.standing-rating {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.standing-tier {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(150, 215, 255, 0.8);
+}
+
+@media (max-width: 720px) {
+  .swiss-history-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .swiss-history-winner {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .swiss-standings li {
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .standing-right {
+    align-items: flex-start;
+    grid-column: 2 / 3;
+  }
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- preserve rating, tier, and match metadata when loading the library catalog so TasteT state persists across reloads
- enrich saved Swiss mini summaries with ordered standings and expose them in the lobby history
- style the Swiss history list to highlight winners and per-image scores after a series completes

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d53b591e1c8322879162c042b6abe9