### PR TITLE
Style library word entries

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -2005,7 +2005,11 @@ export default function Library({ onBack }) {
             )}
             <ul className="word-list">
               {words.map((w) => (
-                <li key={w.id}>{w.text}</li>
+                <li key={w.id} className="word-item">
+                  <div className="word-card">
+                    <span className="word-card-text">{w.text}</span>
+                  </div>
+                </li>
               ))}
             </ul>
           </div>

--- a/src/library.css
+++ b/src/library.css
@@ -593,6 +593,48 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.word-item {
+  margin: 0;
+  padding: 0;
+}
+
+.word-card {
+  background: var(--library-surface);
+  border: 1px solid var(--library-surface-border);
+  border-radius: 16px;
+  padding: 12px 16px;
+  min-width: 140px;
+  max-width: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  box-shadow: var(--library-shadow-soft, 0 6px 16px rgba(15, 23, 42, 0.08));
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease;
+  cursor: grab;
+}
+
+.word-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--library-accent);
+  box-shadow: var(--library-shadow, 0 12px 24px rgba(15, 23, 42, 0.15));
+}
+
+.word-card:active {
+  cursor: grabbing;
+}
+
+.word-card-text {
+  font-size: 0.95rem;
+  color: var(--library-text);
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 /* Sound cards mimic image cards with square aspect and overlay controls */


### PR DESCRIPTION
## Summary
- wrap library word entries in dedicated card containers to give each item a handle
- style word cards with pill-like surfaces that can be grabbed for future drag interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8065d46608322b721283547233ffc