### PR TITLE
fix: probe multiple unity window titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ npm start
 
 Make sure the `.env` file with your Supabase credentials exists before running either command.
 
+### Unity runtime
+
+If you want the Formless layer to embed a Unity scene, place your Windows
+player build inside `runtime/win/UnityPlayer/` and describe its executable and
+window title in `unity.config.json`. See [UNITY_SETUP.md](UNITY_SETUP.md) for the
+step-by-step guide.
+
 ### Profile Pictures
 
 Create a public storage bucket named `avatars` in Supabase. The `profiles`

--- a/UNITY_SETUP.md
+++ b/UNITY_SETUP.md
@@ -1,0 +1,90 @@
+# Unity Runtime Setup
+
+The Electron shell can embed a standalone Windows build of the Unity
+experience. Follow these steps to make sure the renderer can discover and
+attach to the Unity window correctly.
+
+## 1. Drop in your Unity build
+
+1. Create the directory `runtime/win/UnityPlayer/` in the repository root if it
+   does not already exist.
+2. Copy the **contents** of your Unity build output (the `.exe`, the
+   `*_Data/` directory, and any DLLs) into that folder. When running from
+   source, the app reads from this path. In a packaged build the same layout is
+   reproduced inside `resources/app.asar.unpacked/runtime/win/UnityPlayer/`.
+
+Your folder should look similar to:
+
+```
+runtime/
+└── win/
+    └── UnityPlayer/
+        ├── MazedRuntime.exe
+        ├── MazedRuntime_Data/
+        ├── UnityPlayer.dll
+        └── ...
+```
+
+> **Tip:** A development build is not required. Any standalone Windows player
+> works as long as the executable and its data folder stay together in this
+> directory.
+
+## 2. Describe the executable and window title
+
+Create a `unity.config.json` file in `runtime/win/UnityPlayer/` with at least
+these properties:
+
+```json
+{
+  "exe": "MazedRuntime.exe",
+  "title": "Mazed Runtime",
+  "args": []
+}
+```
+
+- `exe` – file name of the Unity executable. If omitted, the app tries to pick
+  the first `.exe` it finds, which might be incorrect if multiple executables
+  are present.
+- `title` – window caption shown by the Unity player. The native embedder
+  searches for a window whose class is `UnityWndClass` and whose title matches
+  this string. Development builds append ` (Development Build)` automatically,
+  so the app now probes both the release and development captions even if you
+  only provide the base title.
+- `args` – optional array of additional command line arguments passed when the
+  player launches.
+
+You can also declare a `titles` array if you need to provide multiple explicit
+caption variants:
+
+```json
+{
+  "exe": "MazedRuntime.exe",
+  "titles": ["Mazed Runtime", "Mazed Runtime QA"],
+  "args": []
+}
+```
+
+All listed titles (plus their development-build counterparts) are tried in
+order until one succeeds.
+
+You can confirm the title by running the Unity executable on its own and
+reading the text in the window’s title bar. Copy that value into the config.
+
+## 3. Launch the app
+
+With the runtime directory populated and the config in place, start the
+Electron app (`npm run dev` for development). When the Formless layer requests a
+Unity mount, the helper process looks for the configured window title up to ten
+ times before giving up. If everything is configured correctly the red failure
+message disappears and the Unity view embeds in the UI.
+
+If you still see the error, double-check:
+
+- the Unity process is running (`Task Manager` shows your executable);
+- the window title in Task Manager matches `title` in `unity.config.json`;
+- the runtime files live in `runtime/win/UnityPlayer/` (case-sensitive on
+  non-Windows filesystems);
+- the executable has not been renamed by SmartScreen or another tool.
+
+These three pieces—the runtime folder, the config file, and the correct window
+caption—allow the embedder to locate and attach to the Unity window reliably.

--- a/electron-main.js
+++ b/electron-main.js
@@ -154,6 +154,7 @@ let unityMounted = false;
 let unityLastRect = null;
 let unityConfigCache = null;
 let unityResizeTimer = null;
