### PR TITLE
Fix packaged build white screen and wire Unity embedding

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const fsp = fs.promises;
+const { spawn } = require('child_process');
 let mainWindow;
 let tray;
 let isQuitting = false;
@@ -141,6 +142,244 @@ function findTrayIcon() {
     } catch {}
   }
   return nativeImage.createEmpty();
+}
+
+const isWindows = process.platform === 'win32';
+const UNITY_RUNTIME_SEGMENTS = ['runtime', 'win', 'UnityPlayer'];
+const UNITY_CONFIG_FILE = 'unity.config.json';
+const UNITY_EMBEDDER_NAME = isWindows ? 'UnityEmbedder.exe' : 'UnityEmbedder';
+
+let unityProcess = null;
+let unityMounted = false;
+let unityLastRect = null;
+let unityConfigCache = null;
+let unityResizeTimer = null;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function resolveUnpackedPath(...segments) {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, 'app.asar.unpacked', ...segments);
+  }
+  return path.join(__dirname, ...segments);
+}
+
+async function readJsonSafeLocal(filePath) {
+  try {
+    const raw = await fsp.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      console.error('Failed to read JSON file', filePath, err);
+    }
+    return null;
+  }
+}
+
+async function resolveUnityConfig() {
+  if (!isWindows) return null;
+  if (unityConfigCache) return unityConfigCache;
+
+  const runtimeDir = resolveUnpackedPath(...UNITY_RUNTIME_SEGMENTS);
+  try {
+    const stat = await fsp.stat(runtimeDir);
+    if (!stat.isDirectory()) {
+      return null;
+    }
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      console.error('Failed to access Unity runtime directory', err);
+    }
+    return null;
+  }
+
+  const cfg = (await readJsonSafeLocal(path.join(runtimeDir, UNITY_CONFIG_FILE))) || {};
+  let exeName = cfg.exe || cfg.executable;
+  const args = Array.isArray(cfg.args) ? cfg.args : [];
+
+  if (typeof exeName !== 'string' || !exeName.trim()) {
+    try {
+      const files = await fsp.readdir(runtimeDir);
+      const ignore = new Set(['unityembedder.exe', 'unitycrashhandler64.exe']);
+      const candidate = files.find((name) => {
+        if (!name.toLowerCase().endsWith('.exe')) return false;
+        return !ignore.has(name.toLowerCase());
+      });
+      if (!candidate) {
+        return null;
+      }
+      exeName = candidate;
+    } catch (err) {
+      console.error('Failed to list Unity runtime directory', err);
+      return null;
+    }
+  }
+
+  const exePath = path.isAbsolute(exeName) ? exeName : path.join(runtimeDir, exeName);
+  try {
+    await fsp.access(exePath);
+  } catch (err) {
+    console.error('Unity executable not found', exePath, err);
+    return null;
+  }
+
+  const title = typeof cfg.title === 'string' && cfg.title.trim() ? cfg.title.trim() : path.parse(exePath).name;
+  unityConfigCache = { runtimeDir, exePath, args, title };
+  return unityConfigCache;
+}
+
+async function ensureUnityProcess() {
+  if (unityProcess && !unityProcess.killed) {
+    return unityProcess;
+  }
+  const config = await resolveUnityConfig();
+  if (!config) {
+    throw new Error('Unity runtime not found.');
+  }
+  try {
+    unityProcess = spawn(config.exePath, config.args || [], {
+      cwd: path.dirname(config.exePath),
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+  } catch (err) {
+    unityProcess = null;
+    throw err;
+  }
+
+  unityProcess.once('exit', () => {
+    unityProcess = null;
+    unityMounted = false;
+  });
+  unityProcess.once('error', (err) => {
+    console.error('Unity process error', err);
+    unityProcess = null;
+    unityMounted = false;
+  });
+  return unityProcess;
+}
+
+function killUnityProcess() {
+  if (unityProcess && !unityProcess.killed) {
+    try {
+      unityProcess.kill();
+    } catch (err) {
+      console.error('Failed to kill Unity process', err);
+    }
+  }
+  unityProcess = null;
+  unityMounted = false;
+}
+
+function getHostWindowHandle() {
+  if (!isWindows || !mainWindow) return null;
+  try {
+    const buf = mainWindow.getNativeWindowHandle();
+    if (!buf) return null;
+    if (typeof buf.readBigUInt64LE === 'function' && buf.length >= 8) {
+      return buf.readBigUInt64LE(0).toString();
+    }
+    return BigInt(buf.readUInt32LE(0)).toString();
+  } catch (err) {
+    console.error('Failed to read native window handle', err);
+    return null;
+  }
+}
+
+async function resolveEmbedderPath() {
+  const embedderPath = resolveUnpackedPath('native', UNITY_EMBEDDER_NAME);
+  try {
+    await fsp.access(embedderPath);
+    return embedderPath;
+  } catch (err) {
+    console.error('Unity embedder executable missing', embedderPath, err);
+    return null;
+  }
+}
+
+async function runUnityEmbedder(args) {
+  const embedder = await resolveEmbedderPath();
+  if (!embedder) {
+    return 1;
+  }
+  return new Promise((resolve) => {
+    const child = spawn(embedder, args, {
+      cwd: path.dirname(embedder),
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+    child.on('error', (err) => {
+      console.error('Unity embedder failed', err);
+      resolve(1);
+    });
+    child.on('exit', (code) => {
+      resolve(typeof code === 'number' ? code : 1);
+    });
+  });
+}
+
+async function embedUnity(rect) {
+  if (!rect || typeof rect.width === 'undefined' || typeof rect.height === 'undefined') {
+    throw new Error('Invalid Unity mount rectangle');
+  }
+  const config = await resolveUnityConfig();
+  if (!config) {
+    throw new Error('Unity runtime is missing.');
+  }
+  await ensureUnityProcess();
+
+  const hostHandle = getHostWindowHandle();
+  if (!hostHandle) {
+    throw new Error('Failed to obtain host window handle.');
+  }
+
+  const width = Math.max(0, Math.floor(rect.width));
+  const height = Math.max(0, Math.floor(rect.height));
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const code = await runUnityEmbedder([
+      'embed',
+      config.title,
+      hostHandle,
+      String(width),
+      String(height),
+    ]);
+    if (code === 0) {
+      unityMounted = true;
+      unityLastRect = { width, height };
+      return true;
+    }
+    await delay(400);
+  }
+  return false;
+}
+
+function scheduleUnityResize(rect) {
+  if (!unityMounted || !rect) return;
+  unityLastRect = { width: rect.width, height: rect.height };
+  if (unityResizeTimer) {
+    clearTimeout(unityResizeTimer);
+  }
+  unityResizeTimer = setTimeout(() => {
+    unityResizeTimer = null;
+    (async () => {
+      const config = await resolveUnityConfig();
+      if (!config) return;
+      const width = Math.max(0, Math.floor(unityLastRect.width));
+      const height = Math.max(0, Math.floor(unityLastRect.height));
+      const code = await runUnityEmbedder([
+        'resize',
+        config.title,
+        String(width),
+        String(height),
+      ]);
+      if (code !== 0) {
+        console.warn('Unity resize command failed with code', code);
+      }
+    })().catch((err) => {
+      console.error('Unity resize failed', err);
+    });
+  }, 120);
 }
 
 function createTray() {
@@ -478,6 +717,50 @@ ipcMain.handle('library-delete-image', async (_event, id) => {
   }
 });
 
+ipcMain.handle('unity:mount', async (_event, rect) => {
+  if (!isWindows) {
+    return { ok: false, error: 'Unity embedding is only supported on Windows.' };
+  }
+  try {
+    const success = await embedUnity(rect || {});
+    if (!success) {
+      return { ok: false, error: 'Failed to locate the Unity window.' };
+    }
+    return { ok: true };
+  } catch (err) {
+    console.error('Unity mount failed', err);
+    return { ok: false, error: err?.message || 'Unity mount failed.' };
+  }
+});
+
+ipcMain.handle('unity:hide', async () => {
+  if (!isWindows) return false;
+  const config = await resolveUnityConfig();
+  if (!config) return false;
+  const code = await runUnityEmbedder(['hide', config.title]);
+  if (code === 0) {
+    unityMounted = false;
+    return true;
+  }
+  return false;
+});
+
+ipcMain.handle('unity:quit', async () => {
+  if (isWindows) {
+    const config = await resolveUnityConfig();
+    if (config) {
+      await runUnityEmbedder(['hide', config.title]);
+    }
+  }
+  killUnityProcess();
+  return true;
+});
+
+ipcMain.on('unity:panel-resize', (_event, rect) => {
+  if (!isWindows) return;
+  scheduleUnityResize(rect);
+});
+
 app.whenReady().then(createWindow);
 app.whenReady().then(() => {
   createTray();
@@ -490,6 +773,7 @@ app.whenReady().then(() => registerGlobalShortcuts());
 
 app.on('before-quit', () => {
   isQuitting = true;
+  killUnityProcess();
 });
 
 // Ensure shortcuts are released on quit

--- a/package.json
+++ b/package.json
@@ -19,11 +19,16 @@
     "files": [
       "dist/**",
       "electron-main.js",
+      "preload.js",
+      "native/**",
+      "runtime/**",
       "package.json"
     ],
     "asar": true,
     "asarUnpack": [
-      "**/*.node"
+      "**/*.node",
+      "native/**",
+      "runtime/**"
     ],
     "mac": { "target": ["dmg", "zip"] },
     "win": { "target": ["nsis", "zip"] },

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -7,6 +7,65 @@ import { useQuests } from "./QuestContext.jsx";
 import TasteT from "./TasteT.jsx";
 import "./world.css";
 
+function FormlessUnityStage() {
+  const [status, setStatus] = useState("loading");
+  const [message, setMessage] = useState("Launching Mazed Unity...");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const mountUnity = async () => {
+      if (!window.unity?.mount) {
+        setStatus("unsupported");
+        setMessage("Unity bridge is unavailable in this build.");
+        return;
+      }
+      try {
+        setStatus("loading");
+        setMessage("Launching Mazed Unity...");
+        const result = await window.unity.mount();
+        if (cancelled) return;
+        if (result && result.ok === false) {
+          throw new Error(result.error || "Unity mount failed");
+        }
+        setStatus("ready");
+      } catch (err) {
+        console.error("Unity mount failed", err);
+        if (cancelled) return;
+        setStatus("error");
+        setMessage(err?.message || "Failed to embed the Unity experience.");
+      }
+    };
+
+    mountUnity();
+
+    return () => {
+      cancelled = true;
+      if (window.unity?.hide) {
+        window.unity
+          .hide()
+          .catch(() => {
+            /* ignore */
+          });
+      }
+    };
+  }, []);
+
+  return (
+    <div className="world-container world-formless-stage">
+      <div id="unity-panel" className="unity-panel" />
+      {status !== "ready" && (
+        <div className={`unity-status unity-status-${status}`}>
+          <span>{message}</span>
+          {status === "unsupported" && (
+            <small>Desktop build is missing the Unity runtime.</small>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function World({ activeLayer = "Form" }) {
   const [resource, setResource] = useState(() => {
     const stored = localStorage.getItem("resourceR");
@@ -108,7 +167,7 @@ export default function World({ activeLayer = "Form" }) {
   }
 
   if (isFormless) {
-    return <div className="world-container world-formless-empty" />;
+    return <FormlessUnityStage />;
   }
 
   return (

--- a/src/world.css
+++ b/src/world.css
@@ -199,6 +199,71 @@
   background: radial-gradient(circle at bottom right, transparent 40%, #d1d1d1 41%);
 }
 
+.world-formless-stage {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.unity-panel {
+  position: relative;
+  flex: 1;
+  max-width: 1200px;
+  height: 100%;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  min-height: 540px;
+}
+
+.unity-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: #f5f6ff;
+  background: linear-gradient(
+      135deg,
+      rgba(18, 18, 28, 0.82),
+      rgba(54, 46, 102, 0.78)
+    );
+  text-align: center;
+  padding: 24px;
+  box-sizing: border-box;
+  font-size: 1.1rem;
+}
+
+.unity-status small {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.unity-status-error {
+  background: linear-gradient(
+      135deg,
+      rgba(48, 11, 17, 0.9),
+      rgba(109, 22, 40, 0.85)
+    );
+}
+
+.unity-status-unsupported {
+  background: linear-gradient(
+      135deg,
+      rgba(14, 14, 24, 0.9),
+      rgba(34, 46, 72, 0.85)
+    );
+}
+
 .contract-box.cut-bl {
   background: radial-gradient(circle at bottom left, transparent 40%, #d1d1d1 41%);
 }


### PR DESCRIPTION
## Summary
- include the preload script, native embedder helper, and Unity runtime folders in the packaged application
- add Unity process lifecycle management and IPC handlers so the renderer can mount, resize, hide, or quit the embedded Unity window
- render a dedicated Unity panel on the Formless world layer with status messaging and styling to host the embedded player

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b30f7d608322abadf861e7122aae