### PR TITLE
Handle Unity embedder positioning offsets

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -368,7 +368,13 @@ async function runUnityEmbedder(args) {
 }
 
 async function embedUnity(rect) {
-  if (!rect || typeof rect.width === 'undefined' || typeof rect.height === 'undefined') {
+  if (
+    !rect ||
+    typeof rect.width === 'undefined' ||
+    typeof rect.height === 'undefined' ||
+    typeof rect.left === 'undefined' ||
+    typeof rect.top === 'undefined'
+  ) {
     throw new Error('Invalid Unity mount rectangle');
   }
   const config = await resolveUnityConfig();
@@ -384,6 +390,8 @@ async function embedUnity(rect) {
 
   const width = Math.max(0, Math.floor(rect.width));
   const height = Math.max(0, Math.floor(rect.height));
+  const left = Math.floor(rect.left);
+  const top = Math.floor(rect.top);
 
   const titles = Array.isArray(config.titles) && config.titles.length > 0 ? config.titles : [];
   if (titles.length === 0) {
@@ -399,10 +407,12 @@ async function embedUnity(rect) {
         hostHandle,
         String(width),
         String(height),
+        String(left),
+        String(top),
       ]);
       if (code === 0) {
         unityMounted = true;
-        unityLastRect = { width, height };
+        unityLastRect = { left, top, width, height };
         unityActiveTitle = title;
         return true;
       }
@@ -440,8 +450,22 @@ function orderedUnityTitles(config) {
 }
 
 function scheduleUnityResize(rect) {
-  if (!unityMounted || !rect) return;
-  unityLastRect = { width: rect.width, height: rect.height };
+  if (
+    !unityMounted ||
+    !rect ||
+    typeof rect.width === 'undefined' ||
+    typeof rect.height === 'undefined' ||
+    typeof rect.left === 'undefined' ||
+    typeof rect.top === 'undefined'
+  ) {
+    return;
+  }
+  unityLastRect = {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
   if (unityResizeTimer) {
     clearTimeout(unityResizeTimer);
   }
@@ -454,12 +478,16 @@ function scheduleUnityResize(rect) {
       if (orderedTitles.length === 0) return;
       const width = Math.max(0, Math.floor(unityLastRect.width));
       const height = Math.max(0, Math.floor(unityLastRect.height));
+      const left = Math.floor(unityLastRect.left);
+      const top = Math.floor(unityLastRect.top);
       for (const title of orderedTitles) {
         const code = await runUnityEmbedder([
           'resize',
           title,
           String(width),
           String(height),
+          String(left),
+          String(top),
         ]);
         if (code === 0) {
           if (!unityActiveTitle || unityActiveTitle.toLowerCase() !== title.toLowerCase()) {

--- a/native/embedder.c
+++ b/native/embedder.c
@@ -19,10 +19,12 @@ int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE hPrev, PWSTR pCmdLine, int nCmdSh
     if (!unity) return 1;
 
     if (lstrcmpiW(mode, L"embed") == 0) {
-        if (argc < 6) return 2;
+        if (argc < 8) return 2;
         ULONGLONG hostVal = _wcstoui64(argv[3], NULL, 10);
         int w = _wtoi(argv[4]);
         int h = _wtoi(argv[5]);
+        int x = _wtoi(argv[6]);
+        int y = _wtoi(argv[7]);
         HWND host = (HWND)(ULONG_PTR)hostVal;
 
         ShowWindow(unity, SW_HIDE);
@@ -33,14 +35,16 @@ int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE hPrev, PWSTR pCmdLine, int nCmdSh
         style &= ~(WS_POPUP | WS_CAPTION | WS_THICKFRAME | WS_MINIMIZE | WS_MAXIMIZE | WS_SYSMENU);
         SetWindowLongPtrW(unity, GWL_STYLE, style);
 
-        SetWindowPos(unity, NULL, 0, 0, w, h, SWP_NOZORDER | SWP_SHOWWINDOW);
+        SetWindowPos(unity, NULL, x, y, w, h, SWP_NOZORDER | SWP_SHOWWINDOW);
         ShowWindow(unity, SW_SHOW);
         return 0;
     } else if (lstrcmpiW(mode, L"resize") == 0) {
-        if (argc < 5) return 2;
+        if (argc < 7) return 2;
         int w = _wtoi(argv[3]);
         int h = _wtoi(argv[4]);
-        MoveWindow(unity, 0, 0, w, h, TRUE);
+        int x = _wtoi(argv[5]);
+        int y = _wtoi(argv[6]);
+        MoveWindow(unity, x, y, w, h, TRUE);
         return 0;
     } else if (lstrcmpiW(mode, L"show") == 0) {
         ShowWindow(unity, SW_SHOW);


### PR DESCRIPTION
## Summary
- include the panel's left/top offsets when mounting and resizing the embedded Unity window from Electron
- update the Win32 helper so embed/resize accept x/y coordinates and position the Unity window accordingly

## Testing
- not run (Windows-only helper)


------
https://chatgpt.com/codex/tasks/task_e_68e3bdb8c3648322b341856486f82257