### PR TITLE
Add Access State Log tool for semi-formless layer

### DIFF
--- a/src/AccessStateLogger.jsx
+++ b/src/AccessStateLogger.jsx
@@ -1,0 +1,266 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './access-state-logger.css';
+
+const LAYERS = ['Form', 'Semi-Formless', 'Formless'];
+const QUADRANTS = ['II', 'IE', 'EI', 'EE'];
+const SIDES = ['♂', '♀'];
+const RATING_OPTIONS = [
+  { key: 'good', label: 'Good' },
+  { key: 'neutral', label: 'Neutral' },
+  { key: 'bad', label: 'Bad' },
+];
+
+const STORAGE_KEY = 'accessStateLog';
+const SELECTION_KEY = 'accessStateSelections';
+
+const createEmptySelection = () => ({
+  layers: ['Semi-Formless'],
+  quadrants: [],
+  sides: [],
+});
+
+export default function AccessStateLogger({ onBack }) {
+  const [selections, setSelections] = useState(() => {
+    try {
+      const stored = localStorage.getItem(SELECTION_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        return {
+          layers: Array.isArray(parsed.layers) ? parsed.layers : ['Semi-Formless'],
+          quadrants: Array.isArray(parsed.quadrants) ? parsed.quadrants : [],
+          sides: Array.isArray(parsed.sides) ? parsed.sides : [],
+        };
+      }
+    } catch (err) {
+      console.warn('Failed to parse selections', err);
+    }
+    return createEmptySelection();
+  });
+
+  const [log, setLog] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          return parsed;
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to parse access log', err);
+    }
+    return [];
+  });
+
+  const [recentRating, setRecentRating] = useState(null);
+
+  useEffect(() => {
+    localStorage.setItem(SELECTION_KEY, JSON.stringify(selections));
+  }, [selections]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(log));
+  }, [log]);
+
+  const toggleSelection = (group, value) => {
+    setSelections((prev) => {
+      const current = prev[group] || [];
+      const exists = current.includes(value);
+      let next;
+      if (exists) {
+        next = current.filter((item) => item !== value);
+      } else {
+        next = [...current, value];
+      }
+
+      if (group === 'layers' && next.length === 0) {
+        next = ['Semi-Formless'];
+      }
+
+      return { ...prev, [group]: next };
+    });
+  };
+
+  const summary = useMemo(() => {
+    const counts = {
+      good: 0,
+      neutral: 0,
+      bad: 0,
+    };
+    log.forEach((entry) => {
+      counts[entry.rating] = (counts[entry.rating] || 0) + 1;
+    });
+    const total = log.length || 1;
+    return RATING_OPTIONS.map((option) => ({
+      ...option,
+      count: counts[option.key] || 0,
+      percentage: Math.round(((counts[option.key] || 0) / total) * 100),
+    }));
+  }, [log]);
+
+  const addEntry = (ratingKey) => {
+    const timestamp = Date.now();
+    const entry = {
+      id: timestamp,
+      timestamp,
+      rating: ratingKey,
+      layers: [...new Set(selections.layers)].sort(),
+      quadrants: [...new Set(selections.quadrants)].sort(),
+      sides: [...new Set(selections.sides)].sort(),
+    };
+    setLog((prev) => [entry, ...prev]);
+    setRecentRating(ratingKey);
+  };
+
+  useEffect(() => {
+    if (!recentRating) return;
+    const timeout = setTimeout(() => setRecentRating(null), 2000);
+    return () => clearTimeout(timeout);
+  }, [recentRating]);
+
+  const renderSelectionGroup = (title, groupKey, options) => (
+    <div className="selection-group">
+      <h3>{title}</h3>
+      <div className="option-list">
+        {options.map((option) => {
+          const active = selections[groupKey]?.includes(option);
+          return (
+            <button
+              key={option}
+              type="button"
+              className={`option-chip ${active ? 'active' : ''}`}
+              onClick={() => toggleSelection(groupKey, option)}
+            >
+              {option}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="access-state-logger">
+      <div className="logger-header">
+        {onBack && (
+          <button className="back-button" onClick={onBack}>
+            Back
+          </button>
+        )}
+        <div className="title-block">
+          <h1>Access State Log</h1>
+          <p>Track which parts of you are online and how the experience felt.</p>
+        </div>
+      </div>
+
+      <div className="selections-grid">
+        {renderSelectionGroup('Layers', 'layers', LAYERS)}
+        {renderSelectionGroup('Quadrants', 'quadrants', QUADRANTS)}
+        {renderSelectionGroup('Side', 'sides', SIDES)}
+      </div>
+
+      <div className="rating-section">
+        <h3>Mood tone</h3>
+        <p className="hint">Click a point to instantly log this moment.</p>
+        <div className="vertical-scale">
+          <div className="scale-line" aria-hidden="true" />
+          {RATING_OPTIONS.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              className={`scale-option ${option.key} ${recentRating === option.key ? 'pulse' : ''}`}
+              onClick={() => addEntry(option.key)}
+            >
+              <span className="marker" />
+              <span className="label">{option.label}</span>
+            </button>
+          ))}
+        </div>
+        <div className="rating-summary">
+          {summary.map((option) => (
+            <div key={option.key} className="summary-pill">
+              <span className="summary-label">{option.label}</span>
+              <span className="summary-count">{option.count}</span>
+              <span className="summary-percentage">{option.percentage}%</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="current-access">
+        <h3>Current access</h3>
+        <div className="access-lines">
+          <div>
+            <span className="line-label">Layers:</span>
+            <span className="line-value">
+              {selections.layers.length > 0
+                ? selections.layers.join(', ')
+                : 'None selected'}
+            </span>
+          </div>
+          <div>
+            <span className="line-label">Quadrants:</span>
+            <span className="line-value">
+              {selections.quadrants.length > 0
+                ? selections.quadrants.join(', ')
+                : 'None selected'}
+            </span>
+          </div>
+          <div>
+            <span className="line-label">Side:</span>
+            <span className="line-value">
+              {selections.sides.length > 0
+                ? selections.sides.join(', ')
+                : 'Neutral'}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="log-section">
+        <h3>Log</h3>
+        {log.length === 0 ? (
+          <p className="empty-state">
+            No entries yet. Activate the modes you feel right now and tap the line to log it.
+          </p>
+        ) : (
+          <ul className="log-list">
+            {log.map((entry) => {
+              const date = new Date(entry.timestamp);
+              return (
+                <li key={entry.id} className={`log-entry ${entry.rating}`}>
+                  <div className="log-meta">
+                    <span className="log-date">
+                      {date.toLocaleDateString()} {date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    </span>
+                    <span className="log-rating">{RATING_OPTIONS.find((opt) => opt.key === entry.rating)?.label}</span>
+                  </div>
+                  <div className="log-data">
+                    <div>
+                      <span className="line-label">Layers:</span>
+                      <span className="line-value">
+                        {entry.layers.length ? entry.layers.join(', ') : '—'}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="line-label">Quadrants:</span>
+                      <span className="line-value">
+                        {entry.quadrants.length ? entry.quadrants.join(', ') : '—'}
+                      </span>
+                    </div>
+                    <div>
+                      <span className="line-label">Side:</span>
+                      <span className="line-value">
+                        {entry.sides.length ? entry.sides.join(', ') : '—'}
+                      </span>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import CharacterEvolve from './CharacterEvolve.jsx';
 import Weakness from './Weakness.jsx';
 import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
 import FormlessCharacter from './FormlessCharacter.jsx';
+import AccessStateLogger from './AccessStateLogger.jsx';
 import SettingsModal from './SettingsModal.jsx';
 import AkashicRecords from './AkashicRecords.jsx';
 import { supabaseClient } from './supabaseClient';
@@ -85,6 +86,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showActivity, setShowActivity] = useState(false);
   const [showCharacterEvolve, setShowCharacterEvolve] = useState(false);
   const [showWeakness, setShowWeakness] = useState(false);
+  const [showAccessLog, setShowAccessLog] = useState(false);
   const [showIdeaBoard, setShowIdeaBoard] = useState(false);
   const [showImplementationIdeas, setShowImplementationIdeas] = useState(false);
   const [showOrb, setShowOrb] = useState(false);
@@ -123,6 +125,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       activity: 'Form',
       characterEvolve: 'Form',
       weakness: 'Semi-Formless',
+      accessLog: 'Semi-Formless',
       ideaBoard: 'Form',
       implementationIdeas: 'Form',
       orb: 'Form',
@@ -194,6 +197,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showActivity ||
     showCharacterEvolve ||
     showWeakness ||
+    showAccessLog ||
     showSemiCharacter ||
     showIdeaBoard ||
     showImplementationIdeas ||
@@ -226,6 +230,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowActivity(false);
     setShowCharacterEvolve(false);
     setShowWeakness(false);
+    setShowAccessLog(false);
     setShowSemiCharacter(false);
     setShowIdeaBoard(false);
     setShowImplementationIdeas(false);
@@ -700,6 +705,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <CharacterEvolve onBack={() => setShowCharacterEvolve(false)} />
             ) : showWeakness ? (
               <Weakness onBack={() => setShowWeakness(false)} />
+            ) : showAccessLog ? (
+              <AccessStateLogger onBack={() => setShowAccessLog(false)} />
             ) : showSemiCharacter ? (
               <SemiFormlessCharacter onBack={() => setShowSemiCharacter(false)} />
             ) : showIdeaBoard ? (
@@ -964,6 +971,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">⚡</div>
                     <span>Weakness</span>
+                  </div>
+                )}
+                {appLayers.accessLog === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowAccessLog(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'accessLog')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'accessLog')}
+                  >
+                    <div className="star-icon">🌀</div>
+                    <span>Access State Log</span>
                   </div>
                 )}
                 {appLayers.semiCharacter === activeLayer && (

--- a/src/access-state-logger.css
+++ b/src/access-state-logger.css
@@ -1,0 +1,330 @@
+.access-state-logger {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 24px;
+  color: #f0f4ff;
+  background: rgba(10, 12, 20, 0.85);
+  backdrop-filter: blur(12px);
+  overflow: hidden;
+}
+
+.access-state-logger .logger-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.access-state-logger .back-button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  color: inherit;
+  padding: 8px 18px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.access-state-logger .back-button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.access-state-logger .title-block h1 {
+  margin: 0;
+  font-size: 1.8rem;
+  letter-spacing: 0.04em;
+}
+
+.access-state-logger .title-block p {
+  margin: 4px 0 0;
+  opacity: 0.7;
+  max-width: 520px;
+}
+
+.selections-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.selection-group h3 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.8;
+}
+
+.option-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.option-chip {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 6px 14px;
+  color: inherit;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.option-chip:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.option-chip.active {
+  background: linear-gradient(135deg, rgba(88, 110, 255, 0.9), rgba(156, 88, 255, 0.9));
+  border-color: rgba(255, 255, 255, 0.5);
+  box-shadow: 0 4px 18px rgba(88, 110, 255, 0.4);
+}
+
+.rating-section {
+  margin-bottom: 24px;
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(22, 24, 36, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.rating-section h3 {
+  margin: 0 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.95rem;
+}
+
+.rating-section .hint {
+  margin: 0 0 18px;
+  opacity: 0.65;
+  font-size: 0.85rem;
+}
+
+.vertical-scale {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 24px;
+  padding-left: 32px;
+  margin-bottom: 16px;
+}
+
+.scale-line {
+  position: absolute;
+  left: 12px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    rgba(80, 120, 255, 0.3),
+    rgba(200, 80, 120, 0.3)
+  );
+}
+
+.scale-option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 12px;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.scale-option .marker {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.scale-option.good .marker {
+  background: rgba(120, 255, 180, 0.9);
+}
+
+.scale-option.neutral .marker {
+  background: rgba(255, 220, 120, 0.9);
+}
+
+.scale-option.bad .marker {
+  background: rgba(255, 120, 120, 0.9);
+}
+
+.scale-option:hover {
+  transform: translateX(6px);
+}
+
+.scale-option:hover .marker {
+  box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.12);
+}
+
+.scale-option.pulse .marker {
+  animation: markerPulse 0.8s ease;
+}
+
+@keyframes markerPulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+  }
+  50% {
+    transform: scale(1.2);
+    box-shadow: 0 0 0 10px rgba(255, 255, 255, 0.15);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+  }
+}
+
+.rating-summary {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.summary-pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 0.85rem;
+}
+
+.summary-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.summary-count {
+  font-variant-numeric: tabular-nums;
+}
+
+.summary-percentage {
+  opacity: 0.6;
+}
+
+.current-access {
+  margin-bottom: 24px;
+  padding: 18px 20px;
+  border-radius: 20px;
+  background: rgba(20, 20, 32, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.access-lines {
+  display: grid;
+  gap: 8px;
+}
+
+.line-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.6;
+  margin-right: 8px;
+}
+
+.line-value {
+  font-weight: 600;
+}
+
+.log-section {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.log-section h3 {
+  margin: 0 0 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.empty-state {
+  margin: 0;
+  opacity: 0.65;
+  font-size: 0.9rem;
+}
+
+.log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.log-entry {
+  padding: 14px 18px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.log-entry.good {
+  border-color: rgba(120, 255, 180, 0.4);
+}
+
+.log-entry.neutral {
+  border-color: rgba(255, 220, 120, 0.35);
+}
+
+.log-entry.bad {
+  border-color: rgba(255, 120, 120, 0.35);
+}
+
+.log-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.log-rating {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.log-data {
+  display: grid;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .access-state-logger {
+    padding: 18px;
+  }
+
+  .vertical-scale {
+    gap: 18px;
+  }
+
+  .log-entry {
+    font-size: 0.85rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an Access State Log tool that records layer, quadrant, and side combinations with instant good/neutral/bad logging
- style the new logger with semi-formless themed layout and vertical scale interactions
- expose the tool from the Tools hub with semi-formless defaults and layer management support

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e6af4b850483229ba07862851be24e