### PR TITLE
Link activity log entries to blog pages

### DIFF
--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -1,4 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import {
+  loadActivityBlogIndex,
+  loadBlogPostsFromStorage,
+  persistActivityBlogIndex,
+  persistBlogPostsToStorage,
+  sanitizeBlogPostRecord,
+} from './ToolsBlog.jsx';
 import './placeholder-app.css';
 import './activity-log.css';
 
@@ -64,6 +71,152 @@ const finalizeSession = (session, endTime = new Date()) => {
     durationMs: elapsed,
     segments,
   };
+};
+
+const sanitizeActivityName = (name) => {
+  if (typeof name !== 'string') {
+    return '';
+  }
+
+  return name.trim();
+};
+
+const loadSanitizedBlogPosts = () => {
+  const storedPosts = loadBlogPostsFromStorage();
+  if (!Array.isArray(storedPosts)) {
+    return [];
+  }
+
+  return storedPosts
+    .map((post) => sanitizeBlogPostRecord(post))
+    .filter(Boolean);
+};
+
+const generatePostId = (posts) => {
+  const usedIds = new Set(posts.map((post) => post.id));
+  let candidate = Date.now();
+
+  while (usedIds.has(candidate)) {
+    candidate += 1;
+  }
+
+  return candidate;
+};
+
+const sanitizeSessionForBlog = (session) => {
+  if (session == null || typeof session !== 'object') {
+    return null;
+  }
+
+  const durationMs = Number(session.durationMs);
+  const sanitizedDuration = Number.isFinite(durationMs) && durationMs >= 0 ? durationMs : 0;
+
+  const sanitizedSession = {
+    id: Number.isInteger(Number(session.id)) ? Number(session.id) : Date.now(),
+    startedAt: typeof session.startedAt === 'string' ? session.startedAt : null,
+    endedAt: typeof session.endedAt === 'string' ? session.endedAt : null,
+    durationMs: sanitizedDuration,
+  };
+
+  if (!sanitizedSession.startedAt && !sanitizedSession.endedAt && sanitizedSession.durationMs === 0) {
+    return null;
+  }
+
+  return sanitizedSession;
+};
+
+const withActivityBlogPost = (activityName, updater) => {
+  const trimmedName = sanitizeActivityName(activityName);
+  if (!trimmedName || typeof window === 'undefined') {
+    return null;
+  }
+
+  const posts = loadSanitizedBlogPosts();
+  const index = loadActivityBlogIndex();
+  const mappedId = Number(index[trimmedName]);
+  const hasMappedId = Number.isInteger(mappedId);
+  let postId = hasMappedId ? mappedId : null;
+  let postIndex = posts.findIndex((post) => post.id === postId);
+
+  if (postIndex === -1) {
+    postId = generatePostId(posts);
+    const newPost = sanitizeBlogPostRecord({
+      id: postId,
+      title: `${trimmedName} activity stream`,
+      status: 'Draft',
+      excerpt: `Automatically collecting moments linked to ${trimmedName}.`,
+      stream: 'training-layer',
+      mood: 'listening',
+      images: [],
+      link: '',
+      activityName: trimmedName,
+      activitySessions: [],
+    });
+
+    if (newPost) {
+      posts.unshift(newPost);
+      postIndex = 0;
+    }
+  }
+
+  if (postIndex === -1) {
+    return null;
+  }
+
+  index[trimmedName] = postId;
+  const post = posts[postIndex];
+  const updatedPost = updater ? updater(post) ?? post : post;
+  const sanitizedPost = sanitizeBlogPostRecord({
+    ...updatedPost,
+    id: postId,
+    activityName: updatedPost.activityName || trimmedName,
+  });
+
+  if (!sanitizedPost) {
+    return null;
+  }
+
+  posts[postIndex] = sanitizedPost;
+  persistBlogPostsToStorage(posts);
+  persistActivityBlogIndex(index);
+
+  return sanitizedPost;
+};
+
+const ensureActivityBlogPost = (activityName) =>
+  withActivityBlogPost(activityName, (post) => post);
+
+const recordSessionInBlog = (session) => {
+  const sanitizedSession = sanitizeSessionForBlog(session);
+  const activityName = sanitizeActivityName(session?.name);
+
+  if (!sanitizedSession || !activityName) {
+    return;
+  }
+
+  withActivityBlogPost(activityName, (post) => {
+    const existingSessions = Array.isArray(post.activitySessions)
+      ? post.activitySessions
+      : [];
+
+    const hasExistingSession = existingSessions.some(
+      (item) => Number(item?.id) === Number(sanitizedSession.id)
+    );
+
+    if (hasExistingSession) {
+      return {
+        ...post,
+        activitySessions: existingSessions.map((item) =>
+          Number(item?.id) === Number(sanitizedSession.id) ? sanitizedSession : item
+        ),
+      };
+    }
+
+    return {
+      ...post,
+      activitySessions: [...existingSessions, sanitizedSession],
+    };
+  });
 };
 
 export default function ActivityLog({ onBack }) {
@@ -167,11 +320,13 @@ export default function ActivityLog({ onBack }) {
   const handleStart = () => {
     if (startDisabled) return;
     const now = new Date();
+    ensureActivityBlogPost(trimmedName);
 
     if (current && current.name !== trimmedName) {
       const finished = finalizeSession(current, now);
       if (finished) {
         persistEntries([...entries, finished]);
+        recordSessionInBlog(finished);
       }
     }
 
@@ -223,6 +378,7 @@ export default function ActivityLog({ onBack }) {
     const finished = finalizeSession(current, new Date());
     if (finished) {
       persistEntries([...entries, finished]);
+      recordSessionInBlog(finished);
     }
     persistCurrent(null);
   };

--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -72,6 +72,7 @@ const MEDIA_BLUEPRINTS = [
 ];
 
 const STORAGE_KEY = 'tools-blog-posts';
+const ACTIVITY_INDEX_KEY = 'activity-blog-index';
 
 const sanitizeImages = (images) =>
   Array.isArray(images)
@@ -185,6 +186,36 @@ const PLACEHOLDER_POSTS = Array.from({ length: 48 }, (_, index) => {
   };
 });
 
+const sanitizeActivitySession = (session) => {
+  if (session == null || typeof session !== 'object') {
+    return null;
+  }
+
+  const sanitizedId = Number(session.id);
+  const parsedId = Number.isInteger(sanitizedId) ? sanitizedId : undefined;
+  const startedAt =
+    typeof session.startedAt === 'string' && session.startedAt.trim()
+      ? session.startedAt
+      : null;
+  const endedAt =
+    typeof session.endedAt === 'string' && session.endedAt.trim()
+      ? session.endedAt
+      : null;
+  const durationMs = Number(session.durationMs);
+  const safeDuration = Number.isFinite(durationMs) && durationMs >= 0 ? durationMs : 0;
+
+  if (!startedAt && !endedAt && safeDuration === 0) {
+    return null;
+  }
+
+  return {
+    id: parsedId ?? Date.now(),
+    startedAt,
+    endedAt,
+    durationMs: safeDuration,
+  };
+};
+
 const sanitizePostRecord = (post) => {
   if (post == null || typeof post !== 'object') {
     return null;
@@ -204,6 +235,13 @@ const sanitizePostRecord = (post) => {
     mood: typeof post.mood === 'string' ? post.mood : MOODS[0],
     images: sanitizeImages(post.images),
     link: sanitizeLink(post.link),
+    activityName:
+      typeof post.activityName === 'string' && post.activityName.trim()
+        ? post.activityName.trim()
+        : '',
+    activitySessions: Array.isArray(post.activitySessions)
+      ? post.activitySessions.map((session) => sanitizeActivitySession(session)).filter(Boolean)
+      : [],
   };
 };
 
@@ -257,6 +295,115 @@ const VIEW_MODES = {
   CLASSIC: 'classic',
 };
 
+const persistBlogPosts = (posts) => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return;
+  }
+
+  try {
+    const sanitizedPosts = posts
+      .map((post) => sanitizePostRecord(post))
+      .filter(Boolean);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizedPosts));
+  } catch (error) {
+    // Ignore persistence errors so the UI remains responsive even if storage is unavailable.
+  }
+};
+
+const formatActivityDuration = (ms) => {
+  if (!ms || ms <= 0) {
+    return '0m 00s';
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+
+  parts.push(`${hours > 0 ? String(minutes).padStart(2, '0') : minutes}m`);
+  parts.push(String(seconds).padStart(2, '0') + 's');
+  return parts.join(' ');
+};
+
+const formatActivityDateTime = (value) => {
+  if (!value) {
+    return 'Unknown time';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown time';
+  }
+
+  return date.toLocaleString();
+};
+
+const sanitizeActivityIndex = (value) => {
+  if (value == null || typeof value !== 'object') {
+    return {};
+  }
+
+  return Object.entries(value).reduce((accumulator, [activityName, postId]) => {
+    if (typeof activityName !== 'string') {
+      return accumulator;
+    }
+
+    const trimmedName = activityName.trim();
+    if (!trimmedName) {
+      return accumulator;
+    }
+
+    const numericId = Number(postId);
+    if (!Number.isInteger(numericId)) {
+      return accumulator;
+    }
+
+    accumulator[trimmedName] = numericId;
+    return accumulator;
+  }, {});
+};
+
+export const BLOG_STORAGE_KEY = STORAGE_KEY;
+export const BLOG_ACTIVITY_INDEX_KEY = ACTIVITY_INDEX_KEY;
+export const sanitizeBlogPostRecord = sanitizePostRecord;
+export const loadBlogPostsFromStorage = () => loadStoredPosts().posts;
+export const persistBlogPostsToStorage = persistBlogPosts;
+export const loadActivityBlogIndex = () => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return {};
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(ACTIVITY_INDEX_KEY);
+    if (storedValue == null) {
+      return {};
+    }
+
+    const parsedValue = JSON.parse(storedValue);
+    return sanitizeActivityIndex(parsedValue);
+  } catch (error) {
+    return {};
+  }
+};
+
+export const persistActivityBlogIndex = (index) => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return;
+  }
+
+  try {
+    const sanitizedIndex = sanitizeActivityIndex(index);
+    window.localStorage.setItem(ACTIVITY_INDEX_KEY, JSON.stringify(sanitizedIndex));
+  } catch (error) {
+    // Ignore persistence errors to keep the UI responsive even when storage is unavailable.
+  }
+};
+
 export default function ToolsBlog({ onBack }) {
   const [posts, setPosts] = useState(buildInitialPosts);
   const [editingPostId, setEditingPostId] = useState(null);
@@ -265,18 +412,7 @@ export default function ToolsBlog({ onBack }) {
   const [viewMode, setViewMode] = useState(VIEW_MODES.LIST);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !('localStorage' in window)) {
-      return;
-    }
-
-    try {
-      const sanitizedPosts = posts
-        .map((post) => sanitizePostRecord(post))
-        .filter(Boolean);
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizedPosts));
-    } catch (error) {
-      // Ignore persistence errors so the UI remains responsive even if storage is unavailable.
-    }
+    persistBlogPosts(posts);
   }, [posts]);
 
   const closeActionMenu = () => setOpenMenuPostId(null);
