### PR TITLE
fix: reset stale TasteT Swiss sessions

### DIFF
--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -74,6 +74,61 @@ export function shouldFinalizeSwissStatus(status) {
   return status === "awaiting-finish" || status === "completed";
 }
 
+export const STALE_SWISS_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+
+function considerTimestamp(latest, value) {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return latest;
+  }
+  if (latest == null) {
+    return value;
+  }
+  return Math.max(latest, value);
+}
+
+function getSwissLastActivityTimestamp(swiss) {
+  if (!swiss || typeof swiss !== "object") {
+    return null;
+  }
+
+  let latest = null;
+  latest = considerTimestamp(latest, swiss.completedAt);
+  latest = considerTimestamp(latest, swiss.createdAt);
+
+  if (Array.isArray(swiss.rounds)) {
+    swiss.rounds.forEach((round) => {
+      latest = considerTimestamp(latest, round?.completedAt);
+      if (Array.isArray(round?.pairings)) {
+        round.pairings.forEach((pair) => {
+          latest = considerTimestamp(latest, pair?.timestamp);
+        });
+      }
+    });
+  }
+
+  if (swiss.finalMatch) {
+    latest = considerTimestamp(latest, swiss.finalMatch.timestamp);
+  }
+
+  if (swiss.finalResult) {
+    latest = considerTimestamp(latest, swiss.finalResult.timestamp);
+  }
+
+  return latest;
+}
+
+export function isSwissSessionStale(swiss, now = Date.now()) {
+  if (!swiss) return false;
+  const lastActivity = getSwissLastActivityTimestamp(swiss);
+  if (lastActivity == null) {
+    return false;
+  }
+  if (now <= lastActivity) {
+    return false;
+  }
+  return now - lastActivity > STALE_SWISS_THRESHOLD_MS;
+}
+
 function coerceLibraryId(value) {
   if (value == null) return null;
   return String(value);
@@ -537,6 +592,10 @@ function prepareStateForStorage(state) {
       swissHistory = [summary, ...swissHistory.filter((entry) => entry.id !== summary.id)].slice(0, HISTORY_LIMIT);
     }
     activeSwiss = finalizedSwiss && finalizedSwiss.status === "completed" ? null : finalizedSwiss;
+  }
+
+  if (activeSwiss && isSwissSessionStale(activeSwiss)) {
+    activeSwiss = null;
   }
 
   return {
@@ -2946,6 +3005,17 @@ function TasteT() {
     }
     finalizeCurrentSwiss();
   }, [activeSwiss, finalizeCurrentSwiss]);
+
+  useEffect(() => {
+    if (!activeSwiss) return;
+    if (!isSwissSessionStale(activeSwiss)) {
+      return;
+    }
+    setActiveSwiss(null);
+    if (mode === "swiss") {
+      setMode("lobby");
+    }
+  }, [activeSwiss, mode]);
 
   const handleCancelSwiss = useCallback(() => {
     setActiveSwiss(null);

--- a/src/__tests__/TasteT.state.test.js
+++ b/src/__tests__/TasteT.state.test.js
@@ -1,4 +1,4 @@
-import { shouldFinalizeSwissStatus } from "../TasteT.jsx";
+import { STALE_SWISS_THRESHOLD_MS, isSwissSessionStale, shouldFinalizeSwissStatus } from "../TasteT.jsx";
 
 describe("TasteT Swiss utilities", () => {
   test("should finalize only awaiting-finish or completed states", () => {
@@ -9,5 +9,55 @@ describe("TasteT Swiss utilities", () => {
     expect(shouldFinalizeSwissStatus("finals")).toBe(false);
     expect(shouldFinalizeSwissStatus(undefined)).toBe(false);
     expect(shouldFinalizeSwissStatus(null)).toBe(false);
+  });
+
+  describe("isSwissSessionStale", () => {
+    const now = 1_700_000_000_000;
+
+    test("returns false when swiss session is missing", () => {
+      expect(isSwissSessionStale(null, now)).toBe(false);
+    });
+
+    test("returns false when there are no timestamps", () => {
+      const swiss = { rounds: [], participants: [] };
+      expect(isSwissSessionStale(swiss, now)).toBe(false);
+    });
+
+    test("returns false when activity is within the staleness window", () => {
+      const recentActivity = now - STALE_SWISS_THRESHOLD_MS + 1_000;
+      const swiss = {
+        createdAt: now - STALE_SWISS_THRESHOLD_MS - 20_000,
+        rounds: [
+          {
+            completedAt: now - STALE_SWISS_THRESHOLD_MS - 5_000,
+            pairings: [{ timestamp: recentActivity - 500 }],
+          },
+        ],
+        finalMatch: { timestamp: recentActivity },
+      };
+      expect(isSwissSessionStale(swiss, now)).toBe(false);
+    });
+
+    test("returns false when current time has not passed last activity", () => {
+      const swiss = {
+        createdAt: now,
+        finalResult: { timestamp: now },
+      };
+      expect(isSwissSessionStale(swiss, now)).toBe(false);
+    });
+
+    test("returns true when last activity exceeds threshold", () => {
+      const staleActivity = now - STALE_SWISS_THRESHOLD_MS - 1_000;
+      const swiss = {
+        createdAt: now - STALE_SWISS_THRESHOLD_MS - 50_000,
+        rounds: [
+          {
+            completedAt: staleActivity,
+            pairings: [{ timestamp: staleActivity }],
+          },
+        ],
+      };
+      expect(isSwissSessionStale(swiss, now)).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- automatically clear out Swiss sessions that have been inactive for more than six hours
- prevent stale Swiss minis from being persisted or restored across reloads
- add unit coverage for the new staleness detection helper

## Testing
- npm test
- npm run build
