### PR TITLE
Finalize TasteT minis when persisting state

### DIFF
--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -518,13 +518,38 @@ function prepareStateForStorage(state) {
     ? state.duelLog.map(serializeDuelLogEntry).filter(Boolean)
     : [];
 
+  let swissHistory = Array.isArray(state.swissHistory)
+    ? state.swissHistory.slice(0, HISTORY_LIMIT)
+    : [];
+  let activeSwiss = state.activeSwiss || null;
+
+  if (activeSwiss && activeSwiss.status === "awaiting-finish") {
+    const finalStandings =
+      activeSwiss.finalStandings || activeSwiss.latestStandings || computeStandings(activeSwiss.participants).standings;
+    const completedAt = activeSwiss.completedAt || Date.now();
+    const completedSwiss = {
+      ...activeSwiss,
+      status: "completed",
+      completedAt,
+      finalStandings,
+      latestStandings: finalStandings,
+    };
+    const imagesById = images.reduce((acc, image) => {
+      acc[image.id] = image;
+      return acc;
+    }, {});
+    const summary = createSwissSummary(completedSwiss, imagesById);
+    if (summary) {
+      swissHistory = [summary, ...swissHistory.filter((entry) => entry.id !== summary.id)].slice(0, HISTORY_LIMIT);
+    }
+    activeSwiss = null;
+  }
+
   return {
     images,
     duelLog,
-    swissHistory: Array.isArray(state.swissHistory)
-      ? state.swissHistory.slice(0, HISTORY_LIMIT)
-      : [],
-    activeSwiss: state.activeSwiss || null,
+    swissHistory,
+    activeSwiss,
     placementQueue: state.placementQueue || null,
     selectedTag: state.selectedTag || "",
     miniSize: state.miniSize || MINI_SIZE_OPTIONS[0],
@@ -1107,10 +1132,33 @@ function loadInitialState() {
     const duelLog = Array.isArray(parsed.duelLog)
       ? parsed.duelLog.slice(0, LOG_LIMIT)
       : base.duelLog;
-    const swissHistory = Array.isArray(parsed.swissHistory)
+    let swissHistory = Array.isArray(parsed.swissHistory)
       ? parsed.swissHistory.slice(0, HISTORY_LIMIT)
       : base.swissHistory;
     let activeSwiss = parsed.activeSwiss ? normalizeSwiss(parsed.activeSwiss) : null;
+
+    const imagesById = images.reduce((acc, image) => {
+      acc[image.id] = image;
+      return acc;
+    }, {});
+
+    if (activeSwiss && activeSwiss.status === "awaiting-finish") {
+      const finalStandings =
+        activeSwiss.finalStandings || activeSwiss.latestStandings || computeStandings(activeSwiss.participants).standings;
+      const completedAt = activeSwiss.completedAt || Date.now();
+      const completedSwiss = {
+        ...activeSwiss,
+        status: "completed",
+        completedAt,
+        finalStandings,
+        latestStandings: finalStandings,
+      };
+      const summary = createSwissSummary(completedSwiss, imagesById);
+      if (summary) {
+        swissHistory = [summary, ...swissHistory.filter((entry) => entry.id !== summary.id)].slice(0, HISTORY_LIMIT);
+      }
+      activeSwiss = null;
+    }
 
     if (activeSwiss && (activeSwiss.status === "completed" || activeSwiss.completedAt)) {
       activeSwiss = null;
@@ -1865,7 +1913,15 @@ function createSwissSummary(swiss, imagesById) {
     winnerId: championId,
     championId,
     finalMatch: resolvedFinal,
-    gallery: sorted.slice(0, 6).map((entry) => ({ id: entry.id, rank: entry.rank, name: entry.name })),
+    gallery: sorted.slice(0, 6).map((entry) => {
+      const image = imagesById[entry.id];
+      return {
+        id: entry.id,
+        rank: entry.rank,
+        name: entry.name,
+        preview: image?.dataUrl || image?.imageUrl || null,
+      };
+    }),
   };
 }
 
@@ -2254,7 +2310,9 @@ function TasteT() {
   const [miniSize, setMiniSize] = useState(initialState.miniSize || 8);
   const [libraryEntries, setLibraryEntries] = useState(initialState.libraryEntries);
   const [mode, setMode] = useState(() => {
-    if (initialState.activeSwiss) return "swiss";
+    if (initialState.activeSwiss) {
+      return initialState.activeSwiss.status === "awaiting-finish" ? "lobby" : "swiss";
+    }
     if (initialState.placementQueue && initialState.placementQueueRestored) return "placement";
     return "lobby";
   });
@@ -2809,22 +2867,28 @@ function TasteT() {
     [imagesById, applyResolution, createUndoState, pushUndoState],
   );
 
-  const handleFinishSwiss = useCallback(() => {
+  const finalizeCurrentSwiss = useCallback(() => {
     let summary = null;
+    let finalized = false;
     setActiveSwiss((current) => {
       if (!current) return current;
+      if (current.status !== "awaiting-finish") {
+        return current;
+      }
       if (current.finalMatch && !current.finalMatch.resolved) {
         return current;
       }
       const { standings } = computeStandings(current.participants);
+      const completedAt = current.completedAt || Date.now();
       const completed = {
         ...current,
         status: "completed",
-        completedAt: Date.now(),
+        completedAt,
         finalStandings: standings,
         latestStandings: standings,
       };
       summary = createSwissSummary(completed, imagesById);
+      finalized = true;
       return null;
     });
     if (summary) {
@@ -2833,8 +2897,22 @@ function TasteT() {
         return [summary, ...filtered].slice(0, HISTORY_LIMIT);
       });
     }
-    setMode("lobby");
-  }, [imagesById]);
+    if (finalized) {
+      setMode("lobby");
+    }
+    return summary;
+  }, [imagesById, setSwissHistory, setMode]);
+
+  const handleFinishSwiss = useCallback(() => {
+    finalizeCurrentSwiss();
+  }, [finalizeCurrentSwiss]);
+
+  useEffect(() => {
+    if (!activeSwiss) return;
+    if (activeSwiss.status !== "awaiting-finish") return;
+    if (mode === "swiss") return;
+    finalizeCurrentSwiss();
+  }, [activeSwiss, mode, finalizeCurrentSwiss]);
 
   const handleCancelSwiss = useCallback(() => {
     setActiveSwiss(null);
@@ -3201,7 +3279,7 @@ function TasteT() {
                           </div>
                           <div className="swiss-history-gallery">
                             {galleryItems.slice(0, 4).map((participant) => {
-                              const preview = getPreviewFor(participant.id);
+                              const preview = participant.preview || getPreviewFor(participant.id);
                               return (
                                 <figure key={participant.id} className="swiss-history-figure">
                                   {preview ? (


### PR DESCRIPTION
## Summary
- ensure TasteT finalizes completed Swiss minis when persisting or restoring state so leaving the mode never resurrects the previous set
- refactor Swiss finalization into a reusable helper used by both the finalize button and a new effect that persists completed minis without replaying them
- capture preview URLs in Swiss history so the end-of-mini gallery reliably renders thumbnails

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d6471cd5c0832295a758933060f929