### PR TITLE
Expand notes library modal layout

### DIFF
--- a/note-modal.css
+++ b/note-modal.css
@@ -151,17 +151,17 @@
 }
 
 .notes-list-modal {
-  width: clamp(1440px, calc(100vw - 24px), 2880px);
-  max-width: calc(100vw - 24px);
-  max-height: min(1040px, calc(100vh - 64px));
-  padding: 40px 48px;
-  gap: 32px;
+  width: min(calc(100vw - 64px), 1840px);
+  max-width: calc(100vw - 64px);
+  max-height: calc(100vh - 64px);
+  padding: 48px 56px;
+  gap: 36px;
+  aspect-ratio: 16 / 9;
 }
 
 @media (min-height: 900px) {
   .notes-list-modal {
-    aspect-ratio: 16 / 10;
-    min-height: clamp(640px, 72vh, 920px);
+    min-height: min(clamp(680px, 78vh, 960px), calc(100vh - 64px));
   }
 }
 
@@ -653,17 +653,17 @@
 
 @media (max-width: 1440px) {
   .notes-list-modal {
-    width: clamp(1040px, calc(100vw - 24px), 1980px);
-    padding: 36px 40px;
-    gap: 30px;
+    width: min(calc(100vw - 48px), 1680px);
+    padding: 44px 48px;
+    gap: 34px;
   }
 }
 
 @media (max-width: 1280px) {
   .notes-list-modal {
-    width: calc(100vw - 24px);
-    max-height: calc(100vh - 60px);
-    padding: 32px 36px;
+    width: calc(100vw - 40px);
+    max-height: calc(100vh - 52px);
+    padding: 36px 40px;
     aspect-ratio: auto;
   }
 

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -151,17 +151,17 @@
 }
 
 .notes-list-modal {
-  width: clamp(1440px, calc(100vw - 24px), 2880px);
-  max-width: calc(100vw - 24px);
-  max-height: min(1040px, calc(100vh - 64px));
-  padding: 40px 48px;
-  gap: 32px;
+  width: min(calc(100vw - 64px), 1840px);
+  max-width: calc(100vw - 64px);
+  max-height: calc(100vh - 64px);
+  padding: 48px 56px;
+  gap: 36px;
+  aspect-ratio: 16 / 9;
 }
 
 @media (min-height: 900px) {
   .notes-list-modal {
-    aspect-ratio: 16 / 10;
-    min-height: clamp(640px, 72vh, 920px);
+    min-height: min(clamp(680px, 78vh, 960px), calc(100vh - 64px));
   }
 }
 
@@ -653,17 +653,17 @@
 
 @media (max-width: 1440px) {
   .notes-list-modal {
-    width: clamp(1040px, calc(100vw - 24px), 1980px);
-    padding: 36px 40px;
-    gap: 30px;
+    width: min(calc(100vw - 48px), 1680px);
+    padding: 44px 48px;
+    gap: 34px;
   }
 }
 
 @media (max-width: 1280px) {
   .notes-list-modal {
-    width: calc(100vw - 24px);
-    max-height: calc(100vh - 60px);
-    padding: 32px 36px;
+    width: calc(100vw - 40px);
+    max-height: calc(100vh - 52px);
+    padding: 36px 40px;
     aspect-ratio: auto;
   }
 


### PR DESCRIPTION
## Summary
- expand the notes library modal so it can occupy nearly the full screen with a 16:9 aspect ratio on large displays
- tweak responsive breakpoints and spacing so the larger layout still adapts cleanly on narrower screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5076c11648322a65555e03c29ccff