@@ -520,6 +656,16 @@ export default function ToolsBlog({ onBack }) {
           const isEditing = editingPostId === post.id;
           const currentStatus = isEditing && editDraft ? editDraft.status : post.status;
           const displayIndex = `#${String(index + 1).padStart(2, '0')}`;
+          const activitySessions = Array.isArray(post.activitySessions)
+            ? post.activitySessions
+            : [];
+          const hasActivityTimeline = Boolean(post.activityName) && activitySessions.length > 0;
+          const totalActivityDuration = hasActivityTimeline
+            ? activitySessions.reduce(
+                (total, session) => total + (session?.durationMs ?? 0),
+                0
+              )
+            : 0;
           const articleClassName = [
             'blog-card',
             viewMode === VIEW_MODES.GRID ? 'blog-card--grid' : '',
@@ -767,6 +913,41 @@ export default function ToolsBlog({ onBack }) {
                 <>
                   <h2 className="blog-card-title">{post.title}</h2>
                   <p className="blog-card-body">{post.excerpt}</p>
+                  {hasActivityTimeline && (
+                    <div className="blog-card-activity" aria-live="polite">
+                      <div className="blog-card-activity-header">
+                        <div className="blog-card-activity-title">
+                          <span className="blog-card-activity-label">Linked activity</span>
+                          <span className="blog-card-activity-name">{post.activityName}</span>
+                        </div>
+                        <div className="blog-card-activity-total">
+                          Total logged time: {formatActivityDuration(totalActivityDuration)}
+                        </div>
+                      </div>
+                      <ul className="blog-card-activity-list">
+                        {activitySessions
+                          .slice()
+                          .sort((a, b) => {
+                            const aDate = new Date(a?.endedAt ?? a?.startedAt ?? 0).getTime();
+                            const bDate = new Date(b?.endedAt ?? b?.startedAt ?? 0).getTime();
+                            return bDate - aDate;
+                          })
+                          .map((session) => {
+                            const key = session.id ?? `${session.startedAt}-${session.endedAt}`;
+                            return (
+                              <li key={key} className="blog-card-activity-item">
+                                <span className="blog-card-activity-time">
+                                  {formatActivityDateTime(session.startedAt)}
+                                </span>
+                                <span className="blog-card-activity-duration">
+                                  {formatActivityDuration(session.durationMs)}
+                                </span>
+                              </li>
+                            );
+                          })}
+                      </ul>
+                    </div>
+                  )}
                   {hasMedia && (
                     <div className="blog-card-media">
                       {imageSources.length > 0 && (

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -510,6 +510,87 @@
   line-height: 1.7;
 }
 
+.blog-card-activity {
+  margin-top: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(120, 154, 255, 0.35);
+  background: rgba(120, 154, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(120, 154, 255, 0.16);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.blog-card-activity-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.blog-card-activity-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.blog-card-activity-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(198, 211, 255, 0.72);
+}
+
+.blog-card-activity-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #f3f4ff;
+}
+
+.blog-card-activity-total {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  color: rgba(216, 223, 255, 0.9);
+  background: rgba(120, 154, 255, 0.18);
+  border-radius: 999px;
+  padding: 4px 12px;
+  border: 1px solid rgba(120, 154, 255, 0.28);
+}
+
+.blog-card-activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.blog-card-activity-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(120, 154, 255, 0.14);
+}
+
+.blog-card-activity-time {
+  font-size: 0.85rem;
+  color: rgba(216, 220, 255, 0.82);
+}
+
+.blog-card-activity-duration {
+  font-size: 0.85rem;
+  color: #f5f6ff;
+  letter-spacing: 0.04em;
+}
+
 .blog-card-media {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- expose shared blog storage helpers and activity session sanitizers for reuse
- ensure the activity log automatically creates and updates linked blog posts when sessions are tracked
- surface linked activity timelines inside blog cards with new styling

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e95bcd80948322a688316e586e5b4c