### PR TITLE
Add Semi-Formless weakness tracker app

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import Orb from '../Orb.jsx';
 import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
 import CharacterEvolve from './CharacterEvolve.jsx';
+import Weakness from './Weakness.jsx';
 import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
 import FormlessCharacter from './FormlessCharacter.jsx';
 import SettingsModal from './SettingsModal.jsx';
@@ -81,6 +82,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showTodoGoals, setShowTodoGoals] = useState(false);
   const [showActivity, setShowActivity] = useState(false);
   const [showCharacterEvolve, setShowCharacterEvolve] = useState(false);
+  const [showWeakness, setShowWeakness] = useState(false);
   const [showIdeaBoard, setShowIdeaBoard] = useState(false);
   const [showImplementationIdeas, setShowImplementationIdeas] = useState(false);
   const [showOrb, setShowOrb] = useState(false);
@@ -117,6 +119,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       todoGoals: 'Form',
       activity: 'Form',
       characterEvolve: 'Form',
+      weakness: 'Semi-Formless',
       ideaBoard: 'Form',
       implementationIdeas: 'Form',
       orb: 'Form',
@@ -186,6 +189,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showTodoGoals ||
     showActivity ||
     showCharacterEvolve ||
+    showWeakness ||
     showSemiCharacter ||
     showIdeaBoard ||
     showImplementationIdeas ||
@@ -216,6 +220,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowTodoGoals(false);
     setShowActivity(false);
     setShowCharacterEvolve(false);
+    setShowWeakness(false);
     setShowSemiCharacter(false);
     setShowIdeaBoard(false);
     setShowImplementationIdeas(false);
