### PR TITLE
Normalize Unity embed coordinates for HiDPI Unity embedding

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -388,10 +388,15 @@ async function embedUnity(rect) {
     throw new Error('Failed to obtain host window handle.');
   }
 
-  const width = Math.max(0, Math.floor(rect.width));
-  const height = Math.max(0, Math.floor(rect.height));
-  const left = Math.floor(rect.left);
-  const top = Math.floor(rect.top);
+  const normalized = normalizeRect(rect);
+  if (!normalized) {
+    throw new Error('Invalid Unity mount rectangle');
+  }
+
+  const width = Math.max(0, Math.floor(normalized.width));
+  const height = Math.max(0, Math.floor(normalized.height));
+  const left = Math.floor(normalized.left);
+  const top = Math.floor(normalized.top);
 
   const titles = Array.isArray(config.titles) && config.titles.length > 0 ? config.titles : [];
   if (titles.length === 0) {
@@ -449,6 +454,21 @@ function orderedUnityTitles(config) {
   return ordered;
 }
 
+function normalizeRect(rect) {
+  if (!rect || typeof rect !== 'object') {
+    return null;
+  }
+  const toNumber = (value) => {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  };
+  const left = toNumber(rect.left);
+  const top = toNumber(rect.top);
+  const width = Math.max(0, toNumber(rect.width));
+  const height = Math.max(0, toNumber(rect.height));
+  return { left, top, width, height };
+}
+
 function scheduleUnityResize(rect) {
   if (
     !unityMounted ||
@@ -460,12 +480,11 @@ function scheduleUnityResize(rect) {
   ) {
     return;
   }
-  unityLastRect = {
-    left: rect.left,
-    top: rect.top,
-    width: rect.width,
-    height: rect.height,
-  };
+  const normalized = normalizeRect(rect);
+  if (!normalized) {
+    return;
+  }
+  unityLastRect = normalized;
   if (unityResizeTimer) {
     clearTimeout(unityResizeTimer);
   }

--- a/preload.js
+++ b/preload.js
@@ -32,11 +32,13 @@ function getPanelRect() {
   const el = getPanelEl();
   if (!el) return null;
   const r = el.getBoundingClientRect();
+  const scale = Number(window.devicePixelRatio) || 1;
   return {
-    left: Math.round(r.left),
-    top: Math.round(r.top),
-    width: Math.round(r.width),
-    height: Math.round(r.height),
+    left: Math.round(r.left * scale),
+    top: Math.round(r.top * scale),
+    width: Math.max(0, Math.round(r.width * scale)),
+    height: Math.max(0, Math.round(r.height * scale)),
+    scale,
   };
 }
 
@@ -78,6 +80,7 @@ contextBridge.exposeInMainWorld('unity', {
     startObservingPanel();
     const rect = getPanelRect();
     if (!rect) throw new Error('Failed to measure unity-panel');
+    ipcRenderer.send('unity:panel-resize', rect);
     return ipcRenderer.invoke('unity:mount', rect);
   },
   /** Hide the embedded Unity view */


### PR DESCRIPTION
## Summary
- scale the unity mount rectangle in the preload script using the current devicePixelRatio before sending it to the main process
- normalize rectangle coordinates/numbers in the Electron main process before embedding or resizing and reuse that helper for resize events
- send an initial panel size update when mounting to ensure the native embedder receives the correct bounds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3dab199088322b8a52c64279ef392