### PR TITLE
feat: infuse NoFap lab with celestial UI

### DIFF
--- a/nofap-calendar.css
+++ b/nofap-calendar.css
@@ -1,117 +1,493 @@
-.nofap-calendar {
+.nofap-shell {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 24px;
+  padding: 32px 40px;
+  color: #f5f7ff;
+  background:
+    radial-gradient(circle at top right, rgba(112, 114, 255, 0.18), transparent 55%),
+    linear-gradient(180deg, rgba(10, 11, 26, 0.92), rgba(15, 16, 30, 0.95));
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.nofap-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.header-left {
+  display: flex;
+  gap: 20px;
   align-items: center;
-  margin-top: 20px;
 }
 
 .back-button {
-  background: #333;
-  color: white;
-  border: none;
-  padding: 6px 12px;
-  border-radius: 4px;
+  background: rgba(68, 74, 120, 0.35);
+  border: 1px solid rgba(108, 118, 235, 0.45);
+  color: inherit;
+  border-radius: 12px;
+  padding: 10px 18px;
   cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
-.calendar-grid {
+.back-button:hover {
+  background: rgba(108, 118, 235, 0.3);
+  border-color: rgba(134, 142, 255, 0.7);
+}
+
+.nofap-header h1 {
+  margin: 0 0 6px;
+  font-size: 32px;
+}
+
+.nofap-header p {
+  margin: 0;
+  max-width: 420px;
+  color: rgba(219, 224, 255, 0.8);
+  line-height: 1.5;
+}
+
+.header-metrics {
   display: flex;
+  gap: 16px;
+}
+
+.metric-card {
+  background: rgba(28, 30, 58, 0.82);
+  padding: 16px 20px;
+  border-radius: 16px;
+  border: 1px solid rgba(120, 128, 255, 0.35);
+  min-width: 150px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: 0 12px 24px rgba(8, 9, 22, 0.45);
+}
+
+.metric-label {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(200, 206, 255, 0.65);
+}
+
+.metric-value {
+  font-size: 18px;
+}
+
+.outcome-banner {
+  padding: 12px 18px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(34, 37, 66, 0.85);
+  box-shadow: inset 0 1px 8px rgba(255, 255, 255, 0.06);
+}
+
+.outcome-banner.victory {
+  border-color: rgba(90, 204, 150, 0.45);
+  background: linear-gradient(120deg, rgba(38, 61, 78, 0.65), rgba(72, 190, 140, 0.22));
+}
+
+.outcome-banner.relapse {
+  border-color: rgba(255, 120, 120, 0.4);
+  background: linear-gradient(120deg, rgba(68, 35, 50, 0.6), rgba(255, 120, 120, 0.16));
+}
+
+.nofap-content {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+  gap: 28px;
+  min-height: 0;
+  flex: 1;
+}
+
+.main-column {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  overflow: hidden;
+}
+
+.streak-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 24px;
+  padding: 24px 28px;
+  border-radius: 20px;
+  border: 1px solid rgba(125, 134, 247, 0.25);
+  background: linear-gradient(120deg, rgba(36, 38, 68, 0.85), rgba(20, 22, 46, 0.9));
+  box-shadow: 0 18px 32px rgba(10, 12, 36, 0.5);
+}
+
+.streak-heart {
+  font-size: 56px;
+  filter: drop-shadow(0 12px 24px rgba(255, 70, 110, 0.35));
+  align-self: center;
+}
+
+.streak-details h2 {
+  margin: 0 0 6px;
+  font-size: 24px;
+}
+
+.streak-details p {
+  margin: 0;
+  color: rgba(212, 218, 255, 0.78);
+  line-height: 1.5;
+}
+
+.streak-count {
+  margin-top: 16px;
+  font-size: 20px;
+  font-weight: 600;
+  color: #fcefff;
+}
+
+.streak-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+}
+
+.pill-button {
+  border-radius: 999px;
+  padding: 10px 22px;
+  border: 1px solid rgba(130, 138, 255, 0.45);
+  background: rgba(32, 34, 60, 0.72);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.pill-button:hover {
+  background: rgba(130, 138, 255, 0.18);
+  border-color: rgba(160, 170, 255, 0.65);
+  transform: translateY(-1px);
+}
+
+.pill-button.primary {
+  background: linear-gradient(135deg, #728bff, #4fd2ff);
+  color: #0d1220;
+  border: none;
+  box-shadow: 0 16px 30px rgba(76, 137, 255, 0.32);
+}
+
+.pill-button.danger {
+  border-color: rgba(255, 120, 120, 0.55);
+  background: rgba(255, 90, 120, 0.16);
+}
+
+.pill-button.danger:hover {
+  background: rgba(255, 120, 150, 0.22);
+  border-color: rgba(255, 140, 160, 0.7);
+}
+
+.heatmap-card,
+.runs-card,
+.insight-card {
+  background: rgba(26, 28, 56, 0.88);
+  border: 1px solid rgba(118, 124, 230, 0.28);
+  border-radius: 20px;
+  padding: 22px 26px;
+  box-shadow: 0 18px 30px rgba(9, 11, 30, 0.55);
+}
+
+.heatmap-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.heatmap-header h2 {
+  margin: 0 0 6px;
+}
+
+.heatmap-header p {
+  margin: 0;
+  color: rgba(208, 214, 250, 0.78);
+}
+
+.legend {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.legend-chip {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.legend-chip.green { background: #2ecc71; }
+.legend-chip.yellow { background: #ffd633; }
+.legend-chip.orange { background: #ff8800; }
+.legend-chip.blue { background: #3498db; }
+.legend-chip.purple { background: #9b59b6; }
+.legend-chip.red { background: #e74c3c; }
+.legend-chip.white { background: #ffffff; }
+
+.legend-label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(210, 215, 255, 0.65);
+}
+
+.heatmap-grid {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 }
 
 .month-labels {
-  display: flex;
-  margin-left: 34px;
-  font-size: 0.8em;
-  color: #ccc;
+  display: grid;
+  grid-template-columns: repeat(53, 16px);
+  gap: 3px;
+  margin-left: 38px;
+  font-size: 12px;
+  color: rgba(190, 196, 245, 0.72);
 }
 
 .month-label {
-  width: 18px;
   text-align: center;
 }
 
-.day-labels {
+.grid-wrapper {
   display: flex;
-  flex-direction: column;
-  margin-right: 4px;
-  font-size: 0.8em;
-  color: #ccc;
-  height: 112px;
-  justify-content: space-between;
+  gap: 12px;
+}
+
+.day-labels {
+  display: grid;
+  grid-template-rows: repeat(7, 16px);
+  gap: 3px;
+  font-size: 11px;
+  color: rgba(190, 196, 245, 0.6);
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(53, 16px);
+  gap: 3px;
 }
 
 .week {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: repeat(7, 16px);
+  gap: 3px;
 }
 
 .day {
   width: 16px;
   height: 16px;
-  margin: 2px;
-  background: #444;
   border-radius: 3px;
+  background: rgba(52, 54, 84, 0.65);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.day.green { background: #2ecc71; }
-.day.yellow { background: #ffd633; }
-.day.orange { background: #ff8800; }
-.day.blue { background: #3498db; }
-.day.purple { background: #9b59b6; }
-.day.red { background: #e74c3c; }
-.day.white { background: #ffffff; }
+.day.active-run {
+  box-shadow: 0 0 6px rgba(104, 132, 255, 0.55);
+}
+
+.day.today {
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 0 0 2px rgba(120, 129, 255, 0.35);
+}
 
 .day.relapse {
-  background: #ff3333;
+  background: #ff4f6d;
   position: relative;
 }
 
 .day.relapse::after {
   content: '\2715';
   position: absolute;
-  top: -2px;
-  left: 0;
-  right: 0;
-  text-align: center;
-  font-size: 14px;
-  line-height: 16px;
-  color: #fff;
-}
-
-.actions {
+  inset: 0;
   display: flex;
-  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 14px;
 }
 
-.stats-line {
-  font-size: 0.9em;
-  color: #ccc;
+.day:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 14px rgba(10, 14, 46, 0.5);
 }
 
-.action-button {
-  background: #007bff;
-  color: white;
-  border: none;
-  padding: 6px 12px;
-  border-radius: 4px;
-  cursor: pointer;
+.runs-card h2 {
+  margin: 0 0 14px;
 }
 
-.action-button:hover {
-  background: #0056b3;
+.runs-timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
-.runs-list {
+.runs-timeline li {
+  background: rgba(18, 20, 46, 0.8);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(128, 136, 255, 0.2);
+}
+
+.timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 6px;
+  background: #63e6be;
+}
+
+.status-dot.relapse {
+  background: #ff6b6b;
+}
+
+.timeline-body {
+  margin-top: 8px;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  width: 100%;
-  max-width: 400px;
 }
 
-.run-banner {
-  background: #333;
-  padding: 6px 10px;
-  border-radius: 6px;
+.duration {
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(200, 206, 255, 0.72);
+}
+
+.reason {
+  margin: 0;
+  color: rgba(214, 218, 255, 0.82);
+  line-height: 1.45;
+}
+
+.reason.subtle {
+  color: rgba(214, 218, 255, 0.55);
+}
+
+.empty-state {
+  margin: 0;
+  color: rgba(200, 206, 255, 0.6);
+}
+
+.insights-column {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.insight-card h3 {
+  margin: 0 0 10px;
+}
+
+.insight-metric {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+
+.insight-meter {
+  width: 100%;
+  height: 8px;
+  background: rgba(70, 74, 130, 0.4);
+  border-radius: 999px;
+  overflow: hidden;
+  margin: 12px 0 10px;
+}
+
+.insight-meter > div {
+  height: 100%;
+  background: linear-gradient(135deg, #6d8cff, #71e0ff);
+  border-radius: 999px;
+}
+
+.insight-footnote {
+  margin: 0;
+  color: rgba(200, 206, 255, 0.62);
+  font-size: 13px;
+}
+
+.insight-highlight {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.focus-card ul {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: rgba(206, 212, 255, 0.78);
+}
+
+.focus-card li {
+  line-height: 1.4;
+}
+
+@media (max-width: 1280px) {
+  .nofap-content {
+    grid-template-columns: 1fr;
+  }
+
+  .insights-column {
+    flex-direction: row;
+    overflow: visible;
+  }
+
+  .insight-card {
+    flex: 1;
+  }
+}
+
+@media (max-width: 900px) {
+  .nofap-shell {
+    padding: 24px 20px;
+  }
+
+  .nofap-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header-metrics {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .streak-card {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .streak-heart {
+    justify-self: center;
+  }
+
+  .streak-actions {
+    justify-content: center;
+  }
 }

--- a/src/NofapCalendar.jsx
+++ b/src/NofapCalendar.jsx
@@ -1,319 +1,725 @@
-import React, { useState, useEffect } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import './nofap-calendar.css';
 import RunEndModal from './RunEndModal.jsx';
 import { supabaseClient } from './supabaseClient';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const HEATMAP_DAYS = 365;
+
+const defaultStats = {
+  runCount: 0,
+  longest: 0,
+  relapses: 0,
+  victories: 0,
+};
+
+const safeParse = (key, fallback) => {
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) return fallback;
+    const parsed = JSON.parse(stored);
+    return parsed ?? fallback;
+  } catch (error) {
+    console.warn(`Failed to parse ${key} from storage`, error);
+    return fallback;
+  }
+};
+
+const startOfDay = (timestamp) => {
+  const d = new Date(Number(timestamp));
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+};
+
+const colorForIndex = (idx) => {
+  const day = idx + 1;
+  if (day <= 7) return 'green';
+  if (day <= 15) return 'yellow';
+  if (day <= 30) return 'orange';
+  if (day <= 45) return 'blue';
+  if (day <= 60) return 'purple';
+  if (day <= 90) return 'red';
+  return 'white';
+};
+
+const mapRemoteRun = (remote) => ({
+  id: remote.id ?? null,
+  start: Number(remote.start),
+  end: remote.end ? Number(remote.end) : null,
+  relapsed: Boolean(remote.relapsed),
+  reason: remote.reason ?? '',
+  relapseTime: remote.relapse_time ?? '',
+});
+
+const formatDuration = (ms) => {
+  if (!ms || ms <= 0) {
+    return '0d 0h 0m';
+  }
+  const days = Math.floor(ms / DAY_MS);
+  const hours = Math.floor((ms % DAY_MS) / (1000 * 60 * 60));
+  const minutes = Math.floor((ms % (1000 * 60 * 60)) / (1000 * 60));
+  return `${days}d ${hours}h ${minutes}m`;
+};
+
+const formatDateRange = (start, end) => {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const format = (date) =>
+    `${date.getDate()} ${date.toLocaleString('default', {
+      month: 'long',
+    })} ${date.getFullYear()}`;
+  return `${format(startDate)} → ${format(endDate)}`;
+};
 
 export default function NofapCalendar({ onBack }) {
-  const [run, setRun] = useState(() => {
-    const stored = localStorage.getItem('nofapRun');
-    return stored ? JSON.parse(stored) : null;
-  });
-  const [statuses, setStatuses] = useState(() => {
-    const stored = localStorage.getItem('nofapStatuses');
-    return stored ? JSON.parse(stored) : {};
-  });
-  const [stats, setStats] = useState(() => {
-    const stored = localStorage.getItem('nofapStats');
-    return stored ? JSON.parse(stored) : { runCount: 0, longest: 0 };
-  });
-  const [now, setNow] = useState(Date.now());
+  const [run, setRun] = useState(() => safeParse('nofapRun', null));
+  const [runs, setRuns] = useState(() => safeParse('nofapRuns', []));
+  const [statuses, setStatuses] = useState(() => safeParse('nofapStatuses', {}));
+  const [stats, setStats] = useState(() => safeParse('nofapStats', defaultStats));
+  const [now, setNow] = useState(() => Date.now());
   const [userId, setUserId] = useState(null);
-  const [runs, setRuns] = useState(() => {
-    const stored = localStorage.getItem('nofapRuns');
-    return stored ? JSON.parse(stored) : [];
-  });
   const [showEndModal, setShowEndModal] = useState(false);
   const [endType, setEndType] = useState('end');
+  const [lastOutcome, setLastOutcome] = useState(null);
+
+  const pendingRunSyncRef = useRef(null);
+  const runRef = useRef(run);
+
+  useEffect(() => {
+    runRef.current = run;
+  }, [run]);
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 60 * 1000);
     return () => clearInterval(id);
   }, []);
 
+  const saveRun = useCallback((updater) => {
+    setRun((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      if (next) {
+        localStorage.setItem('nofapRun', JSON.stringify(next));
+      } else {
+        localStorage.removeItem('nofapRun');
+      }
+      return next;
+    });
+  }, []);
+
+  const saveRuns = useCallback((updater) => {
+    setRuns((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      localStorage.setItem('nofapRuns', JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  const saveStatuses = useCallback((next) => {
+    setStatuses(next);
+    localStorage.setItem('nofapStatuses', JSON.stringify(next));
+  }, []);
+
+  const saveStats = useCallback((next) => {
+    setStats(next);
+    localStorage.setItem('nofapStats', JSON.stringify(next));
+  }, []);
+
   useEffect(() => {
-    const fetchRuns = async () => {
+    if (!runs.length) {
+      saveStatuses({});
+      saveStats(defaultStats);
+      return;
+    }
+
+    const updated = {};
+    let longest = 0;
+    let relapses = 0;
+
+    const ordered = [...runs].sort((a, b) => a.start - b.start);
+    ordered.forEach((entry) => {
+      if (!entry.end) return;
+      const startDay = startOfDay(entry.start);
+      const endDay = startOfDay(entry.end);
+      const duration = endDay - startDay + DAY_MS;
+      longest = Math.max(longest, duration);
+      if (entry.relapsed) relapses += 1;
+
+      let idx = 0;
+      for (let ts = startDay; ts <= endDay; ts += DAY_MS, idx += 1) {
+        const key = new Date(ts).toISOString().slice(0, 10);
+        if (entry.relapsed && ts === endDay) {
+          updated[key] = 'relapse';
+        } else if (!updated[key]) {
+          updated[key] = colorForIndex(idx);
+        }
+      }
+    });
+
+    saveStatuses(updated);
+    saveStats({
+      runCount: ordered.length,
+      longest,
+      relapses,
+      victories: ordered.length - relapses,
+    });
+  }, [runs, saveStats, saveStatuses]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const hydrateFromRemote = async () => {
       if (!navigator.onLine) return;
       const {
         data: { user },
       } = await supabaseClient.auth.getUser();
-      if (!user) return;
+      if (!user || cancelled) return;
       setUserId(user.id);
-      const { data } = await supabaseClient
+
+      const { data, error } = await supabaseClient
         .from('runs')
-        .select('*')
+        .select('id, start, end, relapsed, reason, relapse_time')
         .eq('user_id', user.id);
-      if (data) {
-        const active = data.find((r) => r.end === null);
-        const completed = data.filter((r) => r.end !== null);
-        if (active) {
-          saveRun({ id: active.id, start: active.start });
-        }
-        if (completed.length) {
-          const mapped = completed.map((r) => ({
-            id: r.id,
-            start: r.start,
-            end: r.end,
-            relapsed: r.relapsed,
-            reason: r.reason,
-            relapseTime: r.relapse_time,
-          }));
-          setRuns((prev) => {
-            const byId = {};
-            [...prev, ...mapped].forEach((run) => {
-              const key = run.id || `start_${run.start}`;
-              byId[key] = { ...byId[key], ...run };
-            });
-            const list = Object.values(byId).sort((a, b) => a.start - b.start);
-            localStorage.setItem('nofapRuns', JSON.stringify(list));
-            return list;
-          });
-        }
+
+      if (error || !data || cancelled) {
+        return;
       }
-    };
-    fetchRuns();
-  }, []);
 
-  const saveRun = (r) => {
-    if (r) {
-      localStorage.setItem('nofapRun', JSON.stringify(r));
-    } else {
-      localStorage.removeItem('nofapRun');
-    }
-    setRun(r);
-  };
+      const completed = [];
+      let freshestActive = null;
 
-  const saveRuns = (list) => {
-    setRuns(list);
-    localStorage.setItem('nofapRuns', JSON.stringify(list));
-  };
-
-  const saveStatuses = (s) => {
-    setStatuses(s);
-    localStorage.setItem('nofapStatuses', JSON.stringify(s));
-  };
-
-  const saveStats = (s) => {
-    setStats(s);
-    localStorage.setItem('nofapStats', JSON.stringify(s));
-  };
-
-  useEffect(() => {
-    const compute = () => {
-      const updated = {};
-      let longest = 0;
-      const ordered = [...runs].sort((a, b) => a.start - b.start);
-      ordered.forEach((r) => {
-        const startDay = new Date(r.start);
-        startDay.setHours(0, 0, 0, 0);
-        const endDay = new Date(r.end);
-        endDay.setHours(0, 0, 0, 0);
-        for (
-          let d = new Date(startDay), idx = 0;
-          d <= endDay;
-          d.setDate(d.getDate() + 1), idx++
+      data.forEach((remote) => {
+        const mapped = mapRemoteRun(remote);
+        if (mapped.end) {
+          completed.push(mapped);
+        } else if (
+          !freshestActive ||
+          (mapped.start && mapped.start > freshestActive.start)
         ) {
-          const key = d.toISOString().slice(0, 10);
-          const isRelapseDay = r.relapsed && d.getTime() === endDay.getTime();
-          if (isRelapseDay) {
-            updated[key] = 'relapse';
-          } else if (!updated[key]) {
-            updated[key] = colorForIndex(idx);
-          }
+          freshestActive = mapped;
         }
-        longest = Math.max(longest, r.end - r.start);
       });
-      saveStatuses(updated);
-      saveStats({ runCount: runs.length, longest });
-    };
-    compute();
-  }, [runs]);
 
-  const startRun = async () => {
-    const newRun = { start: Date.now() };
-    if (userId && navigator.onLine) {
-      const { data } = await supabaseClient
-        .from('runs')
-        .insert({ user_id: userId, start: newRun.start })
-        .select()
-        .single();
-      if (data) newRun.id = data.id;
-    }
-    saveRun(newRun);
-  };
-
-  const requestFinish = (type) => {
-    setEndType(type);
-    setShowEndModal(true);
-  };
-
-  const colorForIndex = (idx) => {
-    const day = idx + 1;
-    if (day <= 7) return 'green';
-    if (day <= 15) return 'yellow';
-    if (day <= 30) return 'orange';
-    if (day <= 45) return 'blue';
-    if (day <= 60) return 'purple';
-    if (day <= 90) return 'red';
-    return 'white';
-  };
-
-  const finishRun = async (reason, relapseTime) => {
-    if (!run) return;
-    const relapsed = endType === 'relapse';
-    const nowTime = Date.now();
-    const entry = { ...run, end: nowTime, relapsed, reason };
-    if (relapsed) entry.relapseTime = relapseTime;
-    if (userId && navigator.onLine) {
-      if (run.id) {
-        await supabaseClient
-          .from('runs')
-          .update({ end: nowTime, relapsed, reason, relapse_time: relapseTime })
-          .eq('id', run.id);
-      } else {
-        await supabaseClient.from('runs').insert({
-          user_id: userId,
-          start: run.start,
-          end: nowTime,
-          relapsed,
-          reason,
-          relapse_time: relapseTime,
+      if (!cancelled && completed.length) {
+        saveRuns((prev) => {
+          const byKey = new Map();
+          [...prev, ...completed].forEach((item) => {
+            const key = item.id || item.start;
+            const normalized = {
+              ...item,
+              end: item.end,
+            };
+            byKey.set(key, normalized);
+          });
+          return Array.from(byKey.values()).sort((a, b) => a.start - b.start);
         });
       }
+
+      if (cancelled) return;
+
+      if (freshestActive) {
+        saveRun((current) => {
+          if (current && current.start === freshestActive.start) {
+            return { ...current, id: freshestActive.id };
+          }
+          if (!current || freshestActive.start > (current?.start || 0)) {
+            return {
+              id: freshestActive.id,
+              start: freshestActive.start,
+            };
+          }
+          return current;
+        });
+      } else {
+        saveRun((current) => {
+          if (!current) return current;
+          const remotelyClosed = completed.some(
+            (item) => item.start === current.start && item.end
+          );
+          return remotelyClosed ? null : current;
+        });
+      }
+    };
+
+    hydrateFromRemote();
+    return () => {
+      cancelled = true;
+    };
+  }, [saveRun, saveRuns]);
+
+  const ensureRemoteRunId = useCallback(
+    async (candidateRun) => {
+      if (!candidateRun || !userId || !navigator.onLine) {
+        return null;
+      }
+
+      if (candidateRun.id) return candidateRun.id;
+
+      if (pendingRunSyncRef.current) {
+        try {
+          const { data } = await pendingRunSyncRef.current;
+          if (data?.id) {
+            saveRun((current) => {
+              if (current && current.start === candidateRun.start) {
+                return { ...current, id: data.id };
+              }
+              return current;
+            });
+            return data.id;
+          }
+        } catch (error) {
+          console.warn('Pending run sync failed', error);
+        }
+      }
+
+      const { data } = await supabaseClient
+        .from('runs')
+        .select('id, start')
+        .eq('user_id', userId)
+        .eq('start', candidateRun.start)
+        .limit(1)
+        .maybeSingle();
+
+      if (data?.id) {
+        saveRun((current) => {
+          if (current && current.start === candidateRun.start) {
+            return { ...current, id: data.id };
+          }
+          return current;
+        });
+        return data.id;
+      }
+
+      return null;
+    },
+    [saveRun, userId]
+  );
+
+  const startRun = useCallback(async () => {
+    const startTimestamp = Date.now();
+    const newRun = { start: startTimestamp };
+    saveRun(newRun);
+
+    if (userId && navigator.onLine) {
+      const syncPromise = supabaseClient
+        .from('runs')
+        .insert({ user_id: userId, start: startTimestamp })
+        .select()
+        .single();
+
+      pendingRunSyncRef.current = syncPromise;
+
+      try {
+        const { data } = await syncPromise;
+        if (data?.id) {
+          saveRun((current) => {
+            if (current && current.start === startTimestamp) {
+              return { ...current, id: data.id };
+            }
+            return current;
+          });
+        }
+      } catch (error) {
+        console.warn('Failed to sync started run', error);
+      } finally {
+        pendingRunSyncRef.current = null;
+      }
     }
-    const newRuns = [...runs, entry];
-    saveRuns(newRuns);
-    saveRun(null);
-    setShowEndModal(false);
-  };
+  }, [saveRun, userId]);
 
-  const daysSinceStart = run
-    ? Math.max(0, Math.floor((now - run.start) / DAY_MS))
-    : 0;
-  const hoursSinceStart = run
-    ? Math.max(0, Math.floor((now - run.start) / (1000 * 60 * 60)) % 24)
-    : 0;
-  const minutesSinceStart = run
-    ? Math.max(0, Math.floor((now - run.start) / (1000 * 60)) % 60)
-    : 0;
+  const requestFinish = useCallback((type) => {
+    setEndType(type);
+    setShowEndModal(true);
+  }, []);
 
-  const generateDates = (num) => {
+  const finishRun = useCallback(
+    async (reason, relapseTime) => {
+      const activeRun = runRef.current;
+      if (!activeRun) return;
+
+      const relapsed = endType === 'relapse';
+      const trimmedReason = reason?.trim() ?? '';
+      const finishedAt = Date.now();
+
+      let runId = null;
+      try {
+        runId = await ensureRemoteRunId(activeRun);
+      } catch (error) {
+        console.warn('Failed to ensure remote run id', error);
+      }
+
+      if (userId && navigator.onLine) {
+        const payload = {
+          end: finishedAt,
+          relapsed,
+          reason: trimmedReason,
+          relapse_time: relapsed ? relapseTime : null,
+        };
+        try {
+          if (runId) {
+            await supabaseClient.from('runs').update(payload).eq('id', runId);
+          } else {
+            await supabaseClient.from('runs').insert({
+              user_id: userId,
+              start: activeRun.start,
+              ...payload,
+            });
+          }
+        } catch (error) {
+          console.error('Failed to sync finished run', error);
+        }
+      }
+
+      const completedEntry = {
+        ...activeRun,
+        id: runId || activeRun.id || null,
+        end: finishedAt,
+        relapsed,
+        reason: trimmedReason,
+        relapseTime: relapsed ? relapseTime : undefined,
+      };
+
+      saveRuns((prev) => {
+        const filtered = prev.filter((r) => r.start !== activeRun.start);
+        const merged = [...filtered, completedEntry].sort(
+          (a, b) => a.start - b.start
+        );
+        return merged;
+      });
+
+      saveRun(null);
+      setLastOutcome({
+        relapsed,
+        finishedAt,
+      });
+      setShowEndModal(false);
+    },
+    [endType, ensureRemoteRunId, saveRun, saveRuns, userId]
+  );
+
+  const daysSinceStart = useMemo(() => {
+    if (!run) return 0;
+    return Math.max(0, Math.floor((now - run.start) / DAY_MS));
+  }, [now, run]);
+
+  const currentStreakMs = useMemo(() => {
+    if (!run) return 0;
+    return Math.max(0, now - run.start);
+  }, [now, run]);
+
+  const longestStreakMs = stats.longest || 0;
+
+  const recentRuns = useMemo(() => {
+    if (!runs.length) return [];
+    const sorted = [...runs]
+      .filter((entry) => entry.end)
+      .sort((a, b) => b.end - a.end);
+    return sorted.slice(0, 5);
+  }, [runs]);
+
+  const lastRelapse = useMemo(() => {
+    const relapseRun = [...runs]
+      .filter((entry) => entry.relapsed)
+      .sort((a, b) => b.end - a.end)[0];
+    if (!relapseRun) return null;
+    return relapseRun.end;
+  }, [runs]);
+
+  const dayLabels = useMemo(
+    () => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    []
+  );
+
+  const heatmapData = useMemo(() => {
     const dates = [];
     const start = new Date();
-    start.setDate(start.getDate() - (num - 1));
+    start.setDate(start.getDate() - (HEATMAP_DAYS - 1));
     start.setHours(0, 0, 0, 0);
-    for (let i = 0; i < num; i++) {
-      const d = new Date(start);
-      d.setDate(start.getDate() + i);
-      dates.push(d);
+
+    for (let i = 0; i < HEATMAP_DAYS; i += 1) {
+      dates.push(new Date(start.getTime() + i * DAY_MS));
     }
-    return dates;
-  };
 
-  const allDates = generateDates(365); // last year
-  const weeks = [];
-  for (let i = 0; i < allDates.length; i += 7) {
-    weeks.push(allDates.slice(i, i + 7));
-  }
+    const weeks = [];
+    for (let i = 0; i < dates.length; i += 7) {
+      weeks.push(dates.slice(i, i + 7));
+    }
 
-  const monthLabels = weeks.map((week, idx) => {
-    const month = week[0].toLocaleString('default', { month: 'short' });
-    if (idx === 0) return month;
-    const prev = weeks[idx - 1][0].toLocaleString('default', { month: 'short' });
-    return month === prev ? '' : month;
-  });
+    const monthLabels = weeks.map((week, idx) => {
+      const month = week[0].toLocaleString('default', { month: 'short' });
+      if (idx === 0) return month;
+      const prev = weeks[idx - 1][0].toLocaleString('default', {
+        month: 'short',
+      });
+      return month === prev ? '' : month;
+    });
 
-  const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    return { weeks, monthLabels };
+  }, []);
 
-  const startOfDay = (t) => {
-    const d = new Date(t);
-    d.setHours(0, 0, 0, 0);
-    return d.getTime();
-  };
+  const getDayClass = useCallback(
+    (date) => {
+      const key = date.toISOString().slice(0, 10);
+      if (statuses[key]) return `day ${statuses[key]}`;
 
-  const getDayClass = (date) => {
-    const key = date.toISOString().slice(0, 10);
-    if (statuses[key]) return statuses[key];
-    if (!run) return '';
-    const runStartDay = startOfDay(run.start);
-    const dateDay = startOfDay(date);
-    const currentDay = startOfDay(now);
-    if (dateDay < runStartDay || dateDay > currentDay) return '';
-    const dayIndex = Math.floor((dateDay - runStartDay) / DAY_MS);
-    return colorForIndex(dayIndex);
-  };
+      if (run) {
+        const runStartDay = startOfDay(run.start);
+        const dateDay = startOfDay(date.getTime());
+        const currentDay = startOfDay(now);
+        if (dateDay >= runStartDay && dateDay <= currentDay) {
+          const dayIndex = Math.floor((dateDay - runStartDay) / DAY_MS);
+          if (dayIndex >= 0) return `day active-run ${colorForIndex(dayIndex)}`;
+        }
+      }
+
+      const today = startOfDay(Date.now());
+      if (startOfDay(date.getTime()) === today) {
+        return 'day today';
+      }
+
+      return 'day';
+    },
+    [now, run, statuses]
+  );
 
   return (
-    <div className="nofap-calendar">
-      <button className="back-button" onClick={onBack}>
-        Back
-      </button>
-      {run ? (
-        <>
-          <div className="streak">
-            Streak: {daysSinceStart}d {hoursSinceStart}h {minutesSinceStart}m
+    <div className="nofap-shell">
+      <header className="nofap-header">
+        <div className="header-left">
+          <button type="button" className="back-button" onClick={onBack}>
+            Back
+          </button>
+          <div>
+            <h1>NoFap Lab</h1>
+            <p>
+              Keep shaping the contribution heart. Every day logged builds a
+              stronger baseline.
+            </p>
           </div>
-          <div className="stats-line">
-            Runs: {stats.runCount} | Longest: {Math.floor(stats.longest / DAY_MS)}d {Math.floor(stats.longest / (1000 * 60 * 60)) % 24}h {Math.floor(stats.longest / (1000 * 60)) % 60}m
+        </div>
+        <div className="header-metrics">
+          <div className="metric-card">
+            <span className="metric-label">Current streak</span>
+            <strong className="metric-value">
+              {formatDuration(currentStreakMs)}
+            </strong>
           </div>
-          <div className="month-labels">
-            {monthLabels.map((m, idx) => (
-              <span key={idx} className="month-label">
-                {m}
-              </span>
-            ))}
+          <div className="metric-card">
+            <span className="metric-label">Best streak</span>
+            <strong className="metric-value">
+              {formatDuration(longestStreakMs)}
+            </strong>
           </div>
-          <div style={{ display: 'flex' }}>
-            <div className="day-labels">
-              {dayLabels.map((d, idx) => (
-                <span key={idx}>{[1,3,5].includes(idx) ? d.slice(0,3) : ''}</span>
-              ))}
+          <div className="metric-card">
+            <span className="metric-label">Runs logged</span>
+            <strong className="metric-value">{stats.runCount}</strong>
+          </div>
+        </div>
+      </header>
+
+      {lastOutcome && (
+        <div className={`outcome-banner ${lastOutcome.relapsed ? 'relapse' : 'victory'}`}>
+          {lastOutcome.relapsed
+            ? 'Relapse captured. The slate is clean—start a new run when ready.'
+            : 'Run archived as a victory. Celebrate the progress!'}
+        </div>
+      )}
+
+      <section className="nofap-content">
+        <div className="main-column">
+          <div className="streak-card">
+            <div className="streak-heart" aria-hidden="true">
+              ❤️
             </div>
-            <div className="calendar-grid">
-              {weeks.map((week, wi) => (
-                <div key={wi} className="week">
-                  {week.map((date) => (
-                    <div
-                      key={date.toISOString()}
-                      className={`day ${getDayClass(date)}`}
-                    />
+            <div className="streak-details">
+              {run ? (
+                <>
+                  <h2>Active streak</h2>
+                  <p>
+                    {daysSinceStart} days in. Stay focused—the contribution
+                    heart glows brighter with each win.
+                  </p>
+                  <div className="streak-count">
+                    <span>{formatDuration(currentStreakMs)}</span>
+                  </div>
+                  <div className="streak-actions">
+                    <button
+                      type="button"
+                      className="pill-button"
+                      onClick={() => requestFinish('end')}
+                    >
+                      Mark Completed
+                    </button>
+                    <button
+                      type="button"
+                      className="pill-button danger"
+                      onClick={() => requestFinish('relapse')}
+                    >
+                      Log Relapse
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <h2>No active streak</h2>
+                  <p>
+                    Press the spark to begin a fresh journey and grow the
+                    grid.
+                  </p>
+                  <button
+                    type="button"
+                    className="pill-button primary"
+                    onClick={startRun}
+                  >
+                    Start New Run
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="heatmap-card">
+            <div className="heatmap-header">
+              <div>
+                <h2>Contribution Heart</h2>
+                <p>
+                  A GitHub-style snapshot of the past year. Darker squares
+                  represent longer streak segments, while ✕ marks relapses.
+                </p>
+              </div>
+              <div className="legend">
+                {['green', 'yellow', 'orange', 'blue', 'purple', 'red', 'white'].map(
+                  (color) => (
+                    <span key={color} className={`legend-chip ${color}`} />
+                  )
+                )}
+                <span className="legend-label">Intensity</span>
+              </div>
+            </div>
+            <div className="heatmap-grid">
+              <div className="month-labels">
+                {heatmapData.monthLabels.map((label, idx) => (
+                  <span key={idx} className="month-label">
+                    {label}
+                  </span>
+                ))}
+              </div>
+              <div className="grid-wrapper">
+                <div className="day-labels">
+                  {dayLabels.map((label, idx) => (
+                    <span key={label}>
+                      {[1, 3, 5].includes(idx) ? label.slice(0, 3) : ''}
+                    </span>
                   ))}
                 </div>
-              ))}
+                <div className="calendar-grid">
+                  {heatmapData.weeks.map((week, wi) => (
+                    <div key={`week-${wi}`} className="week">
+                      {week.map((date) => (
+                        <div
+                          key={date.toISOString()}
+                          className={getDayClass(date)}
+                          title={date.toDateString()}
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
-          <div className="actions">
-            <button className="action-button" onClick={() => requestFinish('end')}>
-              End Run
-            </button>
-            <button className="action-button" onClick={() => requestFinish('relapse')}>
-              Relapse
-            </button>
+
+          <div className="runs-card">
+            <h2>Recent runs</h2>
+            {recentRuns.length ? (
+              <ul className="runs-timeline">
+                {recentRuns.map((entry) => (
+                  <li key={entry.start}>
+                    <div className="timeline-header">
+                      <span className={`status-dot ${entry.relapsed ? 'relapse' : 'victory'}`} />
+                      <strong>{formatDateRange(entry.start, entry.end)}</strong>
+                    </div>
+                    <div className="timeline-body">
+                      <span className="duration">{formatDuration(entry.end - entry.start)}</span>
+                      {entry.reason && (
+                        <p className="reason">{entry.reason}</p>
+                      )}
+                      {entry.relapseTime && (
+                        <p className="reason subtle">Relapse at {entry.relapseTime}</p>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="empty-state">
+                No runs logged yet. Start one and your history will live here.
+              </p>
+            )}
           </div>
-        </>
-      ) : (
-        <>
-          <div className="stats-line">
-            Runs: {stats.runCount} | Longest: {Math.floor(stats.longest / DAY_MS)}d {Math.floor(stats.longest / (1000 * 60 * 60)) % 24}h {Math.floor(stats.longest / (1000 * 60)) % 60}m
-          </div>
-          <button className="action-button" onClick={startRun}>
-            Start Run
-          </button>
-        </>
-      )}
-      <h3>Runs</h3>
-      <div className="runs-list">
-        {runs.map((r, idx) => (
-          <div key={idx} className="run-banner">
-            <div>
-              {new Date(r.start).getDate()} {new Date(r.start).toLocaleString('default', { month: 'long' })} {new Date(r.start).getFullYear()} to {new Date(r.end).getDate()} {new Date(r.end).toLocaleString('default', { month: 'long' })} {new Date(r.end).getFullYear()}, {Math.ceil((r.end - r.start) / DAY_MS)} days
+        </div>
+
+        <aside className="insights-column">
+          <div className="insight-card">
+            <h3>Momentum</h3>
+            <div className="insight-metric">
+              <span className="label">Victories</span>
+              <strong>{stats.victories}</strong>
             </div>
-            <div>Reason: {r.reason || 'N/A'}</div>
-            {r.relapseTime && <div>Relapse at: {r.relapseTime}</div>}
+            <div className="insight-metric">
+              <span className="label">Relapses</span>
+              <strong>{stats.relapses}</strong>
+            </div>
+            <div className="insight-meter" role="progressbar" aria-valuemin={0} aria-valuemax={Math.max(stats.victories + stats.relapses, 1)} aria-valuenow={stats.victories}>
+              <div
+                style={{
+                  width: `${Math.min(
+                    100,
+                    stats.runCount
+                      ? Math.round((stats.victories / stats.runCount) * 100)
+                      : 0
+                  )}%`,
+                }}
+              />
+            </div>
+            <p className="insight-footnote">
+              {stats.runCount ? (
+                <>
+                  {Math.round((stats.victories / stats.runCount) * 100)}% of runs ended
+                  as victories.
+                </>
+              ) : (
+                'Log your first run to see momentum insights.'
+              )}
+            </p>
           </div>
-        ))}
-      </div>
+
+          <div className="insight-card">
+            <h3>Last relapse</h3>
+            {lastRelapse ? (
+              <p className="insight-highlight">
+                {new Date(lastRelapse).toLocaleString()}
+              </p>
+            ) : (
+              <p className="empty-state">No relapses on record. Keep it going!</p>
+            )}
+          </div>
+
+          <div className="insight-card focus-card">
+            <h3>Keep the heart glowing</h3>
+            <ul>
+              <li>Stack micro-wins every day to deepen the gradient.</li>
+              <li>Journal the reason after each run to spot patterns.</li>
+              <li>Use relapses as data—log them immediately, then reset.</li>
+            </ul>
+          </div>
+        </aside>
+      </section>
+
       {showEndModal && (
         <RunEndModal
           type={endType}


### PR DESCRIPTION
## Summary
- revamp the NoFap lab header and streak card with celestial styling and aurora-inspired language
- replace the contribution heart copy with an "Aurora Field" presentation while keeping the heatmap visualization
- ensure recent runs stay within view using a scrollable pane and add airy glassmorphism treatments throughout

## Testing
- npm test
- npm run build