### PR TITLE
feat: infuse NoFap lab with celestial UI

### DIFF
--- a/nofap-calendar.css
+++ b/nofap-calendar.css
@@ -31,24 +31,47 @@
   border-radius: 12px;
   padding: 10px 18px;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .back-button:hover {
   background: rgba(108, 118, 235, 0.3);
   border-color: rgba(134, 142, 255, 0.7);
+  transform: translateY(-1px);
+}
+
+.header-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.celestial-pill {
+  align-self: flex-start;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(123, 162, 255, 0.6), rgba(140, 247, 255, 0.45));
+  color: rgba(15, 18, 35, 0.72);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 8px 18px rgba(69, 124, 255, 0.35);
 }
 
 .nofap-header h1 {
-  margin: 0 0 6px;
-  font-size: 32px;
+  margin: 0;
+  font-size: 34px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #f8f6ff;
 }
 
 .nofap-header p {
   margin: 0;
-  max-width: 420px;
-  color: rgba(219, 224, 255, 0.8);
-  line-height: 1.5;
+  max-width: 460px;
+  color: rgba(219, 224, 255, 0.82);
+  line-height: 1.6;
+  font-size: 15px;
 }
 
 .header-metrics {
@@ -116,33 +139,36 @@
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 24px;
-  padding: 24px 28px;
-  border-radius: 20px;
-  border: 1px solid rgba(125, 134, 247, 0.25);
-  background: linear-gradient(120deg, rgba(36, 38, 68, 0.85), rgba(20, 22, 46, 0.9));
-  box-shadow: 0 18px 32px rgba(10, 12, 36, 0.5);
+  padding: 28px 32px;
+  border-radius: 24px;
+  border: 1px solid rgba(150, 186, 255, 0.22);
+  background:
+    linear-gradient(140deg, rgba(55, 60, 120, 0.5), rgba(35, 38, 98, 0.85)),
+    radial-gradient(circle at top left, rgba(119, 209, 255, 0.18), transparent 55%);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 30px 60px rgba(8, 10, 44, 0.46);
 }
 
 .streak-heart {
-  font-size: 56px;
-  filter: drop-shadow(0 12px 24px rgba(255, 70, 110, 0.35));
+  font-size: 60px;
+  filter: drop-shadow(0 18px 36px rgba(143, 179, 255, 0.5));
   align-self: center;
 }
 
 .streak-details h2 {
-  margin: 0 0 6px;
-  font-size: 24px;
+  margin: 0 0 10px;
+  font-size: 26px;
 }
 
 .streak-details p {
   margin: 0;
-  color: rgba(212, 218, 255, 0.78);
-  line-height: 1.5;
+  color: rgba(212, 218, 255, 0.82);
+  line-height: 1.6;
 }
 
 .streak-count {
-  margin-top: 16px;
-  font-size: 20px;
+  margin-top: 18px;
+  font-size: 22px;
   font-weight: 600;
   color: #fcefff;
 }
@@ -190,11 +216,38 @@
 .heatmap-card,
 .runs-card,
 .insight-card {
-  background: rgba(26, 28, 56, 0.88);
+  background: rgba(26, 28, 56, 0.74);
   border: 1px solid rgba(118, 124, 230, 0.28);
-  border-radius: 20px;
-  padding: 22px 26px;
-  box-shadow: 0 18px 30px rgba(9, 11, 30, 0.55);
+  border-radius: 22px;
+  padding: 24px 28px;
+  box-shadow: 0 24px 44px rgba(9, 11, 38, 0.55);
+  backdrop-filter: blur(10px);
+}
+
+.aurora-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.aurora-card::before {
+  content: '';
+  position: absolute;
+  inset: -40% -30% 50% -30%;
+  background: conic-gradient(
+    from 120deg,
+    rgba(120, 245, 255, 0.25),
+    rgba(151, 114, 255, 0.18),
+    rgba(102, 219, 255, 0.3),
+    rgba(120, 245, 255, 0.25)
+  );
+  opacity: 0.7;
+  filter: blur(40px);
+  pointer-events: none;
+}
+
+.aurora-card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .heatmap-header {
@@ -217,6 +270,11 @@
   display: flex;
   gap: 8px;
   align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(30, 36, 80, 0.55);
+  border: 1px solid rgba(140, 147, 255, 0.28);
+  backdrop-filter: blur(8px);
 }
 
 .legend-chip {
@@ -252,7 +310,7 @@
   display: grid;
   grid-template-columns: repeat(53, 16px);
   gap: 3px;
-  margin-left: 38px;
+  margin-left: 44px;
   font-size: 12px;
   color: rgba(190, 196, 245, 0.72);
 }
@@ -289,9 +347,10 @@
 .day {
   width: 16px;
   height: 16px;
-  border-radius: 3px;
+  border-radius: 6px;
   background: rgba(52, 54, 84, 0.65);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border 0.15s ease;
+  border: 1px solid rgba(126, 132, 198, 0.22);
 }
 
 .day.active-run {
@@ -324,8 +383,31 @@
   box-shadow: 0 8px 14px rgba(10, 14, 46, 0.5);
 }
 
