### PR TITLE
Add view selector control to library header

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -321,6 +321,7 @@ export default function Library({ onBack }) {
   const [sortMode, setSortMode] = useState('none'); // 'none', 'color', 'title', 'date', 'rating', 'random'
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
   const [libraryTheme, setLibraryTheme] = useState(() => {
     if (typeof window !== 'undefined') {
       const storedTheme = localStorage.getItem('libraryTheme');
@@ -335,6 +336,15 @@ export default function Library({ onBack }) {
       }
     }
     return 'dark';
+  });
+  const [libraryView, setLibraryView] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const storedView = localStorage.getItem('libraryView');
+      if (storedView === 'tri') {
+        return 'tri';
+      }
+    }
+    return 'classic';
   });
   const [originalImages, setOriginalImages] = useState([]);
   const [draggedId, setDraggedId] = useState(null);
@@ -903,6 +913,11 @@ export default function Library({ onBack }) {
       localStorage.setItem('libraryTheme', libraryTheme);
     }
   }, [libraryTheme]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('libraryView', libraryView);
+    }
+  }, [libraryView]);
   const maxZoom = 1; // max 100% of native size
   const colWidth = 250 * zoom;
   const rowHeight = 1; // finer base row height for masonry grid
@@ -1020,6 +1035,7 @@ export default function Library({ onBack }) {
       setSoundMenu(null);
       setSortMenuOpen(false);
       setSettingsOpen(false);
+      setViewMenuOpen(false);
     };
     window.addEventListener('click', close);
     return () => window.removeEventListener('click', close);
@@ -1622,7 +1638,7 @@ export default function Library({ onBack }) {
     <div
       className={`library-container ${
         isDragging ? 'dragging' : ''
-      } ${libraryTheme === 'light' ? 'light-mode' : 'dark-mode'}`}
+      } ${libraryTheme === 'light' ? 'light-mode' : 'dark-mode'} library-view-${libraryView}`}
       onDragOver={handleDragOver}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
@@ -1637,6 +1653,67 @@ export default function Library({ onBack }) {
           </button>
           <h2>Library</h2>
           <div className="library-actions">
+            <div className="library-view-selector">
+              <button
+                type="button"
+                className={`library-view-button${
+                  viewMenuOpen ? ' open' : ''
+                }`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setViewMenuOpen((open) => !open);
+                  setSettingsOpen(false);
+                  setSortMenuOpen(false);
+                }}
+                aria-haspopup="true"
+                aria-expanded={viewMenuOpen}
+              >
+                View
+              </button>
+              {viewMenuOpen && (
+                <div
+                  className="library-view-menu"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    type="button"
+                    className={libraryView === 'classic' ? 'active' : ''}
+                    onClick={() => {
+                      setLibraryView('classic');
+                      setViewMenuOpen(false);
+                    }}
+                  >
+                    <span>Classic</span>
+                    {libraryView === 'classic' && (
+                      <span
+                        className="library-view-check"
+                        aria-hidden="true"
+                      >
+                        ✓
+                      </span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    className={libraryView === 'tri' ? 'active' : ''}
+                    onClick={() => {
+                      setLibraryView('tri');
+                      setViewMenuOpen(false);
+                    }}
+                  >
+                    <span>Tri</span>
+                    {libraryView === 'tri' && (
+                      <span
+                        className="library-view-check"
+                        aria-hidden="true"
+                      >
+                        ✓
+                      </span>
+                    )}
+                  </button>
+                </div>
+              )}
+            </div>
             <div className="library-settings">
               <button
                 type="button"

--- a/src/library.css
+++ b/src/library.css
@@ -153,6 +153,82 @@
   gap: 12px;
 }
 
+.library-view-selector {
+  position: relative;
+}
+
+.library-view-button {
+  background: var(--library-button-bg);
+  color: var(--library-button-text);
+  border: 1px solid var(--library-button-border);
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease, box-shadow 0.3s ease;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.library-view-button:hover {
+  background: var(--library-accent);
+  color: var(--library-accent-contrast);
+  border-color: transparent;
+  box-shadow: var(--library-glow);
+}
+
+.library-view-button.open {
+  background: var(--library-accent);
+  color: var(--library-accent-contrast);
+  border-color: transparent;
+  box-shadow: var(--library-glow);
+}
+
+.library-view-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  background: var(--library-menu-bg);
+  border: 1px solid var(--library-menu-border);
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  z-index: 12;
+  box-shadow: var(--library-dropdown-shadow);
+  backdrop-filter: blur(12px);
+  min-width: 140px;
+}
+
+.library-view-menu button {
+  background: transparent;
+  border: none;
+  color: var(--library-text);
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.library-view-menu button:hover {
+  background: var(--library-menu-hover);
+  color: var(--library-accent);
+}
+
+.library-view-menu button.active {
+  color: var(--library-accent);
+}
+
+.library-view-check {
+  font-weight: bold;
+  color: var(--library-accent);
+}
+
 .library-settings {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- add a dedicated View button to the library header next to settings
- persist the selected library view in local storage and expose Classic and Tri options
- style the new control and dropdown menu to match existing library actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebac3a6cec8322b1a77082d735dec2