### PR TITLE
Fix Unity scene rendering issue in Electron app

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -394,7 +394,7 @@ function ensureUnityHostWindow() {
         modal: false,
         show: false,
         frame: false,
-        transparent: true,
+        transparent: false,  // Changed: Unity needs an opaque window to render
         resizable: false,
         movable: false,
         minimizable: false,
@@ -403,7 +403,7 @@ function ensureUnityHostWindow() {
         skipTaskbar: true,
         hasShadow: false,
         focusable: true,
-        backgroundColor: '#00000000',
+        backgroundColor: '#000000',  // Changed: Solid black background for Unity rendering
         webPreferences: {
           sandbox: true,
         },
@@ -416,9 +416,7 @@ function ensureUnityHostWindow() {
       if (typeof unityHostWindow.setMenuBarVisibility === 'function') {
         unityHostWindow.setMenuBarVisibility(false);
       }
-      if (typeof unityHostWindow.setAlwaysOnTop === 'function') {
-        unityHostWindow.setAlwaysOnTop(true, 'screen-saver');
-      }
+      // Removed setAlwaysOnTop - it can interfere with Unity rendering
       if (typeof unityHostWindow.showInactive === 'function') {
         unityHostWindow.showInactive();
       } else {
@@ -554,6 +552,7 @@ async function embedUnity(rect) {
 
   for (let attempt = 0; attempt < 10; attempt += 1) {
     for (const title of titles) {
+      console.log(`Unity embed attempt ${attempt + 1} for title: "${title}", handle: ${hostHandle}, dimensions: ${width}x${height}`);
       const code = await runUnityEmbedder([
         'embed',
         title,
@@ -563,12 +562,32 @@ async function embedUnity(rect) {
         '0',
         '0',
       ]);
-        if (code === 0) {
-          unityMounted = true;
-          unityLastRect = normalized;
-          unityActiveTitle = title;
-          return true;
+      if (code === 0) {
+        console.log(`Unity embed successful for title: "${title}"`);
+        // Make sure Unity window is shown after embedding
+        const showCode = await runUnityEmbedder(['show', title]);
+        console.log(`Unity show command result: ${showCode}`);
+        
+        // Force the host window to be visible and on top momentarily to trigger rendering
+        const host = ensureUnityHostWindow();
+        if (host && !host.isDestroyed()) {
+          host.focus();
+          host.blur();
+          // Force a repaint of the host window
+          const bounds = host.getBounds();
+          host.setBounds({ ...bounds, width: bounds.width + 1 });
+          setTimeout(() => {
+            if (!host.isDestroyed()) {
+              host.setBounds(bounds);
+            }
+          }, 50);
         }
+        
+        unityMounted = true;
+        unityLastRect = normalized;
+        unityActiveTitle = title;
+        return true;
+      }
     }
     await delay(400);
   }

--- a/src/world.css
+++ b/src/world.css
@@ -216,11 +216,14 @@
   max-width: 1200px;
   height: 100%;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.06);
-  backdrop-filter: blur(12px);
+  background: #000000; /* Changed: solid black background for Unity to render properly */
+  /* Removed backdrop-filter to prevent rendering issues */
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
   overflow: hidden;
   min-height: 540px;
+  /* Force the element to create a stacking context */
+  isolation: isolate;
+  transform: translateZ(0);
 }
 
 .unity-status {


### PR DESCRIPTION
## Summary

**Droid-assisted** fix for Unity window rendering issue where Unity process runs but scene doesn't display.

## Problem
- Unity app was launching and visible in Task Manager
- Electron showed loading space for Unity
- After loading, Unity scene was invisible despite process running
- Issue persisted for 3+ days of troubleshooting

## Root Causes Identified
1. **Transparent host window**: Unity cannot render on fully transparent windows (backgroundColor: '#00000000')
2. **Window layering conflict**: setAlwaysOnTop() with 'screen-saver' level interfered with rendering
3. **Missing activation**: Unity window wasn't explicitly shown after embedding

## Solution
- Changed Unity host window to opaque with solid black background
- Removed problematic setAlwaysOnTop() call
- Added explicit show command after successful embedding
- Implemented forced repaint mechanism to trigger rendering
- Updated CSS to use solid background instead of transparent blur effect
- Added focus/blur cycling to ensure proper window activation

## Testing Instructions
1. Launch the Electron app
2. Navigate to the Formless layer (World page)
3. Verify Unity scene loads and displays correctly
4. Check console logs for successful Unity embed messages
5. Confirm Unity window responds to resize events

## Technical Details
- Modified electron-main.js Unity host window configuration
- Updated world.css Unity panel styling
- Added debug logging for troubleshooting
- Implemented window repaint workaround for edge cases

This fix addresses the persistent Unity visibility issue while maintaining the embedded window architecture.