@@ -686,6 +691,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <ActivityApp onBack={() => setShowActivity(false)} />
             ) : showCharacterEvolve ? (
               <CharacterEvolve onBack={() => setShowCharacterEvolve(false)} />
+            ) : showWeakness ? (
+              <Weakness onBack={() => setShowWeakness(false)} />
             ) : showSemiCharacter ? (
               <SemiFormlessCharacter onBack={() => setShowSemiCharacter(false)} />
             ) : showIdeaBoard ? (
@@ -926,6 +933,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">🌱</div>
                     <span>Character Evolve</span>
+                  </div>
+                )}
+                {appLayers.weakness === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowWeakness(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'weakness')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'weakness')}
+                  >
+                    <div className="star-icon">⚡</div>
+                    <span>Weakness</span>
                   </div>
                 )}
                 {appLayers.semiCharacter === activeLayer && (

--- a/src/Weakness.jsx
+++ b/src/Weakness.jsx
@@ -1,0 +1,223 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './weakness.css';
+
+const STAGES = ['Awareness', 'Training', 'Mastery'];
+
+const createId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+const loadWeaknesses = () => {
+  try {
+    const stored = JSON.parse(localStorage.getItem('weaknessEntries'));
+    if (Array.isArray(stored)) {
+      return stored.map((item) => ({
+        id: item.id ?? Date.now().toString(),
+        text: item.text ?? '',
+        stage: Number.isInteger(item.stage) ? item.stage % STAGES.length : 0,
+        createdAt: item.createdAt ?? new Date().toISOString(),
+        notes: item.notes ?? '',
+      }));
+    }
+  } catch (error) {
+    console.error('Failed to load weakness entries', error);
+  }
+  return [];
+};
+
+export default function Weakness({ onBack }) {
+  const [weaknesses, setWeaknesses] = useState(loadWeaknesses);
+  const [input, setInput] = useState('');
+  const [notesInput, setNotesInput] = useState('');
+  const [editingId, setEditingId] = useState(null);
+  const [editingText, setEditingText] = useState('');
+  const [editingNotes, setEditingNotes] = useState('');
+
+  useEffect(() => {
+    localStorage.setItem('weaknessEntries', JSON.stringify(weaknesses));
+  }, [weaknesses]);
+
+  const sortedWeaknesses = useMemo(() => {
+    return [...weaknesses].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  }, [weaknesses]);
+
+  const resetInputs = () => {
+    setInput('');
+    setNotesInput('');
+  };
+
+  const handleAdd = () => {
+    if (!input.trim()) return;
+    const entry = {
+      id: createId(),
+      text: input.trim(),
+      notes: notesInput.trim(),
+      stage: 0,
+      createdAt: new Date().toISOString(),
+    };
+    setWeaknesses((prev) => [entry, ...prev]);
+    resetInputs();
+  };
+
+  const handleDelete = (id) => {
+    setWeaknesses((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  const cycleStage = (id) => {
+    setWeaknesses((prev) =>
+      prev.map((item) =>
+        item.id === id
+          ? {
+              ...item,
+              stage: (item.stage + 1) % STAGES.length,
+            }
+          : item
+      )
+    );
+  };
+
+  const startEditing = (item) => {
+    setEditingId(item.id);
+    setEditingText(item.text);
+    setEditingNotes(item.notes || '');
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    setEditingText('');
+    setEditingNotes('');
+  };
+
+  const saveEditing = () => {
+    if (!editingId) return;
+    setWeaknesses((prev) =>
+      prev.map((item) =>
+        item.id === editingId
+          ? {
+              ...item,
+              text: editingText.trim() ? editingText.trim() : item.text,
+              notes: editingNotes.trim(),
+            }
+          : item
+      )
+    );
+    cancelEditing();
+  };
+
+  return (
+    <div className="weakness-app">
+      <header className="weakness-header">
+        <button className="back-button" type="button" onClick={onBack}>
+          Back
+        </button>
+        <div>
+          <h1>Weakness Lab</h1>
+          <p>Capture weaknesses and track your path from awareness to mastery.</p>
+        </div>
+      </header>
+      <section className="weakness-input">
+        <div className="weakness-input-fields">
+          <textarea
+            className="weakness-textarea"
+            placeholder="Describe the weakness you want to transform..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            rows={3}
+          />
+          <textarea
+            className="weakness-textarea notes"
+            placeholder="Optional notes, triggers, or experiments..."
+            value={notesInput}
+            onChange={(e) => setNotesInput(e.target.value)}
+            rows={2}
+          />
+        </div>
+        <button className="weakness-add-button" type="button" onClick={handleAdd}>
+          Add Weakness
+        </button>
+      </section>
+      <section className="weakness-banners" aria-live="polite">
+        {sortedWeaknesses.length === 0 ? (
+          <p className="weakness-empty">
+            No weaknesses logged yet. Start by writing one above and it will appear here
+            as a banner you can revisit.
+          </p>
+        ) : (
+          sortedWeaknesses.map((item) => {
+            const isEditing = editingId === item.id;
+            return (
+              <article
+                key={item.id}
+                className={`weakness-banner stage-${item.stage}`}
+              >
+                <div className="weakness-content">
+                  <div className="weakness-main">
+                    {isEditing ? (
+                      <>
+                        <textarea
+                          className="weakness-edit-text"
+                          value={editingText}
+                          onChange={(e) => setEditingText(e.target.value)}
+                          rows={3}
+                        />
+                        <textarea
+                          className="weakness-edit-notes"
+                          value={editingNotes}
+                          onChange={(e) => setEditingNotes(e.target.value)}
+                          rows={2}
+                          placeholder="Notes, triggers, experiments..."
+                        />
+                      </>
+                    ) : (
+                      <>
+                        <h2>{item.text}</h2>
+                        {item.notes && <p className="weakness-notes">{item.notes}</p>}
+                      </>
+                    )}
+                  </div>
+                  <div className="weakness-meta">
+                    <span className="stage-label">{STAGES[item.stage]}</span>
+                    <time>
+                      {new Date(item.createdAt).toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                        year: 'numeric',
+                      })}
+                    </time>
+                    <div className="weakness-actions">
+                      {isEditing ? (
+                        <>
+                          <button type="button" onClick={saveEditing}>
+                            Save
+                          </button>
+                          <button type="button" onClick={cancelEditing}>
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button type="button" onClick={() => cycleStage(item.id)}>
+                            Advance Stage
+                          </button>
+                          <button type="button" onClick={() => startEditing(item)}>
+                            Edit
+                          </button>
+                          <button type="button" onClick={() => handleDelete(item.id)}>
+                            Delete
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </article>
+            );
+          })
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/weakness.css
+++ b/src/weakness.css
@@ -1,0 +1,240 @@
+.weakness-app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 32px 40px;
+  gap: 24px;
+  color: var(--text-primary, #f0f0f0);
+  background: linear-gradient(160deg, rgba(20, 22, 40, 0.95), rgba(11, 12, 26, 0.92));
+}
+
+.weakness-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.weakness-header h1 {
+  font-size: 32px;
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+
+.weakness-header p {
+  margin: 6px 0 0;
+  max-width: 480px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.weakness-input {
+  display: flex;
+  gap: 16px;
+  align-items: stretch;
+}
+
+.weakness-input-fields {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.weakness-textarea {
+  width: 100%;
+  background: rgba(18, 20, 35, 0.9);
+  color: inherit;
+  border: 1px solid rgba(120, 129, 255, 0.35);
+  border-radius: 16px;
+  padding: 14px 16px;
+  resize: vertical;
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.weakness-textarea:focus {
+  outline: none;
+  border-color: rgba(134, 141, 255, 0.8);
+  box-shadow: 0 0 0 3px rgba(134, 141, 255, 0.25);
+}
+
+.weakness-textarea.notes {
+  min-height: 72px;
+}
+
+.weakness-add-button {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #7b5cff, #5d8bff);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 14px 28px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(92, 119, 255, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.weakness-add-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 24px rgba(92, 119, 255, 0.3);
+}
+
+.weakness-banners {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.weakness-empty {
+  margin: 0;
+  padding: 32px;
+  background: rgba(15, 16, 30, 0.7);
+  border: 1px dashed rgba(128, 138, 255, 0.4);
+  border-radius: 24px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.weakness-banner {
+  border-radius: 28px;
+  padding: 24px 28px;
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 32px rgba(7, 9, 20, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.weakness-banner:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 36px rgba(7, 9, 20, 0.55);
+}
+
+.weakness-banner.stage-0 {
+  background: linear-gradient(120deg, rgba(255, 173, 120, 0.22), rgba(255, 145, 144, 0.15));
+}
+
+.weakness-banner.stage-1 {
+  background: linear-gradient(120deg, rgba(122, 190, 255, 0.22), rgba(115, 152, 255, 0.18));
+}
+
+.weakness-banner.stage-2 {
+  background: linear-gradient(120deg, rgba(120, 255, 189, 0.22), rgba(137, 255, 209, 0.18));
+}
+
+.weakness-content {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.weakness-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.weakness-main h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.weakness-notes {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+}
+
+.weakness-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  min-width: 160px;
+}
+
+.stage-label {
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(13, 15, 30, 0.7);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.weakness-meta time {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.weakness-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.weakness-actions button {
+  background: rgba(16, 18, 35, 0.8);
+  border: 1px solid rgba(150, 160, 255, 0.35);
+  color: inherit;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.weakness-actions button:hover {
+  background: rgba(24, 27, 52, 0.9);
+  border-color: rgba(176, 186, 255, 0.65);
+  transform: translateY(-1px);
+}
+
+.weakness-edit-text,
+.weakness-edit-notes {
+  width: 100%;
+  background: rgba(13, 14, 25, 0.82);
+  border: 1px solid rgba(132, 140, 255, 0.45);
+  border-radius: 16px;
+  padding: 12px 14px;
+  color: inherit;
+  font-size: 15px;
+  line-height: 1.4;
+  resize: vertical;
+}
+
+.weakness-edit-text:focus,
+.weakness-edit-notes:focus {
+  outline: none;
+  border-color: rgba(186, 196, 255, 0.85);
+  box-shadow: 0 0 0 3px rgba(135, 145, 255, 0.35);
+}
+
+@media (max-width: 960px) {
+  .weakness-app {
+    padding: 24px;
+  }
+
+  .weakness-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .weakness-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .weakness-meta {
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- create a Weakness tracker tool with banner-style entries, stage cycling, and inline editing
- wire the new app into the Tools grid with Semi-Formless defaults and persistence updates
- add dedicated styling for the weakness banners and controls

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: electron dependency libatk-1.0.so.0 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d935a37bec8322bc0da8c8c1417c4f