+.runs-card {
+  display: flex;
+  flex-direction: column;
+  max-height: 320px;
+}
+
 .runs-card h2 {
   margin: 0 0 14px;
+}
+
+.runs-scroll {
+  overflow-y: auto;
+  padding-right: 6px;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(118, 124, 230, 0.5) transparent;
+}
+
+.runs-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.runs-scroll::-webkit-scrollbar-thumb {
+  background: rgba(118, 124, 230, 0.5);
+  border-radius: 999px;
 }
 
 .runs-timeline {
@@ -354,7 +436,8 @@
   width: 12px;
   height: 12px;
   border-radius: 6px;
-  background: #63e6be;
+  background: linear-gradient(135deg, #63e6be, #37d3ac);
+  box-shadow: 0 0 12px rgba(67, 230, 190, 0.55);
 }
 
 .status-dot.relapse {
@@ -400,6 +483,8 @@
 
 .insight-card h3 {
   margin: 0 0 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .insight-metric {
@@ -440,7 +525,7 @@
   padding-left: 18px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   color: rgba(206, 212, 255, 0.78);
 }
 

--- a/src/NofapCalendar.jsx
+++ b/src/NofapCalendar.jsx
@@ -493,11 +493,12 @@ export default function NofapCalendar({ onBack }) {
           <button type="button" className="back-button" onClick={onBack}>
             Back
           </button>
-          <div>
-            <h1>NoFap Lab</h1>
+          <div className="header-copy">
+            <span className="celestial-pill">Celestial mode</span>
+            <h1>Celestial NoFap Lab</h1>
             <p>
-              Keep shaping the contribution heart. Every day logged builds a
-              stronger baseline.
+              Lift your streak into the aurora—each check-in leaves light across
+              the maze of stars.
             </p>
           </div>
         </div>
@@ -533,15 +534,15 @@ export default function NofapCalendar({ onBack }) {
         <div className="main-column">
           <div className="streak-card">
             <div className="streak-heart" aria-hidden="true">
-              ❤️
+              ✶
             </div>
             <div className="streak-details">
               {run ? (
                 <>
                   <h2>Active streak</h2>
                   <p>
-                    {daysSinceStart} days in. Stay focused—the contribution
-                    heart glows brighter with each win.
+                    {daysSinceStart} days in. Stay focused—the aurora brightens
+                    with every micro-win.
                   </p>
                   <div className="streak-count">
                     <span>{formatDuration(currentStreakMs)}</span>
@@ -582,13 +583,13 @@ export default function NofapCalendar({ onBack }) {
             </div>
           </div>
 
-          <div className="heatmap-card">
+          <div className="heatmap-card aurora-card">
             <div className="heatmap-header">
               <div>
-                <h2>Contribution Heart</h2>
+                <h2>Aurora Field</h2>
                 <p>
-                  A GitHub-style snapshot of the past year. Darker squares
-                  represent longer streak segments, while ✕ marks relapses.
+                  Watch the cosmic lattice fill in—intensity reflects the glow
+                  of your streak energy.
                 </p>
               </div>
               <div className="legend">
@@ -636,25 +637,27 @@ export default function NofapCalendar({ onBack }) {
           <div className="runs-card">
             <h2>Recent runs</h2>
             {recentRuns.length ? (
-              <ul className="runs-timeline">
-                {recentRuns.map((entry) => (
-                  <li key={entry.start}>
-                    <div className="timeline-header">
-                      <span className={`status-dot ${entry.relapsed ? 'relapse' : 'victory'}`} />
-                      <strong>{formatDateRange(entry.start, entry.end)}</strong>
-                    </div>
-                    <div className="timeline-body">
-                      <span className="duration">{formatDuration(entry.end - entry.start)}</span>
-                      {entry.reason && (
-                        <p className="reason">{entry.reason}</p>
-                      )}
-                      {entry.relapseTime && (
-                        <p className="reason subtle">Relapse at {entry.relapseTime}</p>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
+              <div className="runs-scroll">
+                <ul className="runs-timeline">
+                  {recentRuns.map((entry) => (
+                    <li key={entry.start}>
+                      <div className="timeline-header">
+                        <span className={`status-dot ${entry.relapsed ? 'relapse' : 'victory'}`} />
+                        <strong>{formatDateRange(entry.start, entry.end)}</strong>
+                      </div>
+                      <div className="timeline-body">
+                        <span className="duration">{formatDuration(entry.end - entry.start)}</span>
+                        {entry.reason && (
+                          <p className="reason">{entry.reason}</p>
+                        )}
+                        {entry.relapseTime && (
+                          <p className="reason subtle">Relapse at {entry.relapseTime}</p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ) : (
               <p className="empty-state">
                 No runs logged yet. Start one and your history will live here.


### PR DESCRIPTION
## Summary
- revamp the NoFap lab header and streak card with celestial styling and aurora-inspired language
- replace the contribution heart copy with an "Aurora Field" presentation while keeping the heatmap visualization
- ensure recent runs stay within view using a scrollable pane and add airy glassmorphism treatments throughout

## Testing
- npm test
- npm run build