### PR TITLE
Dynamically size notes library modal to fill available space

### DIFF
--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -1,6 +1,84 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import './note-modal.css';
 
+const VIEWPORT_FALLBACK = { width: 1440, height: 900 };
+const MODAL_ASPECT_RATIO = 16 / 9;
+const MAX_MODAL_WIDTH = 1840;
+const MAX_MODAL_HEIGHT = MAX_MODAL_WIDTH / MODAL_ASPECT_RATIO;
+const MIN_MODAL_WIDTH = 960;
+const MIN_MODAL_HEIGHT = MIN_MODAL_WIDTH / MODAL_ASPECT_RATIO;
+const HORIZONTAL_MARGIN = 64;
+const VERTICAL_MARGIN = 64;
+
+const readViewportSize = () => {
+  if (typeof window === 'undefined') {
+    return VIEWPORT_FALLBACK;
+  }
+
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+};
+
+const clampDimension = (value, margin, minimum, maximum) => {
+  const safeMinimum = Math.min(minimum, value);
+  const safeMaximum = Math.min(maximum, value);
+  const reducedValue = value - margin;
+
+  if (safeMaximum <= 0) {
+    return 0;
+  }
+
+  const expanded = Math.max(reducedValue, safeMinimum);
+  return Math.min(Math.max(expanded, 0), safeMaximum);
+};
+
+const computeModalDimensions = (viewport) => {
+  const baseWidth = viewport?.width ?? VIEWPORT_FALLBACK.width;
+  const baseHeight = viewport?.height ?? VIEWPORT_FALLBACK.height;
+
+  const maxWidth = clampDimension(baseWidth, HORIZONTAL_MARGIN, MIN_MODAL_WIDTH, MAX_MODAL_WIDTH);
+  const maxHeight = clampDimension(baseHeight, VERTICAL_MARGIN, MIN_MODAL_HEIGHT, MAX_MODAL_HEIGHT);
+
+  const hasSpace = maxWidth > 0 && maxHeight > 0;
+  const referenceWidth = hasSpace
+    ? maxWidth
+    : Math.min(VIEWPORT_FALLBACK.width - HORIZONTAL_MARGIN, MAX_MODAL_WIDTH);
+  const referenceHeight = hasSpace
+    ? maxHeight
+    : Math.min(VIEWPORT_FALLBACK.height - VERTICAL_MARGIN, MAX_MODAL_HEIGHT);
+
+  if (!referenceWidth || !referenceHeight) {
+    return {
+      width: MIN_MODAL_WIDTH,
+      height: MIN_MODAL_HEIGHT,
+      maxWidth: MIN_MODAL_WIDTH,
+      maxHeight: MIN_MODAL_HEIGHT,
+    };
+  }
+
+  const widthBasedOnHeight = referenceHeight * MODAL_ASPECT_RATIO;
+
+  if (widthBasedOnHeight <= referenceWidth) {
+    return {
+      width: widthBasedOnHeight,
+      height: referenceHeight,
+      maxWidth,
+      maxHeight,
+    };
+  }
+
+  const heightBasedOnWidth = referenceWidth / MODAL_ASPECT_RATIO;
+
+  return {
+    width: referenceWidth,
+    height: heightBasedOnWidth,
+    maxWidth,
+    maxHeight,
+  };
+};
+
 const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE'];
 const TAG_OPTIONS = ['ALL', ...QUADRANT_TAGS];
 const TAG_COLORS = {
@@ -303,10 +381,24 @@ const loadStoredNotes = () => {
 const pluralise = (count, singular, plural) => (count === 1 ? singular : plural);
 
 export default function NotesListModal({ onClose }) {
+  const [viewportSize, setViewportSize] = useState(() => readViewportSize());
   const [notes, setNotes] = useState(() => loadStoredNotes());
   const [searchTerm, setSearchTerm] = useState('');
   const [activeTag, setActiveTag] = useState('ALL');
   const [selectedId, setSelectedId] = useState(null);
+  const modalDimensions = useMemo(() => computeModalDimensions(viewportSize), [viewportSize]);
+  const modalStyle = useMemo(() => {
+    if (!modalDimensions) {
+      return undefined;
+    }
+
+    return {
+      width: `${modalDimensions.width}px`,
+      height: `${modalDimensions.height}px`,
+      maxWidth: `${modalDimensions.maxWidth}px`,
+      maxHeight: `${modalDimensions.maxHeight}px`,
+    };
+  }, [modalDimensions]);
 
   const filteredNotes = useMemo(() => {
     const query = searchTerm.trim().toLowerCase();
@@ -323,6 +415,23 @@ export default function NotesListModal({ onClose }) {
       return note.searchable.includes(query);
     });
   }, [notes, activeTag, searchTerm]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handleResize = () => {
+      setViewportSize(readViewportSize());
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   useEffect(() => {
     if (filteredNotes.length === 0) {
@@ -406,7 +515,11 @@ export default function NotesListModal({ onClose }) {
 
   return (
     <div className="modal-overlay" onClick={handleOverlayClick}>
-      <div className="modal notes-modal notes-list-modal" onClick={(event) => event.stopPropagation()}>
+      <div
+        className="modal notes-modal notes-list-modal"
+        onClick={(event) => event.stopPropagation()}
+        style={modalStyle}
+      >
         <header className="notes-header">
           <div>
             <h3>Your notes library</h3>

--- a/note-modal.css
+++ b/note-modal.css
@@ -151,17 +151,17 @@
 }
 
 .notes-list-modal {
-  width: clamp(1440px, calc(100vw - 24px), 2880px);
-  max-width: calc(100vw - 24px);
-  max-height: min(1040px, calc(100vh - 64px));
-  padding: 40px 48px;
-  gap: 32px;
+  width: min(calc(100vw - 64px), 1840px);
+  max-width: calc(100vw - 64px);
+  max-height: calc(100vh - 64px);
+  padding: 48px 56px;
+  gap: 36px;
+  aspect-ratio: 16 / 9;
 }
 
 @media (min-height: 900px) {
   .notes-list-modal {
-    aspect-ratio: 16 / 10;
-    min-height: clamp(640px, 72vh, 920px);
+    min-height: min(clamp(680px, 78vh, 960px), calc(100vh - 64px));
   }
 }
 
@@ -452,6 +452,7 @@
   grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
   gap: 32px;
   align-items: stretch;
+  height: 100%;
 }
 
 .notes-grid {
@@ -461,7 +462,13 @@
   align-content: flex-start;
   overflow-y: auto;
   padding-right: 12px;
+  padding-left: 12px;
   min-height: 0;
+}
+
+.notes-grid,
+.notes-detail {
+  height: 100%;
 }
 
 .notes-card {
@@ -653,17 +660,17 @@
 
 @media (max-width: 1440px) {
   .notes-list-modal {
-    width: clamp(1040px, calc(100vw - 24px), 1980px);
-    padding: 36px 40px;
-    gap: 30px;
+    width: min(calc(100vw - 48px), 1680px);
+    padding: 44px 48px;
+    gap: 34px;
   }
 }
 
 @media (max-width: 1280px) {
   .notes-list-modal {
-    width: calc(100vw - 24px);
-    max-height: calc(100vh - 60px);
-    padding: 32px 36px;
+    width: calc(100vw - 40px);
+    max-height: calc(100vh - 52px);
+    padding: 36px 40px;
     aspect-ratio: auto;
   }
 
@@ -687,16 +694,19 @@
   .notes-body {
     grid-template-columns: 1fr;
     gap: 24px;
+    height: auto;
   }
 
   .notes-detail {
     order: -1;
+    height: auto;
   }
 
   .notes-grid {
     max-height: 45vh;
     grid-template-columns: minmax(0, 1fr);
     padding-right: 0;
+    height: auto;
   }
 }
 

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -1,6 +1,84 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import './note-modal.css';
 
+const VIEWPORT_FALLBACK = { width: 1440, height: 900 };
+const MODAL_ASPECT_RATIO = 16 / 9;
+const MAX_MODAL_WIDTH = 1840;
+const MAX_MODAL_HEIGHT = MAX_MODAL_WIDTH / MODAL_ASPECT_RATIO;
+const MIN_MODAL_WIDTH = 960;
+const MIN_MODAL_HEIGHT = MIN_MODAL_WIDTH / MODAL_ASPECT_RATIO;
+const HORIZONTAL_MARGIN = 64;
+const VERTICAL_MARGIN = 64;
+
+const readViewportSize = () => {
+  if (typeof window === 'undefined') {
+    return VIEWPORT_FALLBACK;
+  }
+
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+};
+
+const clampDimension = (value, margin, minimum, maximum) => {
+  const safeMinimum = Math.min(minimum, value);
+  const safeMaximum = Math.min(maximum, value);
+  const reducedValue = value - margin;
+
+  if (safeMaximum <= 0) {
+    return 0;
+  }
+
+  const expanded = Math.max(reducedValue, safeMinimum);
+  return Math.min(Math.max(expanded, 0), safeMaximum);
+};
+
+const computeModalDimensions = (viewport) => {
+  const baseWidth = viewport?.width ?? VIEWPORT_FALLBACK.width;
+  const baseHeight = viewport?.height ?? VIEWPORT_FALLBACK.height;
+
+  const maxWidth = clampDimension(baseWidth, HORIZONTAL_MARGIN, MIN_MODAL_WIDTH, MAX_MODAL_WIDTH);
+  const maxHeight = clampDimension(baseHeight, VERTICAL_MARGIN, MIN_MODAL_HEIGHT, MAX_MODAL_HEIGHT);
+
+  const hasSpace = maxWidth > 0 && maxHeight > 0;
+  const referenceWidth = hasSpace
+    ? maxWidth
+    : Math.min(VIEWPORT_FALLBACK.width - HORIZONTAL_MARGIN, MAX_MODAL_WIDTH);
+  const referenceHeight = hasSpace
+    ? maxHeight
+    : Math.min(VIEWPORT_FALLBACK.height - VERTICAL_MARGIN, MAX_MODAL_HEIGHT);
+
+  if (!referenceWidth || !referenceHeight) {
+    return {
+      width: MIN_MODAL_WIDTH,
+      height: MIN_MODAL_HEIGHT,
+      maxWidth: MIN_MODAL_WIDTH,
+      maxHeight: MIN_MODAL_HEIGHT,
+    };
+  }
+
+  const widthBasedOnHeight = referenceHeight * MODAL_ASPECT_RATIO;
+
+  if (widthBasedOnHeight <= referenceWidth) {
+    return {
+      width: widthBasedOnHeight,
+      height: referenceHeight,
+      maxWidth,
+      maxHeight,
+    };
+  }
+
+  const heightBasedOnWidth = referenceWidth / MODAL_ASPECT_RATIO;
+
+  return {
+    width: referenceWidth,
+    height: heightBasedOnWidth,
+    maxWidth,
+    maxHeight,
+  };
+};
+
 const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE'];
 const TAG_OPTIONS = ['ALL', ...QUADRANT_TAGS];
 const TAG_COLORS = {
@@ -303,10 +381,24 @@ const loadStoredNotes = () => {
 const pluralise = (count, singular, plural) => (count === 1 ? singular : plural);
 
 export default function NotesListModal({ onClose }) {
+  const [viewportSize, setViewportSize] = useState(() => readViewportSize());
   const [notes, setNotes] = useState(() => loadStoredNotes());
   const [searchTerm, setSearchTerm] = useState('');
   const [activeTag, setActiveTag] = useState('ALL');
   const [selectedId, setSelectedId] = useState(null);
+  const modalDimensions = useMemo(() => computeModalDimensions(viewportSize), [viewportSize]);
+  const modalStyle = useMemo(() => {
+    if (!modalDimensions) {
+      return undefined;
+    }
+
+    return {
+      width: `${modalDimensions.width}px`,
+      height: `${modalDimensions.height}px`,
+      maxWidth: `${modalDimensions.maxWidth}px`,
+      maxHeight: `${modalDimensions.maxHeight}px`,
+    };
+  }, [modalDimensions]);
 
   const filteredNotes = useMemo(() => {
     const query = searchTerm.trim().toLowerCase();
@@ -323,6 +415,23 @@ export default function NotesListModal({ onClose }) {
       return note.searchable.includes(query);
     });
   }, [notes, activeTag, searchTerm]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handleResize = () => {
+      setViewportSize(readViewportSize());
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   useEffect(() => {
     if (filteredNotes.length === 0) {
@@ -406,7 +515,11 @@ export default function NotesListModal({ onClose }) {
 
   return (
     <div className="modal-overlay" onClick={handleOverlayClick}>
-      <div className="modal notes-modal notes-list-modal" onClick={(event) => event.stopPropagation()}>
+      <div
+        className="modal notes-modal notes-list-modal"
+        onClick={(event) => event.stopPropagation()}
+        style={modalStyle}
+      >
         <header className="notes-header">
           <div>
             <h3>Your notes library</h3>

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -151,17 +151,17 @@
 }
 
 .notes-list-modal {
-  width: clamp(1440px, calc(100vw - 24px), 2880px);
-  max-width: calc(100vw - 24px);
-  max-height: min(1040px, calc(100vh - 64px));
-  padding: 40px 48px;
-  gap: 32px;
+  width: min(calc(100vw - 64px), 1840px);
+  max-width: calc(100vw - 64px);
+  max-height: calc(100vh - 64px);
+  padding: 48px 56px;
+  gap: 36px;
+  aspect-ratio: 16 / 9;
 }
 
 @media (min-height: 900px) {
   .notes-list-modal {
-    aspect-ratio: 16 / 10;
-    min-height: clamp(640px, 72vh, 920px);
+    min-height: min(clamp(680px, 78vh, 960px), calc(100vh - 64px));
   }
 }
 
@@ -452,6 +452,7 @@
   grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
   gap: 32px;
   align-items: stretch;
+  height: 100%;
 }
 
 .notes-grid {
@@ -461,7 +462,13 @@
   align-content: flex-start;
   overflow-y: auto;
   padding-right: 12px;
+  padding-left: 12px;
   min-height: 0;
+}
+
+.notes-grid,
+.notes-detail {
+  height: 100%;
 }
 
 .notes-card {
@@ -653,17 +660,17 @@
 
 @media (max-width: 1440px) {
   .notes-list-modal {
-    width: clamp(1040px, calc(100vw - 24px), 1980px);
-    padding: 36px 40px;
-    gap: 30px;
+    width: min(calc(100vw - 48px), 1680px);
+    padding: 44px 48px;
+    gap: 34px;
   }
 }
 
 @media (max-width: 1280px) {
   .notes-list-modal {
-    width: calc(100vw - 24px);
-    max-height: calc(100vh - 60px);
-    padding: 32px 36px;
+    width: calc(100vw - 40px);
+    max-height: calc(100vh - 52px);
+    padding: 36px 40px;
     aspect-ratio: auto;
   }
 
@@ -687,16 +694,19 @@
   .notes-body {
     grid-template-columns: 1fr;
     gap: 24px;
+    height: auto;
   }
 
   .notes-detail {
     order: -1;
+    height: auto;
   }
 
   .notes-grid {
     max-height: 45vh;
     grid-template-columns: minmax(0, 1fr);
     padding-right: 0;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- calculate viewport-aware dimensions for the notes library modal and apply them inline so the layout always expands toward a 16:9 frame
- watch window resize events to recalc the modal size and keep the experience responsive across screen sizes
- adjust supporting styles so the grid and detail panes stretch to the new height on large displays while collapsing cleanly on smaller ones
- balance the notes grid padding so the left gutter matches the right-hand spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5076c11648322a65555e03c29ccff