### PR TITLE
Expand embedded Library layout within Form tools

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './ToolsBlog.jsx';
+import Library from './Library.jsx';
 import MomentoMori from '../MomentoMori.jsx';
 import Watchdog from './Watchdog.jsx';
 import QuadrantCombinaisons from './QuadrantCombinaisons.jsx';
@@ -75,6 +76,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   // Blog visibility starts hidden and becomes visible when on the Form layer.
   // Use a unique name to avoid clashes with the top-level App component.
   const [showToolsBlog, setShowToolsBlog] = useState(false);
+  const [showLibrary, setShowLibrary] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
   const [showBlog, setShowBlog] = useState(false);
   const [showQuadrantComb, setShowQuadrantComb] = useState(false);
@@ -116,6 +118,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       trinities: 'Form',
       anima: 'Form',
       blog: 'Form',
+      library: 'Form',
       todoGoals: 'Form',
       activity: 'Form',
       characterEvolve: 'Form',
@@ -186,6 +189,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showTrinities ||
     showAnima ||
     showBlog ||
+    showLibrary ||
     showTodoGoals ||
     showActivity ||
     showCharacterEvolve ||
@@ -217,6 +221,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowTrinities(false);
     setShowAnima(false);
     setShowBlog(false);
+    setShowLibrary(false);
     setShowTodoGoals(false);
     setShowActivity(false);
     setShowCharacterEvolve(false);
@@ -685,6 +690,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <Anima onBack={() => setShowAnima(false)} />
             ) : showBlog ? (
               <ToolsBlog onBack={() => setShowBlog(false)} />
+            ) : showLibrary ? (
+              <Library onBack={() => setShowLibrary(false)} />
             ) : showTodoGoals ? (
               <TodoGoals onBack={() => setShowTodoGoals(false)} />
             ) : showActivity ? (
@@ -897,6 +904,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">📰</div>
                     <span>Tools Blog</span>
+                  </div>
+                )}
+                {appLayers.library === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowLibrary(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'library')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'library')}
+                  >
+                    <div className="star-icon">📚</div>
+                    <span>Library</span>
                   </div>
                 )}
                 {appLayers.todoGoals === activeLayer && (

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -225,6 +225,7 @@ export default function PageRouter() {
       trinities: <Trinities onBack={goBack} />,
       anima: <Anima onBack={goBack} />,
       blog: <ToolsBlog onBack={goBack} />,
+      library: <Library onBack={goBack} />,
       todoGoals: <TodoGoals onBack={goBack} />,
       activity: <ActivityApp onBack={goBack} />,
       characterEvolve: <CharacterEvolve onBack={goBack} />,

--- a/src/library.css
+++ b/src/library.css
@@ -30,10 +30,13 @@
   --library-input-bg: #2a2a2d;
   --library-input-border: #3a3a3d;
   min-height: 100vh;
+  width: 100%;
   background: var(--library-bg);
   color: var(--library-text);
   font-family: 'Oxanium', sans-serif;
   position: relative;
+  display: flex;
+  flex-direction: column;
   transition: background 0.3s ease, color 0.3s ease;
 }
 
@@ -105,6 +108,10 @@
 
 .library-manager {
   padding: 20px;
+  flex: 1;
+  width: 100%;
+  min-height: 0;
+  box-sizing: border-box;
 }
 
 .library-header {

--- a/src/styles.css
+++ b/src/styles.css
@@ -277,7 +277,8 @@ body.character-page {
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
+  min-height: 0;
 }
 
 .icon {
@@ -397,10 +398,17 @@ body.idea-board-page .content {
 .tools-layout {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 20px;
   flex: 1;
   width: 100%;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.tools-layout > .library-container {
+  flex: 1;
+  min-height: 0;
 }
 
 .feature-cards {


### PR DESCRIPTION
## Summary
- let the tools content area stretch and scroll so embedded apps can fill the panel
- update the Library container to grow to the available width when launched from the Form tools deck

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1696bfbf48322abbc2efc9b6fcffb