### PR TITLE
Add activity selection menu linked to blog pages

### DIFF
--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ensureActivityBlogPost,
+  loadRegisteredActivityNames,
+  recordActivitySessionInBlog,
+  sanitizeActivityName,
+} from './ToolsBlog.jsx';
 import './placeholder-app.css';
 import './activity-log.css';
 
@@ -66,6 +72,8 @@ const finalizeSession = (session, endTime = new Date()) => {
   };
 };
 
+const DEFAULT_ACTIVITIES = ['Singing', 'Writing'];
+
 export default function ActivityLog({ onBack }) {
   const [entries, setEntries] = useState(() =>
     safeParse(localStorage.getItem(ENTRIES_KEY), [])
@@ -74,7 +82,16 @@ export default function ActivityLog({ onBack }) {
     safeParse(localStorage.getItem(CURRENT_KEY), null)
   );
   const [activityName, setActivityName] = useState(() => current?.name || '');
+  const [activityOptions, setActivityOptions] = useState(() =>
+    loadRegisteredActivityNames()
+  );
+  const [isAddingActivity, setIsAddingActivity] = useState(false);
+  const [newActivityName, setNewActivityName] = useState('');
   const [tick, setTick] = useState(() => Date.now());
+
+  const refreshActivityOptions = useCallback(() => {
+    setActivityOptions(loadRegisteredActivityNames());
+  }, []);
 
   useEffect(() => {
     const id = setInterval(() => setTick(Date.now()), 1000);
@@ -92,6 +109,26 @@ export default function ActivityLog({ onBack }) {
       localStorage.removeItem(CURRENT_KEY);
     }
   }, [current]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    DEFAULT_ACTIVITIES.forEach((name) => ensureActivityBlogPost(name));
+    refreshActivityOptions();
+  }, [refreshActivityOptions]);
+
+  useEffect(() => {
+    const sanitizedCurrent = sanitizeActivityName(activityName);
+    if (
+      !isAddingActivity &&
+      !sanitizedCurrent &&
+      activityOptions.length > 0
+    ) {
+      setActivityName(activityOptions[0]);
+    }
+  }, [activityOptions, activityName, isAddingActivity]);
 
   const currentElapsed = useMemo(() => {
     if (!current) return 0;
@@ -111,22 +148,18 @@ export default function ActivityLog({ onBack }) {
   const totals = useMemo(() => {
     const map = new Map();
     entries.forEach((entry) => {
-      if (!entry?.name || !entry?.durationMs) return;
-      const prev = map.get(entry.name) || 0;
-      map.set(entry.name, prev + entry.durationMs);
+      const sanitizedName = sanitizeActivityName(entry?.name);
+      if (!sanitizedName || !entry?.durationMs) return;
+      const prev = map.get(sanitizedName) || 0;
+      map.set(sanitizedName, prev + entry.durationMs);
     });
     if (current?.name) {
-      const prev = map.get(current.name) || 0;
-      map.set(current.name, prev + currentElapsed);
+      const sanitizedName = sanitizeActivityName(current.name);
+      const prev = map.get(sanitizedName) || 0;
+      map.set(sanitizedName, prev + currentElapsed);
     }
     return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
   }, [entries, current, currentElapsed]);
-
-  const suggestions = useMemo(() => {
-    const set = new Set(entries.map((entry) => entry.name).filter(Boolean));
-    if (current?.name) set.add(current.name);
-    return Array.from(set).sort((a, b) => a.localeCompare(b));
-  }, [entries, current]);
 
   const sortedHistory = useMemo(() => {
     return [...entries].sort((a, b) => {
@@ -137,10 +170,12 @@ export default function ActivityLog({ onBack }) {
   }, [entries]);
 
   const isRunning = Boolean(current?.activeSegmentStart);
-  const trimmedName = activityName.trim();
-  const isSameActivity = current?.name && trimmedName === current.name;
-  const startDisabled = !trimmedName || (isSameActivity && isRunning);
-  const startLabel = !trimmedName
+  const sanitizedSelectedName = sanitizeActivityName(activityName);
+  const sanitizedCurrentName = sanitizeActivityName(current?.name);
+  const isSameActivity =
+    Boolean(sanitizedSelectedName) && sanitizedSelectedName === sanitizedCurrentName;
+  const startDisabled = !sanitizedSelectedName || (isSameActivity && isRunning);
+  const startLabel = !sanitizedSelectedName
     ? 'Start Activity'
     : isSameActivity
       ? isRunning
@@ -167,15 +202,17 @@ export default function ActivityLog({ onBack }) {
   const handleStart = () => {
     if (startDisabled) return;
     const now = new Date();
+    ensureActivityBlogPost(sanitizedSelectedName);
 
-    if (current && current.name !== trimmedName) {
+    if (current && sanitizeActivityName(current.name) !== sanitizedSelectedName) {
       const finished = finalizeSession(current, now);
       if (finished) {
         persistEntries([...entries, finished]);
+        recordActivitySessionInBlog(finished);
       }
     }
 
-    if (current && current.name === trimmedName) {
+    if (current && sanitizeActivityName(current.name) === sanitizedSelectedName) {
       if (current.activeSegmentStart) return;
       const resumed = {
         ...current,
@@ -185,14 +222,14 @@ export default function ActivityLog({ onBack }) {
     } else {
       const nextSession = {
         id: now.getTime(),
-        name: trimmedName,
+        name: sanitizedSelectedName,
         startedAt: now.toISOString(),
         elapsed: 0,
         segments: [],
         activeSegmentStart: now.toISOString(),
       };
       persistCurrent(nextSession);
-      setActivityName(trimmedName);
+      setActivityName(sanitizedSelectedName);
     }
   };
 
@@ -223,6 +260,7 @@ export default function ActivityLog({ onBack }) {
     const finished = finalizeSession(current, new Date());
     if (finished) {
       persistEntries([...entries, finished]);
+      recordActivitySessionInBlog(finished);
     }
     persistCurrent(null);
   };
@@ -234,6 +272,45 @@ export default function ActivityLog({ onBack }) {
       persistCurrent(null);
       setActivityName('');
     }
+  };
+
+  const handleSelectActivity = (event) => {
+    setActivityName(event.target.value);
+  };
+
+  const handleStartAdding = () => {
+    setIsAddingActivity(true);
+    setNewActivityName('');
+  };
+
+  const handleCancelAdding = () => {
+    setIsAddingActivity(false);
+    setNewActivityName('');
+  };
+
+  const handleCreateActivity = (event) => {
+    event.preventDefault();
+    const sanitizedName = sanitizeActivityName(newActivityName);
+    if (!sanitizedName) {
+      return;
+    }
+
+    const existingMatch = activityOptions.find(
+      (option) => option.toLowerCase() === sanitizedName.toLowerCase()
+    );
+
+    if (existingMatch) {
+      setActivityName(existingMatch);
+      setIsAddingActivity(false);
+      setNewActivityName('');
+      return;
+    }
+
+    ensureActivityBlogPost(sanitizedName);
+    refreshActivityOptions();
+    setActivityName(sanitizedName);
+    setIsAddingActivity(false);
+    setNewActivityName('');
   };
 
   return (
@@ -265,33 +342,51 @@ export default function ActivityLog({ onBack }) {
         <label htmlFor="activity-input" className="activity-input-label">
           What are you doing right now?
         </label>
-        <input
-          id="activity-input"
-          className="activity-input"
-          type="text"
-          placeholder="e.g. Singing, Coding, Reading"
-          value={activityName}
-          onChange={(event) => setActivityName(event.target.value)}
-        />
-        {suggestions.length > 0 && (
-          <div className="activity-suggestions">
-            <span>Recent:</span>
-            <div className="chips">
-              {suggestions.map((name) => (
-                <button
-                  key={name}
-                  type="button"
-                  className={
-                    name === trimmedName ? 'chip selected' : 'chip'
-                  }
-                  onClick={() => setActivityName(name)}
-                >
-                  {name}
-                </button>
-              ))}
-            </div>
+        <div className="activity-picker">
+          <select
+            id="activity-input"
+            className="activity-select"
+            value={activityOptions.includes(activityName) ? activityName : ''}
+            onChange={handleSelectActivity}
+          >
+            <option value="" disabled>
+              Select a tracked activity
+            </option>
+            {activityOptions.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <div className="activity-picker-actions">
+            {isAddingActivity ? (
+              <form className="activity-picker-new" onSubmit={handleCreateActivity}>
+                <input
+                  type="text"
+                  className="activity-input"
+                  placeholder="Name the new activity"
+                  value={newActivityName}
+                  onChange={(event) => setNewActivityName(event.target.value)}
+                />
+                <div className="activity-picker-buttons">
+                  <button type="submit" className="primary">
+                    Save activity
+                  </button>
+                  <button type="button" onClick={handleCancelAdding}>
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <button type="button" className="secondary" onClick={handleStartAdding}>
+                Add a new activity
+              </button>
+            )}
           </div>
-        )}
+        </div>
+        <p className="activity-picker-hint">
+          Each activity in this list has a dedicated blog page where moments from across the app are collected.
+        </p>
         <div className="control-buttons">
           <button
             type="button"

--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -72,6 +72,7 @@ const MEDIA_BLUEPRINTS = [
 ];
 
 const STORAGE_KEY = 'tools-blog-posts';
+const ACTIVITY_INDEX_KEY = 'activity-blog-index';
 
 const sanitizeImages = (images) =>
   Array.isArray(images)
@@ -185,6 +186,36 @@ const PLACEHOLDER_POSTS = Array.from({ length: 48 }, (_, index) => {
   };
 });
 
+const sanitizeActivitySession = (session) => {
+  if (session == null || typeof session !== 'object') {
+    return null;
+  }
+
+  const sanitizedId = Number(session.id);
+  const parsedId = Number.isInteger(sanitizedId) ? sanitizedId : undefined;
+  const startedAt =
+    typeof session.startedAt === 'string' && session.startedAt.trim()
+      ? session.startedAt
+      : null;
+  const endedAt =
+    typeof session.endedAt === 'string' && session.endedAt.trim()
+      ? session.endedAt
+      : null;
+  const durationMs = Number(session.durationMs);
+  const safeDuration = Number.isFinite(durationMs) && durationMs >= 0 ? durationMs : 0;
+
+  if (!startedAt && !endedAt && safeDuration === 0) {
+    return null;
+  }
+
+  return {
+    id: parsedId ?? Date.now(),
+    startedAt,
+    endedAt,
+    durationMs: safeDuration,
+  };
+};
+
 const sanitizePostRecord = (post) => {
   if (post == null || typeof post !== 'object') {
     return null;
@@ -204,7 +235,42 @@ const sanitizePostRecord = (post) => {
     mood: typeof post.mood === 'string' ? post.mood : MOODS[0],
     images: sanitizeImages(post.images),
     link: sanitizeLink(post.link),
+    activityName:
+      typeof post.activityName === 'string' && post.activityName.trim()
+        ? post.activityName.trim()
+        : '',
+    activitySessions: Array.isArray(post.activitySessions)
+      ? post.activitySessions.map((session) => sanitizeActivitySession(session)).filter(Boolean)
+      : [],
   };
+};
+
+const loadSanitizedBlogPosts = () => {
+  const { posts } = loadStoredPosts();
+  if (!Array.isArray(posts)) {
+    return [];
+  }
+
+  return posts.map((post) => sanitizePostRecord(post)).filter(Boolean);
+};
+
+const generateActivityPostId = (posts) => {
+  const usedIds = new Set(posts.map((post) => post.id));
+  let candidate = Date.now();
+
+  while (usedIds.has(candidate)) {
+    candidate += 1;
+  }
+
+  return candidate;
+};
+
+export const sanitizeActivityName = (name) => {
+  if (typeof name !== 'string') {
+    return '';
+  }
+
+  return name.trim();
 };
 
 const loadStoredPosts = () => {
@@ -257,6 +323,252 @@ const VIEW_MODES = {
   CLASSIC: 'classic',
 };
 
+const persistBlogPosts = (posts) => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return;
+  }
+
+  try {
+    const sanitizedPosts = posts
+      .map((post) => sanitizePostRecord(post))
+      .filter(Boolean);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizedPosts));
+  } catch (error) {
+    // Ignore persistence errors so the UI remains responsive even if storage is unavailable.
+  }
+};
+
+const formatActivityDuration = (ms) => {
+  if (!ms || ms <= 0) {
+    return '0m 00s';
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+
+  parts.push(`${hours > 0 ? String(minutes).padStart(2, '0') : minutes}m`);
+  parts.push(String(seconds).padStart(2, '0') + 's');
+  return parts.join(' ');
+};
+
+const formatActivityDateTime = (value) => {
+  if (!value) {
+    return 'Unknown time';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown time';
+  }
+
+  return date.toLocaleString();
+};
+
+const sanitizeActivityIndex = (value) => {
+  if (value == null || typeof value !== 'object') {
+    return {};
+  }
+
+  return Object.entries(value).reduce((accumulator, [activityName, postId]) => {
+    if (typeof activityName !== 'string') {
+      return accumulator;
+    }
+
+    const trimmedName = activityName.trim();
+    if (!trimmedName) {
+      return accumulator;
+    }
+
+    const numericId = Number(postId);
+    if (!Number.isInteger(numericId)) {
+      return accumulator;
+    }
+
+    accumulator[trimmedName] = numericId;
+    return accumulator;
+  }, {});
+};
+
+export const BLOG_STORAGE_KEY = STORAGE_KEY;
+export const BLOG_ACTIVITY_INDEX_KEY = ACTIVITY_INDEX_KEY;
+export const sanitizeBlogPostRecord = sanitizePostRecord;
+export const loadBlogPostsFromStorage = () => loadStoredPosts().posts;
+export const persistBlogPostsToStorage = persistBlogPosts;
+export const loadActivityBlogIndex = () => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return {};
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(ACTIVITY_INDEX_KEY);
+    if (storedValue == null) {
+      return {};
+    }
+
+    const parsedValue = JSON.parse(storedValue);
+    return sanitizeActivityIndex(parsedValue);
+  } catch (error) {
+    return {};
+  }
+};
+
+export const persistActivityBlogIndex = (index) => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return;
+  }
+
+  try {
+    const sanitizedIndex = sanitizeActivityIndex(index);
+    window.localStorage.setItem(ACTIVITY_INDEX_KEY, JSON.stringify(sanitizedIndex));
+  } catch (error) {
+    // Ignore persistence errors to keep the UI responsive even when storage is unavailable.
+  }
+};
+
+const withActivityBlogPost = (activityName, updater) => {
+  const trimmedName = sanitizeActivityName(activityName);
+  if (!trimmedName || typeof window === 'undefined') {
+    return null;
+  }
+
+  const posts = loadSanitizedBlogPosts();
+  const index = loadActivityBlogIndex();
+  const mappedId = Number(index[trimmedName]);
+  const hasMappedId = Number.isInteger(mappedId);
+  let postId = hasMappedId ? mappedId : null;
+  let postIndex = posts.findIndex((post) => post.id === postId);
+
+  if (postIndex === -1) {
+    postId = generateActivityPostId(posts);
+    const newPost = sanitizePostRecord({
+      id: postId,
+      title: `${trimmedName} activity stream`,
+      status: 'Draft',
+      excerpt: `Automatically collecting moments linked to ${trimmedName}.`,
+      stream: 'training-layer',
+      mood: 'listening',
+      images: [],
+      link: '',
+      activityName: trimmedName,
+      activitySessions: [],
+    });
+
+    if (newPost) {
+      posts.unshift(newPost);
+      postIndex = 0;
+    }
+  }
+
+  if (postIndex === -1) {
+    return null;
+  }
+
+  index[trimmedName] = postId;
+  const post = posts[postIndex];
+  const updatedPost = updater ? updater(post) ?? post : post;
+  const sanitizedPost = sanitizePostRecord({
+    ...updatedPost,
+    id: postId,
+    activityName: updatedPost.activityName || trimmedName,
+  });
+
+  if (!sanitizedPost) {
+    return null;
+  }
+
+  posts[postIndex] = sanitizedPost;
+  persistBlogPosts(posts);
+  persistActivityBlogIndex(index);
+
+  return sanitizedPost;
+};
+
+export const ensureActivityBlogPost = (activityName) =>
+  withActivityBlogPost(activityName, (post) => post);
+
+export const recordActivitySessionInBlog = (session) => {
+  const activityName = sanitizeActivityName(session?.name ?? session?.activityName ?? '');
+  const sanitizedSession = sanitizeActivitySession(session);
+
+  if (!activityName || !sanitizedSession) {
+    return;
+  }
+
+  withActivityBlogPost(activityName, (post) => {
+    const existingSessions = Array.isArray(post.activitySessions)
+      ? post.activitySessions
+      : [];
+
+    const hasExistingSession = existingSessions.some(
+      (item) => Number(item?.id) === Number(sanitizedSession.id)
+    );
+
+    if (hasExistingSession) {
+      return {
+        ...post,
+        activitySessions: existingSessions.map((item) =>
+          Number(item?.id) === Number(sanitizedSession.id) ? sanitizedSession : item
+        ),
+      };
+    }
+
+    return {
+      ...post,
+      activitySessions: [...existingSessions, sanitizedSession],
+    };
+  });
+};
+
+export const loadRegisteredActivities = () => {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return [];
+  }
+
+  const posts = loadSanitizedBlogPosts();
+  const index = loadActivityBlogIndex();
+  const activityMap = new Map();
+
+  posts.forEach((post) => {
+    if (post?.activityName && Number.isInteger(post.id)) {
+      activityMap.set(post.activityName, post.id);
+    }
+  });
+
+  Object.entries(index).forEach(([name, postId]) => {
+    const trimmedName = sanitizeActivityName(name);
+    const numericId = Number(postId);
+    if (trimmedName && Number.isInteger(numericId)) {
+      activityMap.set(trimmedName, numericId);
+    }
+  });
+
+  const syncedIndex = Array.from(activityMap.entries()).reduce(
+    (accumulator, [name, postId]) => ({
+      ...accumulator,
+      [name]: postId,
+    }),
+    {}
+  );
+
+  persistActivityBlogIndex(syncedIndex);
+
+  return Array.from(activityMap.entries())
+    .map(([name, postId]) => ({ name, postId }))
+    .sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base', numeric: true })
+    );
+};
+
+export const loadRegisteredActivityNames = () =>
+  loadRegisteredActivities().map((activity) => activity.name);
+
 export default function ToolsBlog({ onBack }) {
   const [posts, setPosts] = useState(buildInitialPosts);
   const [editingPostId, setEditingPostId] = useState(null);
@@ -265,18 +577,7 @@ export default function ToolsBlog({ onBack }) {
   const [viewMode, setViewMode] = useState(VIEW_MODES.LIST);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !('localStorage' in window)) {
-      return;
-    }
-
-    try {
-      const sanitizedPosts = posts
-        .map((post) => sanitizePostRecord(post))
-        .filter(Boolean);
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizedPosts));
-    } catch (error) {
-      // Ignore persistence errors so the UI remains responsive even if storage is unavailable.
-    }
+    persistBlogPosts(posts);
   }, [posts]);
 
   const closeActionMenu = () => setOpenMenuPostId(null);
@@ -520,6 +821,16 @@ export default function ToolsBlog({ onBack }) {
           const isEditing = editingPostId === post.id;
           const currentStatus = isEditing && editDraft ? editDraft.status : post.status;
           const displayIndex = `#${String(index + 1).padStart(2, '0')}`;
+          const activitySessions = Array.isArray(post.activitySessions)
+            ? post.activitySessions
+            : [];
+          const hasActivityTimeline = Boolean(post.activityName) && activitySessions.length > 0;
+          const totalActivityDuration = hasActivityTimeline
+            ? activitySessions.reduce(
+                (total, session) => total + (session?.durationMs ?? 0),
+                0
+              )
+            : 0;
           const articleClassName = [
             'blog-card',
             viewMode === VIEW_MODES.GRID ? 'blog-card--grid' : '',
@@ -767,6 +1078,41 @@ export default function ToolsBlog({ onBack }) {
                 <>
                   <h2 className="blog-card-title">{post.title}</h2>
                   <p className="blog-card-body">{post.excerpt}</p>
+                  {hasActivityTimeline && (
+                    <div className="blog-card-activity" aria-live="polite">
+                      <div className="blog-card-activity-header">
+                        <div className="blog-card-activity-title">
+                          <span className="blog-card-activity-label">Linked activity</span>
+                          <span className="blog-card-activity-name">{post.activityName}</span>
+                        </div>
+                        <div className="blog-card-activity-total">
+                          Total logged time: {formatActivityDuration(totalActivityDuration)}
+                        </div>
+                      </div>
+                      <ul className="blog-card-activity-list">
+                        {activitySessions
+                          .slice()
+                          .sort((a, b) => {
+                            const aDate = new Date(a?.endedAt ?? a?.startedAt ?? 0).getTime();
+                            const bDate = new Date(b?.endedAt ?? b?.startedAt ?? 0).getTime();
+                            return bDate - aDate;
+                          })
+                          .map((session) => {
+                            const key = session.id ?? `${session.startedAt}-${session.endedAt}`;
+                            return (
+                              <li key={key} className="blog-card-activity-item">
+                                <span className="blog-card-activity-time">
+                                  {formatActivityDateTime(session.startedAt)}
+                                </span>
+                                <span className="blog-card-activity-duration">
+                                  {formatActivityDuration(session.durationMs)}
+                                </span>
+                              </li>
+                            );
+                          })}
+                      </ul>
+                    </div>
+                  )}
                   {hasMedia && (
                     <div className="blog-card-media">
                       {imageSources.length > 0 && (

--- a/src/activity-log.css
+++ b/src/activity-log.css
@@ -98,6 +98,54 @@
   box-shadow: 0 0 0 2px rgba(118, 255, 176, 0.2);
 }
 
+.activity-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.activity-select {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+  font-size: 1rem;
+  appearance: none;
+  cursor: pointer;
+}
+
+.activity-select:focus {
+  outline: none;
+  border-color: rgba(118, 255, 176, 0.6);
+  box-shadow: 0 0 0 2px rgba(118, 255, 176, 0.2);
+}
+
+.activity-picker-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.activity-picker-new {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.activity-picker-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.activity-picker-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
 .activity-suggestions {
   display: flex;
   flex-wrap: wrap;

--- a/src/tools-blog.css
+++ b/src/tools-blog.css
@@ -510,6 +510,87 @@
   line-height: 1.7;
 }
 
+.blog-card-activity {
+  margin-top: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(120, 154, 255, 0.35);
+  background: rgba(120, 154, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(120, 154, 255, 0.16);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.blog-card-activity-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.blog-card-activity-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.blog-card-activity-label {
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(198, 211, 255, 0.72);
+}
+
+.blog-card-activity-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #f3f4ff;
+}
+
+.blog-card-activity-total {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  color: rgba(216, 223, 255, 0.9);
+  background: rgba(120, 154, 255, 0.18);
+  border-radius: 999px;
+  padding: 4px 12px;
+  border: 1px solid rgba(120, 154, 255, 0.28);
+}
+
+.blog-card-activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.blog-card-activity-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(120, 154, 255, 0.14);
+}
+
+.blog-card-activity-time {
+  font-size: 0.85rem;
+  color: rgba(216, 220, 255, 0.82);
+}
+
+.blog-card-activity-duration {
+  font-size: 0.85rem;
+  color: #f5f6ff;
+  letter-spacing: 0.04em;
+}
+
 .blog-card-media {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- replace the free-text activity input with a selector for registered activities and an inline creator tied to blog pages
- bootstrap default activities and reuse shared blog helpers so logged sessions sync to their dedicated posts
- expose activity registration utilities in the blog tools and style the tracker for the new picker

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e95bcd80948322a688316e586e5b4c