### PR TITLE
Fix duplicate normalized variable declaration in electron main process

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -337,6 +337,20 @@ function readWindowHandleBuffer(buf) {
     console.error('Failed to interpret native window handle buffer', err);
     return null;
   }
+}
+
+function applyUnityHostBounds() {
+  if (!isWindows || !mainWindow || !unityHostLastRect) {
+    return;
+  }
+  updateUnityHostWindowBounds(unityHostLastRect);
+}
+
+function updateUnityHostFromRect(rect) {
+  const normalized = rect && rect.__normalized ? rect : normalizeRect(rect);
+  if (!normalized) {
+    return null;
+  }
   unityHostLastRect = normalized;
   applyUnityHostBounds();
   return normalized;
@@ -606,11 +620,6 @@ function scheduleUnityResize(rect) {
   if (!unityMounted) {
     return;
   }
-  const normalized = normalizeRect(rect);
-  if (!normalized) {
-    return;
-  }
-  unityLastRect = normalized;
   if (unityResizeTimer) {
     clearTimeout(unityResizeTimer);
   }


### PR DESCRIPTION
## Summary
- add helper utilities to normalize Unity host rectangles without re-declaration errors
- reuse cached bounds when scheduling Unity resize updates to prevent runtime crashes

## Testing
- npm test -- --runTestsByPath Anima.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3f0adee4c83228100d4a6740b42ab