+let unityActiveTitle = null;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -196,6 +197,17 @@ async function resolveUnityConfig() {
   const cfg = (await readJsonSafeLocal(path.join(runtimeDir, UNITY_CONFIG_FILE))) || {};
   let exeName = cfg.exe || cfg.executable;
   const args = Array.isArray(cfg.args) ? cfg.args : [];
+  const rawTitles = [];
+  const addTitle = (value) => {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const lower = trimmed.toLowerCase();
+    if (rawTitles.some((existing) => existing.toLowerCase() === lower)) {
+      return;
+    }
+    rawTitles.push(trimmed);
+  };
 
   if (typeof exeName !== 'string' || !exeName.trim()) {
     try {
@@ -223,8 +235,42 @@ async function resolveUnityConfig() {
     return null;
   }
 
-  const title = typeof cfg.title === 'string' && cfg.title.trim() ? cfg.title.trim() : path.parse(exePath).name;
-  unityConfigCache = { runtimeDir, exePath, args, title };
+  addTitle(cfg.title);
+  if (Array.isArray(cfg.titles)) {
+    for (const candidate of cfg.titles) {
+      addTitle(candidate);
+    }
+  }
+  if (rawTitles.length === 0) {
+    addTitle(path.parse(exePath).name);
+  }
+
+  const titles = [];
+  const seen = new Set();
+  const devSuffix = ' (Development Build)';
+  const pushTitle = (value) => {
+    if (typeof value !== 'string' || !value) return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const lower = trimmed.toLowerCase();
+    if (seen.has(lower)) return;
+    seen.add(lower);
+    titles.push(trimmed);
+  };
+
+  for (const title of rawTitles) {
+    pushTitle(title);
+  }
+
+  for (const title of rawTitles) {
+    if (title.toLowerCase().endsWith(devSuffix.toLowerCase())) {
+      pushTitle(title.slice(0, -devSuffix.length));
+    } else {
+      pushTitle(`${title}${devSuffix}`);
+    }
+  }
+
+  unityConfigCache = { runtimeDir, exePath, args, titles };
   return unityConfigCache;
 }
 
@@ -250,11 +296,13 @@ async function ensureUnityProcess() {
   unityProcess.once('exit', () => {
     unityProcess = null;
     unityMounted = false;
+    unityActiveTitle = null;
   });
   unityProcess.once('error', (err) => {
     console.error('Unity process error', err);
     unityProcess = null;
     unityMounted = false;
+    unityActiveTitle = null;
   });
   return unityProcess;
 }
@@ -269,6 +317,7 @@ function killUnityProcess() {
   }
   unityProcess = null;
   unityMounted = false;
+  unityActiveTitle = null;
 }
 
 function getHostWindowHandle() {
@@ -336,22 +385,58 @@ async function embedUnity(rect) {
   const width = Math.max(0, Math.floor(rect.width));
   const height = Math.max(0, Math.floor(rect.height));
 
+  const titles = Array.isArray(config.titles) && config.titles.length > 0 ? config.titles : [];
+  if (titles.length === 0) {
+    throw new Error('Unity configuration is missing window titles.');
+  }
+  unityActiveTitle = null;
+
   for (let attempt = 0; attempt < 10; attempt += 1) {
-    const code = await runUnityEmbedder([
-      'embed',
-      config.title,
-      hostHandle,
-      String(width),
-      String(height),
-    ]);
-    if (code === 0) {
-      unityMounted = true;
-      unityLastRect = { width, height };
-      return true;
+    for (const title of titles) {
+      const code = await runUnityEmbedder([
+        'embed',
+        title,
+        hostHandle,
+        String(width),
+        String(height),
+      ]);
+      if (code === 0) {
+        unityMounted = true;
+        unityLastRect = { width, height };
+        unityActiveTitle = title;
+        return true;
+      }
     }
     await delay(400);
   }
   return false;
+}
+
+function orderedUnityTitles(config) {
+  if (!config || !Array.isArray(config.titles) || config.titles.length === 0) {
+    return [];
+  }
+  if (!unityActiveTitle) {
+    return config.titles;
+  }
+  const lowerActive = unityActiveTitle.toLowerCase();
+  const ordered = [];
+  const seen = new Set();
+  for (const title of config.titles) {
+    const lower = title.toLowerCase();
+    if (seen.has(lower)) continue;
+    if (lower === lowerActive) {
+      ordered.unshift(title);
+      seen.add(lower);
+    }
+  }
+  for (const title of config.titles) {
+    const lower = title.toLowerCase();
+    if (seen.has(lower)) continue;
+    ordered.push(title);
+    seen.add(lower);
+  }
+  return ordered;
 }
 
 function scheduleUnityResize(rect) {
@@ -365,17 +450,25 @@ function scheduleUnityResize(rect) {
     (async () => {
       const config = await resolveUnityConfig();
       if (!config) return;
+      const orderedTitles = orderedUnityTitles(config);
+      if (orderedTitles.length === 0) return;
       const width = Math.max(0, Math.floor(unityLastRect.width));
       const height = Math.max(0, Math.floor(unityLastRect.height));
-      const code = await runUnityEmbedder([
-        'resize',
-        config.title,
-        String(width),
-        String(height),
-      ]);
-      if (code !== 0) {
-        console.warn('Unity resize command failed with code', code);
+      for (const title of orderedTitles) {
+        const code = await runUnityEmbedder([
+          'resize',
+          title,
+          String(width),
+          String(height),
+        ]);
+        if (code === 0) {
+          if (!unityActiveTitle || unityActiveTitle.toLowerCase() !== title.toLowerCase()) {
+            unityActiveTitle = title;
+          }
+          return;
+        }
       }
+      console.warn('Unity resize command failed for all configured titles');
     })().catch((err) => {
       console.error('Unity resize failed', err);
     });
@@ -737,10 +830,14 @@ ipcMain.handle('unity:hide', async () => {
   if (!isWindows) return false;
   const config = await resolveUnityConfig();
   if (!config) return false;
-  const code = await runUnityEmbedder(['hide', config.title]);
-  if (code === 0) {
-    unityMounted = false;
-    return true;
+  const titles = orderedUnityTitles(config);
+  for (const title of titles) {
+    const code = await runUnityEmbedder(['hide', title]);
+    if (code === 0) {
+      unityMounted = false;
+      unityActiveTitle = title;
+      return true;
+    }
   }
   return false;
 });
@@ -749,7 +846,14 @@ ipcMain.handle('unity:quit', async () => {
   if (isWindows) {
     const config = await resolveUnityConfig();
     if (config) {
-      await runUnityEmbedder(['hide', config.title]);
+      const titles = orderedUnityTitles(config);
+      for (const title of titles) {
+        const code = await runUnityEmbedder(['hide', title]);
+        if (code === 0) {
+          unityActiveTitle = title;
+          break;
+        }
+      }
     }
   }
   killUnityProcess();


### PR DESCRIPTION
## Summary
- expand the Unity runtime loader to accept multiple window titles and auto-try the development build suffix
- reuse the detected window caption for resize/hide flows while falling back across all configured variants
- document the new `titles` array option and note the automatic probing of development build captions

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3904d58c08322a369f50f5ba41d63