### PR TITLE
Handle cleared Unity host state during scheduled resize

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -632,14 +632,18 @@ function scheduleUnityResize(rect) {
   }
   unityResizeTimer = setTimeout(() => {
     unityResizeTimer = null;
+    const rectToResize = unityLastRect;
+    if (!unityMounted || !rectToResize) {
+      return;
+    }
     (async () => {
       const config = await resolveUnityConfig();
       if (!config) return;
       const orderedTitles = orderedUnityTitles(config);
       if (orderedTitles.length === 0) return;
-      updateUnityHostWindowBounds(unityLastRect);
-      const width = Math.max(0, Math.floor(unityLastRect.width));
-      const height = Math.max(0, Math.floor(unityLastRect.height));
+      updateUnityHostWindowBounds(rectToResize);
+      const width = Math.max(0, Math.floor(rectToResize.width));
+      const height = Math.max(0, Math.floor(rectToResize.height));
       if (width <= 0 || height <= 0) {
         return;
       }


### PR DESCRIPTION
## Summary
- guard the Unity resize timer to abort when the host has been unmounted
- reuse the captured host bounds for window updates and size calculations

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3f891c56c8322b2d042d32769ae00