### PR TITLE
Fix Unity embedder argument handling

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -543,10 +543,8 @@ async function embedUnity(rect) {
     throw new Error('Failed to obtain host window handle.');
   }
 
-  const width = Math.max(0, Math.floor(normalized.width));
-  const height = Math.max(0, Math.floor(normalized.height));
-  const left = Math.floor(normalized.left);
-  const top = Math.floor(normalized.top);
+  const width = Math.max(0, Math.floor(hostBounds.width));
+  const height = Math.max(0, Math.floor(hostBounds.height));
 
   const titles = Array.isArray(config.titles) && config.titles.length > 0 ? config.titles : [];
   if (titles.length === 0) {
@@ -562,6 +560,8 @@ async function embedUnity(rect) {
         hostHandle,
         String(width),
         String(height),
+        '0',
+        '0',
       ]);
         if (code === 0) {
           unityMounted = true;
@@ -643,9 +643,12 @@ function scheduleUnityResize(rect) {
       if (!config) return;
       const orderedTitles = orderedUnityTitles(config);
       if (orderedTitles.length === 0) return;
-      updateUnityHostWindowBounds(rectToResize);
-      const width = Math.max(0, Math.floor(rectToResize.width));
-      const height = Math.max(0, Math.floor(rectToResize.height));
+      const hostBounds = updateUnityHostWindowBounds(rectToResize);
+      if (!hostBounds) {
+        return;
+      }
+      const width = Math.max(0, Math.floor(hostBounds.width));
+      const height = Math.max(0, Math.floor(hostBounds.height));
       if (width <= 0 || height <= 0) {
         return;
       }
@@ -655,6 +658,8 @@ function scheduleUnityResize(rect) {
           title,
           String(width),
           String(height),
+          '0',
+          '0',
         ]);
         if (code === 0) {
           if (!unityActiveTitle || unityActiveTitle.toLowerCase() !== title.toLowerCase()) {


### PR DESCRIPTION
## Summary
- ensure the Unity embed command provides the expected host window coordinates
- use the calculated host bounds for embed and resize commands so sizing matches the host window
- guard against missing host bounds during resize scheduling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e517286df0832292d2bb1d1b9b44a9