### PR TITLE
Add activity logging tracker

### DIFF
--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -1,0 +1,373 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './placeholder-app.css';
+import './activity-log.css';
+
+const ENTRIES_KEY = 'activityLogEntries';
+const CURRENT_KEY = 'activityLogCurrent';
+
+const safeParse = (value, fallback) => {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(fallback) && !Array.isArray(parsed) ? fallback : parsed ?? fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+const formatDuration = (ms) => {
+  if (!ms || ms <= 0) return '0m 00s';
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  parts.push(`${hours > 0 ? String(minutes).padStart(2, '0') : minutes}m`);
+  parts.push(String(seconds).padStart(2, '0') + 's');
+  return parts.join(' ');
+};
+
+const formatDateTime = (value) => {
+  if (!value) return 'Unknown';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  return date.toLocaleString();
+};
+
+const finalizeSession = (session, endTime = new Date()) => {
+  if (!session) return null;
+  const end = endTime instanceof Date ? endTime : new Date(endTime);
+  const segments = Array.isArray(session.segments) ? [...session.segments] : [];
+  let elapsed = session.elapsed || 0;
+
+  if (session.activeSegmentStart) {
+    const startMs = new Date(session.activeSegmentStart).getTime();
+    const endMs = end.getTime();
+    if (!Number.isNaN(startMs) && endMs > startMs) {
+      elapsed += endMs - startMs;
+      segments.push({
+        start: session.activeSegmentStart,
+        end: end.toISOString(),
+      });
+    }
+  }
+
+  if (elapsed <= 0) {
+    return null;
+  }
+
+  return {
+    id: session.id || end.getTime(),
+    name: session.name,
+    startedAt: session.startedAt,
+    endedAt: end.toISOString(),
+    durationMs: elapsed,
+    segments,
+  };
+};
+
+export default function ActivityLog({ onBack }) {
+  const [entries, setEntries] = useState(() =>
+    safeParse(localStorage.getItem(ENTRIES_KEY), [])
+  );
+  const [current, setCurrent] = useState(() =>
+    safeParse(localStorage.getItem(CURRENT_KEY), null)
+  );
+  const [activityName, setActivityName] = useState(() => current?.name || '');
+  const [tick, setTick] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setTick(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(ENTRIES_KEY, JSON.stringify(entries));
+  }, [entries]);
+
+  useEffect(() => {
+    if (current) {
+      localStorage.setItem(CURRENT_KEY, JSON.stringify(current));
+    } else {
+      localStorage.removeItem(CURRENT_KEY);
+    }
+  }, [current]);
+
+  const currentElapsed = useMemo(() => {
+    if (!current) return 0;
+    const activeStart = current.activeSegmentStart
+      ? new Date(current.activeSegmentStart).getTime()
+      : null;
+    if (!activeStart) {
+      return current.elapsed || 0;
+    }
+    const now = tick;
+    if (Number.isNaN(activeStart) || now <= activeStart) {
+      return current.elapsed || 0;
+    }
+    return (current.elapsed || 0) + (now - activeStart);
+  }, [current, tick]);
+
+  const totals = useMemo(() => {
+    const map = new Map();
+    entries.forEach((entry) => {
+      if (!entry?.name || !entry?.durationMs) return;
+      const prev = map.get(entry.name) || 0;
+      map.set(entry.name, prev + entry.durationMs);
+    });
+    if (current?.name) {
+      const prev = map.get(current.name) || 0;
+      map.set(current.name, prev + currentElapsed);
+    }
+    return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
+  }, [entries, current, currentElapsed]);
+
+  const suggestions = useMemo(() => {
+    const set = new Set(entries.map((entry) => entry.name).filter(Boolean));
+    if (current?.name) set.add(current.name);
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [entries, current]);
+
+  const sortedHistory = useMemo(() => {
+    return [...entries].sort((a, b) => {
+      const aDate = new Date(a.endedAt || a.startedAt || 0).getTime();
+      const bDate = new Date(b.endedAt || b.startedAt || 0).getTime();
+      return bDate - aDate;
+    });
+  }, [entries]);
+
+  const isRunning = Boolean(current?.activeSegmentStart);
+  const trimmedName = activityName.trim();
+  const isSameActivity = current?.name && trimmedName === current.name;
+  const startDisabled = !trimmedName || (isSameActivity && isRunning);
+  const startLabel = !trimmedName
+    ? 'Start Activity'
+    : isSameActivity
+      ? isRunning
+        ? 'Running'
+        : 'Resume Activity'
+      : current
+        ? 'Switch Activity'
+        : 'Start Activity';
+
+  const persistEntries = (next) => {
+    setEntries(next);
+    localStorage.setItem(ENTRIES_KEY, JSON.stringify(next));
+  };
+
+  const persistCurrent = (next) => {
+    setCurrent(next);
+    if (next) {
+      localStorage.setItem(CURRENT_KEY, JSON.stringify(next));
+    } else {
+      localStorage.removeItem(CURRENT_KEY);
+    }
+  };
+
+  const handleStart = () => {
+    if (startDisabled) return;
+    const now = new Date();
+
+    if (current && current.name !== trimmedName) {
+      const finished = finalizeSession(current, now);
+      if (finished) {
+        persistEntries([...entries, finished]);
+      }
+    }
+
+    if (current && current.name === trimmedName) {
+      if (current.activeSegmentStart) return;
+      const resumed = {
+        ...current,
+        activeSegmentStart: now.toISOString(),
+      };
+      persistCurrent(resumed);
+    } else {
+      const nextSession = {
+        id: now.getTime(),
+        name: trimmedName,
+        startedAt: now.toISOString(),
+        elapsed: 0,
+        segments: [],
+        activeSegmentStart: now.toISOString(),
+      };
+      persistCurrent(nextSession);
+      setActivityName(trimmedName);
+    }
+  };
+
+  const handlePause = () => {
+    if (!current?.activeSegmentStart) return;
+    const now = new Date();
+    const startMs = new Date(current.activeSegmentStart).getTime();
+    if (Number.isNaN(startMs)) {
+      persistCurrent({ ...current, activeSegmentStart: null });
+      return;
+    }
+    const endIso = now.toISOString();
+    const duration = now.getTime() - startMs;
+    const next = {
+      ...current,
+      elapsed: (current.elapsed || 0) + Math.max(0, duration),
+      segments: [
+        ...(Array.isArray(current.segments) ? current.segments : []),
+        { start: current.activeSegmentStart, end: endIso },
+      ],
+      activeSegmentStart: null,
+    };
+    persistCurrent(next);
+  };
+
+  const handleStop = () => {
+    if (!current) return;
+    const finished = finalizeSession(current, new Date());
+    if (finished) {
+      persistEntries([...entries, finished]);
+    }
+    persistCurrent(null);
+  };
+
+  const handleClear = () => {
+    if (!entries.length && !current) return;
+    if (window.confirm('Clear all logged activities? This cannot be undone.')) {
+      persistEntries([]);
+      persistCurrent(null);
+      setActivityName('');
+    }
+  };
+
+  return (
+    <div className="placeholder-app activity-log">
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
+      <div className="current-activity-card">
+        <div>
+          <h2>Activity Tracker</h2>
+          <p className="current-activity-label">
+            {current ? (
+              <>
+                <span className="pill running">{current.name}</span>
+                <span className="separator">•</span>
+                {isRunning ? 'Tracking now' : 'Paused'}
+              </>
+            ) : (
+              'No activity running'
+            )}
+          </p>
+        </div>
+        <div className="current-activity-time">
+          {formatDuration(currentElapsed)}
+        </div>
+      </div>
+
+      <section className="activity-log-controls">
+        <label htmlFor="activity-input" className="activity-input-label">
+          What are you doing right now?
+        </label>
+        <input
+          id="activity-input"
+          className="activity-input"
+          type="text"
+          placeholder="e.g. Singing, Coding, Reading"
+          value={activityName}
+          onChange={(event) => setActivityName(event.target.value)}
+        />
+        {suggestions.length > 0 && (
+          <div className="activity-suggestions">
+            <span>Recent:</span>
+            <div className="chips">
+              {suggestions.map((name) => (
+                <button
+                  key={name}
+                  type="button"
+                  className={
+                    name === trimmedName ? 'chip selected' : 'chip'
+                  }
+                  onClick={() => setActivityName(name)}
+                >
+                  {name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        <div className="control-buttons">
+          <button
+            type="button"
+            className="primary"
+            onClick={handleStart}
+            disabled={startDisabled}
+          >
+            {startLabel}
+          </button>
+          <button
+            type="button"
+            onClick={handlePause}
+            disabled={!isRunning}
+          >
+            Pause
+          </button>
+          <button type="button" onClick={handleStop} disabled={!current}>
+            Stop &amp; Save
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={handleClear}
+            disabled={!entries.length && !current}
+          >
+            Clear Log
+          </button>
+        </div>
+      </section>
+
+      <section className="activity-summary">
+        <h3>Total time by activity</h3>
+        {totals.length === 0 ? (
+          <p className="empty">You have not logged any activity yet.</p>
+        ) : (
+          <ul>
+            {totals.map(([name, duration]) => (
+              <li key={name}>
+                <span>{name}</span>
+                <span>
+                  {formatDuration(duration)}
+                  <span className="hours">({(duration / 3600000).toFixed(2)} h)</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="activity-history">
+        <h3>Session history</h3>
+        {sortedHistory.length === 0 ? (
+          <p className="empty">No sessions saved yet.</p>
+        ) : (
+          <ul>
+            {sortedHistory.map((entry) => (
+              <li key={entry.id}>
+                <div className="history-header">
+                  <span className="history-activity">{entry.name}</span>
+                  <span className="history-duration">
+                    {formatDuration(entry.durationMs)}
+                  </span>
+                </div>
+                <div className="history-meta">
+                  {formatDateTime(entry.startedAt)} → {formatDateTime(entry.endedAt)}
+                </div>
+                {entry.segments && entry.segments.length > 1 && (
+                  <div className="history-meta muted">
+                    {entry.segments.length} segments logged
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
 import TodoGoals from './TodoGoals.jsx';
 import ActivityApp from './ActivityApp.jsx';
+import ActivityLog from './ActivityLog.jsx';
 import Orb from '../Orb.jsx';
 import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
@@ -84,6 +85,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showTrinities, setShowTrinities] = useState(false);
   const [showTodoGoals, setShowTodoGoals] = useState(false);
   const [showActivity, setShowActivity] = useState(false);
+  const [showActivityLog, setShowActivityLog] = useState(false);
   const [showCharacterEvolve, setShowCharacterEvolve] = useState(false);
   const [showWeakness, setShowWeakness] = useState(false);
   const [showAccessLog, setShowAccessLog] = useState(false);
@@ -123,6 +125,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       library: 'Form',
       todoGoals: 'Form',
       activity: 'Form',
+      activityLog: 'Form',
       characterEvolve: 'Form',
       weakness: 'Semi-Formless',
       accessLog: 'Semi-Formless',
@@ -195,6 +198,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showLibrary ||
     showTodoGoals ||
     showActivity ||
+    showActivityLog ||
     showCharacterEvolve ||
     showWeakness ||
     showAccessLog ||
@@ -228,6 +232,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowLibrary(false);
     setShowTodoGoals(false);
     setShowActivity(false);
+    setShowActivityLog(false);
     setShowCharacterEvolve(false);
     setShowWeakness(false);
     setShowAccessLog(false);
@@ -701,6 +706,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <TodoGoals onBack={() => setShowTodoGoals(false)} />
             ) : showActivity ? (
               <ActivityApp onBack={() => setShowActivity(false)} />
+            ) : showActivityLog ? (
+              <ActivityLog onBack={() => setShowActivityLog(false)} />
             ) : showCharacterEvolve ? (
               <CharacterEvolve onBack={() => setShowCharacterEvolve(false)} />
             ) : showWeakness ? (
@@ -947,6 +954,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">🏃</div>
                     <span>Activity</span>
+                  </div>
+                )}
+                {appLayers.activityLog === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowActivityLog(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'activityLog')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'activityLog')}
+                  >
+                    <div className="star-icon">⏱️</div>
+                    <span>Activity Log</span>
                   </div>
                 )}
                 {appLayers.characterEvolve === activeLayer && (

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -29,6 +29,7 @@ import Anima from './Anima.jsx';
 import ToolsBlog from './ToolsBlog.jsx';
 import TodoGoals from './TodoGoals.jsx';
 import ActivityApp from './ActivityApp.jsx';
+import ActivityLog from './ActivityLog.jsx';
 import CharacterEvolve from './CharacterEvolve.jsx';
 import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
 import FormlessCharacter from './FormlessCharacter.jsx';
@@ -228,6 +229,7 @@ export default function PageRouter() {
       library: <Library onBack={goBack} />,
       todoGoals: <TodoGoals onBack={goBack} />,
       activity: <ActivityApp onBack={goBack} />,
+      activityLog: <ActivityLog onBack={goBack} />,
       characterEvolve: <CharacterEvolve onBack={goBack} />,
       semiCharacter: <SemiFormlessCharacter onBack={goBack} />,
       formlessCharacter: <FormlessCharacter onBack={goBack} />,

--- a/src/activity-log.css
+++ b/src/activity-log.css
@@ -1,0 +1,273 @@
+.activity-log {
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  align-items: stretch;
+  gap: 24px;
+}
+
+.activity-log .back-button {
+  align-self: flex-start;
+}
+
+.current-activity-card {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(6px);
+  gap: 16px;
+}
+
+.current-activity-card h2 {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+
+.current-activity-label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.75);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.current-activity-time {
+  font-size: 2rem;
+  font-weight: 600;
+  color: #76ffb0;
+  text-shadow: 0 0 12px rgba(118, 255, 176, 0.4);
+}
+
+.pill {
+  display: inline-flex;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(118, 255, 176, 0.2);
+  color: #9affc6;
+}
+
+.pill.running {
+  background: rgba(118, 255, 176, 0.25);
+  color: #d7ffe8;
+}
+
+.separator {
+  opacity: 0.5;
+}
+
+.activity-log-controls {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 24px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+}
+
+.activity-input-label {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.activity-input {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+  font-size: 1rem;
+}
+
+.activity-input:focus {
+  outline: none;
+  border-color: rgba(118, 255, 176, 0.6);
+  box-shadow: 0 0 0 2px rgba(118, 255, 176, 0.2);
+}
+
+.activity-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.activity-suggestions .chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chip:hover {
+  border-color: rgba(118, 255, 176, 0.6);
+  color: #d7ffe8;
+}
+
+.chip.selected {
+  background: rgba(118, 255, 176, 0.25);
+  border-color: rgba(118, 255, 176, 0.7);
+  color: #d7ffe8;
+}
+
+.control-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.control-buttons button {
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.3);
+  color: inherit;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 600;
+}
+
+.control-buttons button.primary {
+  background: linear-gradient(135deg, #31d47d, #20a95c);
+  border-color: rgba(118, 255, 176, 0.6);
+  color: #00190c;
+  text-shadow: none;
+}
+
+.control-buttons button.secondary {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.control-buttons button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.control-buttons button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+}
+
+.activity-summary,
+.activity-history {
+  width: 100%;
+  padding: 20px 24px;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+}
+
+.activity-summary h3,
+.activity-history h3 {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.activity-summary ul,
+.activity-history ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.activity-summary li,
+.activity-history li {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.activity-summary li span:last-child {
+  font-weight: 600;
+}
+
+.activity-summary .hours {
+  margin-left: 8px;
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.history-header {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.history-meta {
+  width: 100%;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.history-meta.muted {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.empty {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+@media (max-width: 720px) {
+  .current-activity-card,
+  .activity-log-controls,
+  .activity-summary,
+  .activity-history {
+    padding: 16px;
+  }
+
+  .current-activity-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .current-activity-time {
+    font-size: 1.5rem;
+  }
+
+  .control-buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-buttons button {
+    width: 100%;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add an Activity Log tool that lets users start, pause, resume, and stop manual activity sessions with cumulative statistics
- style the tracker with a dedicated layout for the current timer, controls, and history views
- expose the new tracker from the Tools quadrant and dock layout so it can open alongside existing apps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8f3e402c483228035917a6d19e749