### PR TITLE
Add mood quadrant exploration mini game

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -12,6 +12,7 @@ import Calendar from './src/Calendar.jsx';
 import Timeline from './Timeline.jsx';
 import Typomancy from './Typomancy.jsx';
 import Moodtracker from './Moodtracker.jsx';
+import MoodQuadrantGame from './MoodQuadrantGame.jsx';
 import Anima from './Anima.jsx';
 import ToolsBlog from './src/ToolsBlog.jsx';
 import MomentoMori from './MomentoMori.jsx';
@@ -65,6 +66,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showTypomancy, setShowTypomancy] = useState(false);
   const [showMoodtracker, setShowMoodtracker] = useState(false);
   const [showAnima, setShowAnima] = useState(false);
+  const [showMoodQuadrantGame, setShowMoodQuadrantGame] = useState(false);
   const [showMomentoMori, setShowMomentoMori] = useState(false);
   // Avoid naming clash with src/App.jsx by giving the blog state a unique name
   const [showToolsBlog, setShowToolsBlog] = useState(false);
@@ -97,6 +99,7 @@ const anyAppOpen =
   showTypomancy ||
   showMoodtracker ||
   showAnima ||
+  showMoodQuadrantGame ||
   showMomentoMori ||
   showWatchdog ||
   showToolsBlog ||
