### PR TITLE
Add classic canvas layout option to Tools Blog

### DIFF
--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -254,6 +254,7 @@ const buildInitialPosts = () => {
 const VIEW_MODES = {
   LIST: 'list',
   GRID: 'grid',
+  CLASSIC: 'classic',
 };
 
 export default function ToolsBlog({ onBack }) {
@@ -489,6 +490,18 @@ export default function ToolsBlog({ onBack }) {
                   ⧉
                 </span>
               </button>
+              <button
+                type="button"
+                className={`blog-view-button ${viewMode === VIEW_MODES.CLASSIC ? 'blog-view-button--active' : ''}`}
+                onClick={() => handleViewModeChange(VIEW_MODES.CLASSIC)}
+                aria-pressed={viewMode === VIEW_MODES.CLASSIC}
+                aria-label="Show posts on the classic canvas"
+                title="Classic view"
+              >
+                <span className="blog-view-icon" aria-hidden="true">
+                  ✦
+                </span>
+              </button>
             </div>
           </div>
         </div>
@@ -506,6 +519,7 @@ export default function ToolsBlog({ onBack }) {
           const articleClassName = [
             'blog-card',
             viewMode === VIEW_MODES.GRID ? 'blog-card--grid' : '',
+            viewMode === VIEW_MODES.CLASSIC ? 'blog-card--classic' : '',
             isEditing ? 'blog-card--editing' : '',
           ]
             .filter(Boolean)

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -181,6 +181,40 @@
   align-items: start;
 }
 
+.blog-feed--classic {
+  position: relative;
+  max-width: min(1600px, 96vw);
+  margin: 0 auto;
+  padding: clamp(48px, 6vw, 96px);
+  border-radius: 42px;
+  background: radial-gradient(140% 120% at 50% 0%, rgba(65, 65, 85, 0.28) 0%, rgba(8, 8, 12, 0.92) 65%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 40px 120px -60px rgba(0, 0, 0, 0.9);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-start;
+  gap: clamp(22px, 4vw, 52px);
+  overflow: hidden;
+}
+
+.blog-feed--classic::before {
+  content: '';
+  position: absolute;
+  inset: 18px;
+  border-radius: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.04) 0%,
+      rgba(255, 255, 255, 0.01) 45%,
+      transparent 100%
+    ),
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.04), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(90, 110, 255, 0.08), transparent 50%);
+  pointer-events: none;
+  z-index: 0;
+}
+
 .blog-card {
   background: linear-gradient(165deg, rgba(30, 30, 30, 0.92), rgba(10, 10, 10, 0.9));
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -191,11 +225,48 @@
   gap: 18px;
   box-shadow: 0 30px 80px -50px rgba(0, 0, 0, 0.9);
   transition: transform 180ms ease, border-color 180ms ease;
+  position: relative;
+  z-index: 1;
 }
 
 .blog-card:hover {
   transform: translateY(-4px);
   border-color: rgba(255, 255, 255, 0.18);
+}
+
+.blog-card--classic {
+  width: clamp(240px, 26vw, 360px);
+  min-height: 240px;
+  backdrop-filter: blur(4px);
+  background: linear-gradient(170deg, rgba(24, 24, 28, 0.92), rgba(12, 12, 16, 0.88));
+  box-shadow: 0 40px 90px -65px rgba(8, 8, 12, 0.9);
+  transform-origin: center;
+  transition: transform 220ms ease, border-color 180ms ease, box-shadow 220ms ease;
+}
+
+.blog-card--classic:nth-child(6n + 1) {
+  transform: rotate(-1.6deg);
+}
+
+.blog-card--classic:nth-child(6n + 3) {
+  transform: rotate(1.4deg);
+}
+
+.blog-card--classic:nth-child(6n + 5) {
+  transform: rotate(-0.8deg);
+}
+
+.blog-card--classic:hover,
+.blog-card--classic:focus-within {
+  transform: scale(1.02) translateY(-6px);
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 48px 120px -70px rgba(25, 25, 35, 0.95);
+}
+
+.blog-feed--classic .blog-card--editing {
+  width: min(720px, 100%);
+  transform: none;
+  box-shadow: 0 26px 80px -54px rgba(0, 0, 0, 0.8);
 }
 
 .blog-card--grid {


### PR DESCRIPTION
## Summary
- add a classic canvas option to the Tools Blog view selector and wire up mode handling
- style the classic mode with a full-width atmospheric board layout and bespoke card treatments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e13f8bffe0832293c11f51a11d8250