### PR TITLE
Fix undefined Unity host bounds reference

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -158,6 +158,7 @@ let unityActiveTitle = null;
 let unityHostWindow = null;
 let unityHostHandle = null;
 let unityHostBounds = null;
+let unityHostLastRect = null;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -376,6 +377,7 @@ function destroyUnityHostWindow() {
   unityMounted = false;
   unityActiveTitle = null;
   unityLastRect = null;
+  unityHostLastRect = null;
 }
 
 function ensureUnityHostWindow() {


### PR DESCRIPTION
## Summary
- define `unityHostLastRect` to prevent runtime reference errors when applying Unity host bounds
- reset the cached rectangle when tearing down the Unity host window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5127b897483228b6830a4a241480b