### PR TITLE
Fix activity log initialization failures

### DIFF
--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   loadActivityBlogIndex,
   loadBlogPostsFromStorage,
+  loadRegisteredActivityNames,
   persistActivityBlogIndex,
   persistBlogPostsToStorage,
   sanitizeBlogPostRecord,
@@ -11,6 +12,14 @@ import './activity-log.css';
 
 const ENTRIES_KEY = 'activityLogEntries';
 const CURRENT_KEY = 'activityLogCurrent';
+
+const DEFAULT_ACTIVITIES = [
+  'Meditation - Vipassana',
+  'Meditation - Ramana',
+  'Yoga',
+  'Workout',
+  'Reading',
+];
 
 const safeParse = (value, fallback) => {
   try {
@@ -82,14 +91,23 @@ const sanitizeActivityName = (name) => {
 };
 
 const loadSanitizedBlogPosts = () => {
-  const storedPosts = loadBlogPostsFromStorage();
-  if (!Array.isArray(storedPosts)) {
+  if (typeof loadBlogPostsFromStorage !== 'function') {
     return [];
   }
 
-  return storedPosts
-    .map((post) => sanitizeBlogPostRecord(post))
-    .filter(Boolean);
+  try {
+    const storedPosts = loadBlogPostsFromStorage();
+    if (!Array.isArray(storedPosts)) {
+      return [];
+    }
+
+    return storedPosts
+      .map((post) => safeSanitizeBlogPostRecord(post))
+      .filter(Boolean);
+  } catch (error) {
+    console.error('Failed to load blog posts from storage', error);
+    return [];
+  }
 };
 
 const generatePostId = (posts) => {
@@ -125,6 +143,46 @@ const sanitizeSessionForBlog = (session) => {
   return sanitizedSession;
 };
 
+const safeSanitizeBlogPostRecord = (post) => {
+  if (typeof sanitizeBlogPostRecord === 'function') {
+    try {
+      return sanitizeBlogPostRecord(post);
+    } catch (error) {
+      console.error('Failed to sanitize blog post record', error);
+      return null;
+    }
+  }
+
+  if (post && typeof post === 'object') {
+    return { ...post };
+  }
+
+  return null;
+};
+
+const buildActivityOptions = (names) => {
+  if (!Array.isArray(names)) {
+    return [];
+  }
+
+  const byKey = new Map();
+  names.forEach((name) => {
+    const sanitized = sanitizeActivityName(name);
+    if (!sanitized) {
+      return;
+    }
+
+    const key = sanitized.toLowerCase();
+    if (!byKey.has(key)) {
+      byKey.set(key, sanitized);
+    }
+  });
+
+  return Array.from(byKey.values()).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' })
+  );
+};
+
 const withActivityBlogPost = (activityName, updater) => {
   const trimmedName = sanitizeActivityName(activityName);
   if (!trimmedName || typeof window === 'undefined') {
@@ -132,7 +190,10 @@ const withActivityBlogPost = (activityName, updater) => {
   }
 
   const posts = loadSanitizedBlogPosts();
-  const index = loadActivityBlogIndex();
+  const index =
+    typeof loadActivityBlogIndex === 'function'
+      ? loadActivityBlogIndex() || {}
+      : {};
   const mappedId = Number(index[trimmedName]);
   const hasMappedId = Number.isInteger(mappedId);
   let postId = hasMappedId ? mappedId : null;
@@ -140,7 +201,7 @@ const withActivityBlogPost = (activityName, updater) => {
 
   if (postIndex === -1) {
     postId = generatePostId(posts);
-    const newPost = sanitizeBlogPostRecord({
+    const newPost = safeSanitizeBlogPostRecord({
       id: postId,
       title: `${trimmedName} activity stream`,
       status: 'Draft',
@@ -166,7 +227,7 @@ const withActivityBlogPost = (activityName, updater) => {
   index[trimmedName] = postId;
   const post = posts[postIndex];
   const updatedPost = updater ? updater(post) ?? post : post;
-  const sanitizedPost = sanitizeBlogPostRecord({
+  const sanitizedPost = safeSanitizeBlogPostRecord({
     ...updatedPost,
     id: postId,
     activityName: updatedPost.activityName || trimmedName,
@@ -177,8 +238,20 @@ const withActivityBlogPost = (activityName, updater) => {
   }
 
   posts[postIndex] = sanitizedPost;
-  persistBlogPostsToStorage(posts);
-  persistActivityBlogIndex(index);
+  if (typeof persistBlogPostsToStorage === 'function') {
+    try {
+      persistBlogPostsToStorage(posts);
+    } catch (error) {
+      console.error('Failed to persist blog posts to storage', error);
+    }
+  }
+  if (typeof persistActivityBlogIndex === 'function') {
+    try {
+      persistActivityBlogIndex(index);
+    } catch (error) {
+      console.error('Failed to persist activity blog index', error);
+    }
+  }
 
   return sanitizedPost;
 };
@@ -220,6 +293,26 @@ const recordSessionInBlog = (session) => {
 };
 
 export default function ActivityLog({ onBack }) {
+  const buildOptionsFromStorage = useCallback(() => {
+    let storedNames = [];
+    try {
+      storedNames =
+        typeof loadRegisteredActivityNames === 'function'
+          ? loadRegisteredActivityNames()
+          : [];
+    } catch (error) {
+      console.error('Failed to load registered activity names', error);
+      storedNames = [];
+    }
+    const sanitizedStored = Array.isArray(storedNames)
+      ? buildActivityOptions(storedNames)
+      : [];
+    if (sanitizedStored.length > 0) {
+      return sanitizedStored;
+    }
+    return buildActivityOptions(DEFAULT_ACTIVITIES);
+  }, []);
+
   const [entries, setEntries] = useState(() =>
     safeParse(localStorage.getItem(ENTRIES_KEY), [])
   );
@@ -228,15 +321,15 @@ export default function ActivityLog({ onBack }) {
   );
   const [activityName, setActivityName] = useState(() => current?.name || '');
   const [activityOptions, setActivityOptions] = useState(() =>
-    loadRegisteredActivityNames()
+    buildOptionsFromStorage()
   );
   const [isAddingActivity, setIsAddingActivity] = useState(false);
   const [newActivityName, setNewActivityName] = useState('');
   const [tick, setTick] = useState(() => Date.now());
 
   const refreshActivityOptions = useCallback(() => {
-    setActivityOptions(loadRegisteredActivityNames());
-  }, []);
+    setActivityOptions(buildOptionsFromStorage());
+  }, [buildOptionsFromStorage]);
 
   useEffect(() => {
     const id = setInterval(() => setTick(Date.now()), 1000);
@@ -349,7 +442,7 @@ export default function ActivityLog({ onBack }) {
   const handleStart = () => {
     if (startDisabled) return;
     const now = new Date();
-    ensureActivityBlogPost(trimmedName);
+    ensureActivityBlogPost(sanitizedSelectedName);
 
     if (current && sanitizeActivityName(current.name) !== sanitizedSelectedName) {
       const finished = finalizeSession(current, now);

--- a/src/ToolsBlog.jsx
+++ b/src/ToolsBlog.jsx
@@ -432,6 +432,36 @@ export const persistActivityBlogIndex = (index) => {
   }
 };
 
+export const loadRegisteredActivityNames = () => {
+  const posts = loadSanitizedBlogPosts();
+  const index = loadActivityBlogIndex();
+  const names = new Map();
+
+  const register = (name) => {
+    const sanitized = sanitizeActivityName(name);
+    if (!sanitized) {
+      return;
+    }
+
+    const key = sanitized.toLowerCase();
+    if (!names.has(key)) {
+      names.set(key, sanitized);
+    }
+  };
+
+  posts.forEach((post) => {
+    register(post?.activityName ?? post?.title);
+  });
+
+  Object.keys(index || {}).forEach((activityName) => {
+    register(activityName);
+  });
+
+  return Array.from(names.values()).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' })
+  );
+};
+
 export default function ToolsBlog({ onBack }) {
   const [posts, setPosts] = useState(buildInitialPosts);
   const [editingPostId, setEditingPostId] = useState(null);


### PR DESCRIPTION
## Summary
- prevent ActivityLog from crashing by restoring the loadRegisteredActivityNames import and using safe fallbacks when blog utilities are unavailable
- rebuild the activity options list with sanitized, deduplicated names and default fallbacks for empty storage
- expose loadRegisteredActivityNames from ToolsBlog so the log can repopulate its dropdown

## Testing
- npm test -- ActivityLog

------
https://chatgpt.com/codex/tasks/task_e_68e968e2f7808322a5ce6e3806318574