### PR TITLE
Fix Unity embedder arguments

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -562,6 +562,8 @@ async function embedUnity(rect) {
         hostHandle,
         String(width),
         String(height),
+        '0',
+        '0',
       ]);
         if (code === 0) {
           unityMounted = true;
@@ -655,6 +657,8 @@ function scheduleUnityResize(rect) {
           title,
           String(width),
           String(height),
+          '0',
+          '0',
         ]);
         if (code === 0) {
           if (!unityActiveTitle || unityActiveTitle.toLowerCase() !== title.toLowerCase()) {


### PR DESCRIPTION
## Summary
- ensure the Unity embedder receives the expected width/height/offset arguments when attaching the player window
- provide the same offsets during resize operations so the embedder can update the Unity window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5154105a48322810817947b1336f1