### PR TITLE
Automatically exit Swiss minis after finalization

### DIFF
--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -2917,7 +2917,7 @@ function TasteT() {
 
       summary = completedSummary;
       finalized = completedSwiss;
-      return completedSwiss;
+      return null;
     });
     if (summary) {
       setSwissHistory((current) => {
@@ -2925,11 +2925,11 @@ function TasteT() {
         return [summary, ...filtered].slice(0, HISTORY_LIMIT);
       });
     }
-    if (finalized && finalized.status === "completed" && mode !== "swiss") {
+    if (finalized) {
       setMode("lobby");
     }
     return summary;
-  }, [imagesById, setSwissHistory, setMode, mode]);
+  }, [imagesById, setSwissHistory, setMode]);
 
   const handleFinishSwiss = useCallback(() => {
     finalizeCurrentSwiss();


### PR DESCRIPTION
## Summary
- reset the active Swiss mini state after finalizing a Swiss mini so TasteT no longer reopens the completed series
- return the interface to the lobby view immediately upon completion

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d68992a3e083229fa8860498ef97ae