@@ -117,6 +120,7 @@ const closeOpenApp = () => {
   setShowTypomancy(false);
   setShowMoodtracker(false);
   setShowAnima(false);
+  setShowMoodQuadrantGame(false);
   setShowMomentoMori(false);
   setShowWatchdog(false);
   setShowToolsBlog(false);
@@ -362,6 +366,8 @@ useEffect(() => {
               <Typomancy onBack={() => setShowTypomancy(false)} />
             ) : showMoodtracker ? (
               <Moodtracker onBack={() => setShowMoodtracker(false)} />
+            ) : showMoodQuadrantGame ? (
+              <MoodQuadrantGame onBack={() => setShowMoodQuadrantGame(false)} />
             ) : showMomentoMori ? (
               <MomentoMori onBack={() => setShowMomentoMori(false)} />
             ) : showWatchdog ? (
@@ -415,6 +421,13 @@ useEffect(() => {
                 <div className="app-card" onClick={() => setShowMoodtracker(true)}>
                   <div className="star-icon">😊</div>
                   <span>Moodtracker</span>
+                </div>
+                <div
+                  className="app-card"
+                  onClick={() => setShowMoodQuadrantGame(true)}
+                >
+                  <div className="star-icon">🧭</div>
+                  <span>Mood Quadrant</span>
                 </div>
                 <div className="app-card" onClick={() => setShowMomentoMori(true)}>
                   <div className="star-icon">☠️</div>

--- a/MoodQuadrantGame.jsx
+++ b/MoodQuadrantGame.jsx
@@ -1,0 +1,309 @@
+import React, { useMemo, useState } from 'react';
+import './mood-quadrant-game.css';
+
+const CONTENT_LIBRARY = [
+  {
+    id: 'sunrise-playlist',
+    title: 'Sunrise Playlist',
+    description: 'Gentle acoustic tracks to ease into the day.',
+    moodTags: ['Calm', 'Hopeful'],
+    quadrant: 'II',
+  },
+  {
+    id: 'focus-ritual',
+    title: 'Focus Ritual',
+    description: 'A candle, a mantra, and 10 minutes of deep work.',
+    moodTags: ['Focused', 'Grounded'],
+    quadrant: 'IE',
+  },
+  {
+    id: 'spontaneous-dance',
+    title: 'Spontaneous Dance',
+    description: 'Pick a song at random and dance until it ends.',
+    moodTags: ['Playful', 'Energised'],
+    quadrant: 'EE',
+  },
+  {
+    id: 'gratitude-scan',
+    title: 'Gratitude Scan',
+    description: 'List three things that made you smile today.',
+    moodTags: ['Grateful', 'Warm'],
+    quadrant: 'II',
+  },
+  {
+    id: 'mirror-pep-talk',
+    title: 'Mirror Pep Talk',
+    description: 'Give yourself the best hype speech you can.',
+    moodTags: ['Confident', 'Bold'],
+    quadrant: 'EI',
+  },
+  {
+    id: 'forest-walk',
+    title: 'Forest Walk',
+    description: 'Take a mindful stroll and observe every colour you see.',
+    moodTags: ['Calm', 'Curious'],
+    quadrant: 'IE',
+  },
+  {
+    id: 'idea-lightning',
+    title: 'Idea Lightning',
+    description: 'Write five ideas in five minutes without judging them.',
+    moodTags: ['Curious', 'Creative'],
+    quadrant: 'EI',
+  },
+  {
+    id: 'call-a-friend',
+    title: 'Call a Friend',
+    description: 'Share a recent win or ask them about theirs.',
+    moodTags: ['Connected', 'Supportive'],
+    quadrant: 'EE',
+  },
+  {
+    id: 'slow-tea',
+    title: 'Slow Tea',
+    description: 'Brew your favourite tea and sip it with total presence.',
+    moodTags: ['Calm', 'Grounded'],
+    quadrant: 'II',
+  },
+  {
+    id: 'bold-micro-action',
+    title: 'Bold Micro Action',
+    description: 'Take the smallest step toward something that scares you.',
+    moodTags: ['Bold', 'Adventurous'],
+    quadrant: 'EI',
+  },
+  {
+    id: 'inspiration-gallery',
+    title: 'Inspiration Gallery',
+    description: 'Scroll through saved artworks and pin the one that resonates.',
+    moodTags: ['Inspired', 'Reflective'],
+    quadrant: 'IE',
+  },
+  {
+    id: 'celebration-toast',
+    title: 'Celebration Toast',
+    description: 'Raise a glass (water counts) to a tiny victory.',
+    moodTags: ['Joyful', 'Confident'],
+    quadrant: 'EE',
+  },
+];
+
+const STORAGE_KEY = 'moodQuadrantSelections';
+
+const allMoodTags = Array.from(
+  new Set(CONTENT_LIBRARY.flatMap((entry) => entry.moodTags))
+).sort();
+
+function formatTimestamp(timestamp) {
+  const date = new Date(timestamp);
+  return `${date.toLocaleDateString()} • ${date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  })}`;
+}
+
+export default function MoodQuadrantGame({ onBack }) {
+  const [selections, setSelections] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) return [];
+      const parsed = JSON.parse(stored);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (err) {
+      console.warn('Unable to read stored selections', err);
+      return [];
+    }
+  });
+  const [filter, setFilter] = useState('All');
+
+  const entryById = useMemo(() => {
+    const map = new Map();
+    CONTENT_LIBRARY.forEach((entry) => {
+      map.set(entry.id, entry);
+    });
+    return map;
+  }, []);
+
+  const resolvedSelections = useMemo(
+    () =>
+      selections
+        .map((selection) => ({
+          ...entryById.get(selection.id),
+          timestamp: selection.timestamp,
+        }))
+        .filter((entry) => entry.id),
+    [entryById, selections]
+  );
+
+  const insights = useMemo(() => {
+    const moodCounts = new Map();
+    const quadrantCounts = new Map();
+
+    resolvedSelections.forEach((entry) => {
+      entry.moodTags.forEach((tag) => {
+        moodCounts.set(tag, (moodCounts.get(tag) || 0) + 1);
+      });
+      quadrantCounts.set(
+        entry.quadrant,
+        (quadrantCounts.get(entry.quadrant) || 0) + 1
+      );
+    });
+
+    const sortedMoods = Array.from(moodCounts.entries()).sort(
+      (a, b) => b[1] - a[1]
+    );
+    const sortedQuadrants = Array.from(quadrantCounts.entries()).sort(
+      (a, b) => b[1] - a[1]
+    );
+
+    const topMood = sortedMoods[0]?.[0] || 'Not enough data';
+    const secondaryMood = sortedMoods[1]?.[0] || null;
+    const dominantQuadrant = sortedQuadrants[0]?.[0] || '—';
+
+    return {
+      moodCounts,
+      quadrantCounts,
+      sortedMoods,
+      sortedQuadrants,
+      topMood,
+      secondaryMood,
+      dominantQuadrant,
+    };
+  }, [resolvedSelections]);
+
+  const filteredLibrary = useMemo(() => {
+    if (filter === 'All') return CONTENT_LIBRARY;
+    return CONTENT_LIBRARY.filter((entry) => entry.moodTags.includes(filter));
+  }, [filter]);
+
+  const handleSelect = (entry) => {
+    setSelections((prev) => {
+      const next = [...prev, { id: entry.id, timestamp: Date.now() }];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  };
+
+  const handleReset = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    setSelections([]);
+  };
+
+  return (
+    <div className="mood-quadrant-game">
+      <aside className="mood-quadrant-sidebar">
+        <button className="back-button" onClick={onBack}>
+          ← Back
+        </button>
+        <h2>Signal Scanner</h2>
+        <p>
+          Choose the experiences that resonate with you right now. We will use
+          their mood tags and quadrant labels to sketch the state you are in.
+        </p>
+        <div className="insight-card">
+          <h3>Current Mood Signal</h3>
+          <p className="primary-reading">{insights.topMood}</p>
+          {insights.secondaryMood ? (
+            <p className="secondary-reading">
+              Secondary tone: {insights.secondaryMood}
+            </p>
+          ) : (
+            <p className="secondary-reading subtle">Select a few entries</p>
+          )}
+        </div>
+        <div className="insight-card">
+          <h3>Dominant Quadrant</h3>
+          <p className="primary-reading quadrant">{insights.dominantQuadrant}</p>
+          <ul className="distribution">
+            {insights.sortedQuadrants.map(([label, value]) => (
+              <li key={label}>
+                <span>{label}</span>
+                <span className="bar">
+                  <span
+                    className="fill"
+                    style={{ width: `${(value / resolvedSelections.length) * 100}%` }}
+                  ></span>
+                </span>
+                <span>{value}</span>
+              </li>
+            ))}
+            {!resolvedSelections.length && <li className="subtle">No data yet</li>}
+          </ul>
+        </div>
+        <button className="reset-button" onClick={handleReset} disabled={!selections.length}>
+          Reset log
+        </button>
+      </aside>
+      <main className="mood-quadrant-main">
+        <section className="library-header">
+          <h2>Library Picks</h2>
+          <div className="filters">
+            <button
+              className={filter === 'All' ? 'active' : ''}
+              onClick={() => setFilter('All')}
+            >
+              All moods
+            </button>
+            {allMoodTags.map((tag) => (
+              <button
+                key={tag}
+                className={filter === tag ? 'active' : ''}
+                onClick={() => setFilter(tag)}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        </section>
+        <section className="library-grid">
+          {filteredLibrary.map((entry) => (
+            <button
+              key={entry.id}
+              className="library-card"
+              onClick={() => handleSelect(entry)}
+            >
+              <div className="card-head">
+                <span className="quadrant-pill">{entry.quadrant}</span>
+                <div className="mood-tags">
+                  {entry.moodTags.map((tag) => (
+                    <span key={tag} className="tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <h3>{entry.title}</h3>
+              <p>{entry.description}</p>
+            </button>
+          ))}
+        </section>
+        <section className="recent-selections">
+          <h2>Recent selections</h2>
+          {resolvedSelections.length ? (
+            <ul>
+              {resolvedSelections
+                .slice()
+                .reverse()
+                .slice(0, 6)
+                .map((entry, index) => (
+                  <li key={`${entry.id}-${index}`}>
+                    <div>
+                      <strong>{entry.title}</strong>
+                      <span className="timestamp">
+                        {formatTimestamp(entry.timestamp)}
+                      </span>
+                    </div>
+                    <div className="recent-tags">
+                      {entry.moodTags.join(' • ')}
+                    </div>
+                  </li>
+                ))}
+            </ul>
+          ) : (
+            <p className="subtle">No picks logged yet. Try tapping a card above.</p>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/mood-quadrant-game.css
+++ b/mood-quadrant-game.css
@@ -1,0 +1,305 @@
+.mood-quadrant-game {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  height: 100%;
+  color: #f6f6f6;
+  background: linear-gradient(135deg, #11141d, #1f2233 40%, #0f111c 100%);
+}
+
+.mood-quadrant-sidebar {
+  padding: 32px 28px;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background: rgba(6, 8, 14, 0.6);
+  backdrop-filter: blur(16px);
+}
+
+.mood-quadrant-sidebar h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.mood-quadrant-sidebar p {
+  margin: 0;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.back-button {
+  align-self: flex-start;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.back-button:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+  transform: translateX(-2px);
+}
+
+.insight-card {
+  border-radius: 18px;
+  padding: 18px;
+  background: rgba(28, 31, 48, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.insight-card h3 {
+  margin: 0;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.primary-reading {
+  font-size: 26px;
+  font-weight: 600;
+}
+
+.primary-reading.quadrant {
+  font-size: 32px;
+  letter-spacing: 0.08em;
+}
+
+.secondary-reading {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.secondary-reading.subtle,
+.subtle {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.distribution {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.distribution li {
+  display: grid;
+  grid-template-columns: 32px 1fr 36px;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+}
+
+.distribution .bar {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.distribution .fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: linear-gradient(90deg, #4f6ef7, #aa73ff);
+}
+
+.reset-button {
+  margin-top: auto;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.reset-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.reset-button:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.mood-quadrant-main {
+  display: flex;
+  flex-direction: column;
+  padding: 32px 36px;
+  gap: 32px;
+  overflow-y: auto;
+}
+
+.library-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.library-header h2 {
+  margin: 0;
+  font-size: 28px;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.filters button {
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.filters button.active,
+.filters button:hover {
+  background: rgba(79, 110, 247, 0.25);
+  border-color: rgba(110, 140, 255, 0.6);
+}
+
+.library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.library-card {
+  text-align: left;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 18px;
+  background: rgba(14, 17, 27, 0.65);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: inherit;
+  transition: transform 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.library-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(110, 140, 255, 0.4);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.library-card h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.library-card p {
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.quadrant-pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(79, 110, 247, 0.35);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+}
+
+.mood-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+.tag {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+}
+
+.recent-selections ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recent-selections li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(16, 19, 30, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.recent-selections strong {
+  display: block;
+  font-size: 15px;
+}
+
+.timestamp {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.recent-tags {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 1100px) {
+  .mood-quadrant-game {
+    grid-template-columns: 1fr;
+  }
+
+  .mood-quadrant-sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    border-right: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .mood-quadrant-sidebar .insight-card {
+    flex: 1;
+    min-width: 200px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Mood Quadrant mini game that lets users pick tagged library items and highlights their dominant moods and quadrants
- surface the tool from the Tools tab alongside existing mood tracker functionality
- style the experience with a dedicated layout, insight sidebar, and interactive library grid

## Testing
- npm test -- --runTestsByPath Moodtracker.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e6b60361688322a30742bbfdfa13e4