### PR TITLE
Fix shift+enter closing notes, add new tag options, and save notes on Enter

### DIFF
--- a/FifthMain.jsx
+++ b/FifthMain.jsx
@@ -102,6 +102,10 @@ export default function FifthMain({ onSelectQuadrant }) {
 
   useEffect(() => {
     const handleNav = (e) => {
+      if (showModal || showList || showPlanner) {
+        return;
+      }
+
       const key = e.key.toLowerCase();
       if (key === 'a') {
         setMenuIndex((prev) => Math.max(0, prev - 1));
@@ -126,7 +130,7 @@ export default function FifthMain({ onSelectQuadrant }) {
     };
     window.addEventListener('keydown', handleNav);
     return () => window.removeEventListener('keydown', handleNav);
-  }, [menuIndex, onSelectQuadrant]);
+  }, [menuIndex, onSelectQuadrant, showModal, showList, showPlanner]);
 
   return (
     <div className="main-page">

--- a/NoteModal.jsx
+++ b/NoteModal.jsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
-const TAGS = ['II', 'IE', 'EI', 'EE'];
+const TAGS = ['II', 'IE', 'EI', 'EE', 'form', 'semi-formless', 'formless'];
 const TAG_COLORS = {
   II: '#f59e0b',
   IE: '#38bdf8',
   EI: '#34d399',
   EE: '#c084fc',
+  form: '#fb923c',
+  'semi-formless': '#f472b6',
+  formless: '#60a5fa',
 };
 
 const loadStoredNotes = () => {
@@ -58,6 +61,16 @@ export default function NoteModal({ onClose }) {
     onClose();
   };
 
+  const handleEditorKeyDown = (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      const tagName = event.target?.tagName?.toLowerCase();
+      if (tagName === 'textarea' || tagName === 'input') {
+        event.preventDefault();
+        handleSave();
+      }
+    }
+  };
+
   const handleOverlayClick = (event) => {
     if (event.target === event.currentTarget) {
       onClose();
@@ -69,6 +82,7 @@ export default function NoteModal({ onClose }) {
       <div
         className="modal notes-modal note-editor-modal"
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleEditorKeyDown}
       >
         <header className="note-editor__header">
           <div>

--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -79,7 +79,7 @@ const computeModalDimensions = (viewport) => {
   };
 };
 
-const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE'];
+const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE', 'form', 'semi-formless', 'formless'];
 const TAG_OPTIONS = ['ALL', ...QUADRANT_TAGS];
 const TAG_COLORS = {
   ALL: '#38bdf8',
@@ -87,6 +87,9 @@ const TAG_COLORS = {
   IE: '#38bdf8',
   EI: '#34d399',
   EE: '#c084fc',
+  form: '#fb923c',
+  'semi-formless': '#f472b6',
+  formless: '#60a5fa',
 };
 
 const getLocalStorage = () => {

--- a/src/FifthMain.jsx
+++ b/src/FifthMain.jsx
@@ -102,6 +102,10 @@ export default function FifthMain({ onSelectQuadrant }) {
 
   useEffect(() => {
     const handleNav = (e) => {
+      if (showModal || showList || showPlanner) {
+        return;
+      }
+
       const key = e.key.toLowerCase();
       if (key === 'a') {
         setMenuIndex((prev) => Math.max(0, prev - 1));
@@ -128,7 +132,7 @@ export default function FifthMain({ onSelectQuadrant }) {
     };
     window.addEventListener('keydown', handleNav);
     return () => window.removeEventListener('keydown', handleNav);
-  }, [menuIndex, onSelectQuadrant]);
+  }, [menuIndex, onSelectQuadrant, showModal, showList, showPlanner]);
 
   return (
     <div className="main-page">

--- a/src/NoteModal.jsx
+++ b/src/NoteModal.jsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import './note-modal.css';
 
-const TAGS = ['II', 'IE', 'EI', 'EE'];
+const TAGS = ['II', 'IE', 'EI', 'EE', 'form', 'semi-formless', 'formless'];
 const TAG_COLORS = {
   II: '#f59e0b',
   IE: '#38bdf8',
   EI: '#34d399',
   EE: '#c084fc',
+  form: '#fb923c',
+  'semi-formless': '#f472b6',
+  formless: '#60a5fa',
 };
 
 const loadStoredNotes = () => {
@@ -58,6 +61,16 @@ export default function NoteModal({ onClose }) {
     onClose();
   };
 
+  const handleEditorKeyDown = (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      const tagName = event.target?.tagName?.toLowerCase();
+      if (tagName === 'textarea' || tagName === 'input') {
+        event.preventDefault();
+        handleSave();
+      }
+    }
+  };
+
   const handleOverlayClick = (event) => {
     if (event.target === event.currentTarget) {
       onClose();
@@ -69,6 +82,7 @@ export default function NoteModal({ onClose }) {
       <div
         className="modal notes-modal note-editor-modal"
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleEditorKeyDown}
       >
         <header className="note-editor__header">
           <div>

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -79,7 +79,7 @@ const computeModalDimensions = (viewport) => {
   };
 };
 
-const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE'];
+const QUADRANT_TAGS = ['II', 'IE', 'EI', 'EE', 'form', 'semi-formless', 'formless'];
 const TAG_OPTIONS = ['ALL', ...QUADRANT_TAGS];
 const TAG_COLORS = {
   ALL: '#38bdf8',
@@ -87,6 +87,9 @@ const TAG_COLORS = {
   IE: '#38bdf8',
   EI: '#34d399',
   EE: '#c084fc',
+  form: '#fb923c',
+  'semi-formless': '#f472b6',
+  formless: '#60a5fa',
 };
 
 const getLocalStorage = () => {


### PR DESCRIPTION
## Summary
- add form, semi-formless, and formless tag options (with colors) to the note editor and notes list views
- prevent global keyboard navigation shortcuts from firing while note-related modals are open so shift+enter can create newlines
- save the note when the user presses Enter inside the editor fields while preserving Shift+Enter for newlines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e947de7ce48322aae0e9622695ea93