### PR TITLE
Implement draggable Tri view for library

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -39,6 +39,68 @@ const SOUND_PRESET_TAGS = [
   ...QUALITY_TAGS,
 ];
 
+const TRI_VIEW_CATEGORIES = [
+  { id: 'form', label: 'Form' },
+  { id: 'semi-formless', label: 'Semi-Formless' },
+  { id: 'formless', label: 'Formless' },
+];
+
+const TRI_CATEGORY_IDS = TRI_VIEW_CATEGORIES.map((category) => category.id);
+
+const normalizeTriCategory = (value) =>
+  TRI_CATEGORY_IDS.includes(value) ? value : null;
+
+const normalizeTriOrder = (value) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+const buildTriIdLists = (items) => {
+  const indexMap = new Map(items.map((item, idx) => [item.id, idx]));
+  const buckets = {
+    form: [],
+    'semi-formless': [],
+    formless: [],
+    drawer: [],
+  };
+
+  items.forEach((img) => {
+    const category = normalizeTriCategory(img.triCategory);
+    if (category) {
+      buckets[category].push({
+        id: img.id,
+        order: normalizeTriOrder(img.triOrder),
+      });
+    } else {
+      buckets.drawer.push(img.id);
+    }
+  });
+
+  const sortCategory = (entries) =>
+    entries
+      .slice()
+      .sort((a, b) => {
+        const orderA =
+          typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER;
+        const orderB =
+          typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER;
+        if (orderA !== orderB) {
+          return orderA - orderB;
+        }
+        return (indexMap.get(a.id) ?? 0) - (indexMap.get(b.id) ?? 0);
+      })
+      .map((entry) => entry.id);
+
+  return {
+    form: sortCategory(buckets.form),
+    'semi-formless': sortCategory(buckets['semi-formless']),
+    formless: sortCategory(buckets.formless),
+    drawer: buckets.drawer
+      .slice()
+      .sort(
+        (a, b) => (indexMap.get(a) ?? 0) - (indexMap.get(b) ?? 0)
+      ),
+  };
+};
+
 const parseSoundTags = (sound) => {
   const seen = new Set();
   const tags = [];
@@ -321,6 +383,7 @@ export default function Library({ onBack }) {
   const [sortMode, setSortMode] = useState('none'); // 'none', 'color', 'title', 'date', 'rating', 'random'
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
   const [libraryTheme, setLibraryTheme] = useState(() => {
     if (typeof window !== 'undefined') {
       const storedTheme = localStorage.getItem('libraryTheme');
@@ -336,8 +399,19 @@ export default function Library({ onBack }) {
     }
     return 'dark';
   });
+  const [libraryView, setLibraryView] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const storedView = localStorage.getItem('libraryView');
+      if (storedView === 'tri') {
+        return 'tri';
+      }
+    }
+    return 'classic';
+  });
   const [originalImages, setOriginalImages] = useState([]);
   const [draggedId, setDraggedId] = useState(null);
+  const [triDraggingId, setTriDraggingId] = useState(null);
+  const [triActiveZone, setTriActiveZone] = useState(null);
 
   const saveSequenceRef = useRef(0);
   const lastSavedImagesRef = useRef(new Map());
@@ -510,7 +584,11 @@ export default function Library({ onBack }) {
 
         const base = { ...entry };
         const normalizedTags = normalizeImageTags(base.tags);
+        const triCategory = normalizeTriCategory(base.triCategory);
+        const triOrder = normalizeTriOrder(base.triOrder);
         base.tags = normalizedTags;
+        base.triCategory = triCategory;
+        base.triOrder = triOrder;
 
         const dataUrl =
           typeof base.dataUrl === 'string' && base.dataUrl.length
@@ -744,10 +822,14 @@ export default function Library({ onBack }) {
     const normalized = imgs.map((img) => {
       const normalizedTags = normalizeImageTags(img.tags);
       const mimeType = img.mimeType || extractMimeType(img.dataUrl) || null;
+      const triCategory = normalizeTriCategory(img.triCategory);
+      const triOrder = normalizeTriOrder(img.triOrder);
       return {
         ...img,
         tags: normalizedTags,
         mimeType,
+        triCategory,
+        triOrder,
       };
     });
     setImages(normalized);
@@ -903,6 +985,11 @@ export default function Library({ onBack }) {
       localStorage.setItem('libraryTheme', libraryTheme);
     }
   }, [libraryTheme]);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('libraryView', libraryView);
+    }
+  }, [libraryView]);
   const maxZoom = 1; // max 100% of native size
   const colWidth = 250 * zoom;
   const rowHeight = 1; // finer base row height for masonry grid
@@ -1020,6 +1107,7 @@ export default function Library({ onBack }) {
       setSoundMenu(null);
       setSortMenuOpen(false);
       setSettingsOpen(false);
+      setViewMenuOpen(false);
     };
     window.addEventListener('click', close);
     return () => window.removeEventListener('click', close);
@@ -1596,6 +1684,283 @@ export default function Library({ onBack }) {
     );
   };
 
+  const triAssignments = useMemo(() => {
+    const empty = TRI_CATEGORY_IDS.reduce(
+      (acc, id) => ({ ...acc, [id]: [] }),
+      {}
+    );
+    if (!images.length) {
+      return { categories: empty, drawer: [] };
+    }
+    const lists = buildTriIdLists(images);
+    const imageMap = new Map(images.map((img) => [img.id, img]));
+    const categories = { ...empty };
+    TRI_CATEGORY_IDS.forEach((id) => {
+      const ids = lists[id] || [];
+      categories[id] = ids
+        .map((imageId) => imageMap.get(imageId))
+        .filter(Boolean);
+    });
+    const drawer = (lists.drawer || [])
+      .map((imageId) => imageMap.get(imageId))
+      .filter(Boolean);
+    return { categories, drawer };
+  }, [images]);
+
+  const isFileTransfer = (dataTransfer) => {
+    if (!dataTransfer) return false;
+    if (dataTransfer.files && dataTransfer.files.length > 0) {
+      return true;
+    }
+    const types = Array.isArray(dataTransfer.types)
+      ? dataTransfer.types
+      : Array.from(dataTransfer.types || []);
+    return types.includes('Files');
+  };
+
+  const updateTriPlacement = (imageId, targetCategory, targetIndex) => {
+    const lists = buildTriIdLists(images);
+    const categories = {
+      form: [...lists.form],
+      'semi-formless': [...lists['semi-formless']],
+      formless: [...lists.formless],
+    };
+    const drawer = [...lists.drawer];
+
+    const removeFromList = (list) => {
+      const idx = list.indexOf(imageId);
+      if (idx !== -1) {
+        list.splice(idx, 1);
+      }
+    };
+
+    Object.values(categories).forEach(removeFromList);
+    removeFromList(drawer);
+
+    const insertInto = (list) => {
+      if (!Array.isArray(list)) return;
+      const safeIndex =
+        typeof targetIndex === 'number'
+          ? Math.max(0, Math.min(targetIndex, list.length))
+          : list.length;
+      list.splice(safeIndex, 0, imageId);
+    };
+
+    if (targetCategory && categories[targetCategory]) {
+      insertInto(categories[targetCategory]);
+    } else {
+      insertInto(drawer);
+    }
+
+    const placement = new Map();
+    TRI_CATEGORY_IDS.forEach((id) => {
+      const list = categories[id] || [];
+      list.forEach((entryId, idx) => {
+        placement.set(entryId, {
+          category: id,
+          order: idx,
+        });
+      });
+    });
+    drawer.forEach((entryId) => {
+      placement.set(entryId, { category: null, order: null });
+    });
+
+    const updated = images.map((img) => {
+      const nextPlacement = placement.get(img.id);
+      if (!nextPlacement) {
+        return img;
+      }
+      const nextCategory = nextPlacement.category;
+      const nextOrder = normalizeTriOrder(nextPlacement.order);
+      const currentCategory = normalizeTriCategory(img.triCategory);
+      const currentOrder = normalizeTriOrder(img.triOrder);
+      if (currentCategory !== nextCategory || currentOrder !== nextOrder) {
+        return {
+          ...img,
+          triCategory: nextCategory,
+          triOrder: nextOrder,
+        };
+      }
+      return img;
+    });
+
+    saveImages(updated);
+  };
+
+  const findImageIdFromDragData = (raw) => {
+    if (typeof raw !== 'string' || !raw) return null;
+    const match = images.find((img) => String(img.id) === raw);
+    return match ? match.id : null;
+  };
+
+  const handleTriDragOverZone = (event, zoneId) => {
+    if (isFileTransfer(event.dataTransfer)) {
+      handleDragOver(event);
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    setTriActiveZone((prev) => (prev === zoneId ? prev : zoneId));
+  };
+
+  const handleTriDrop = (event, categoryId, index) => {
+    if (isFileTransfer(event.dataTransfer)) {
+      handleDrop(event);
+      setTriActiveZone(null);
+      setTriDraggingId(null);
+      return;
+    }
+    event.preventDefault();
+    const raw =
+      event.dataTransfer?.getData('application/x-library-tri-image') ||
+      event.dataTransfer?.getData('text/plain');
+    let resolvedId = findImageIdFromDragData(raw);
+    if (resolvedId === null || typeof resolvedId === 'undefined') {
+      resolvedId = triDraggingId ?? null;
+    }
+    if (resolvedId === null || typeof resolvedId === 'undefined') {
+      setTriActiveZone(null);
+      setTriDraggingId(null);
+      return;
+    }
+    updateTriPlacement(resolvedId, categoryId, index);
+    setTriActiveZone(null);
+    setTriDraggingId(null);
+  };
+
+  const renderTriTile = (img, categoryId = null, index = null) => {
+    const isLoaded = Boolean(img.dataUrl);
+    const zoneId = categoryId || 'drawer';
+    const title = img.title || 'Untitled';
+    return (
+      <div
+        key={img.id}
+        className={`tri-image-tile${
+          triDraggingId === img.id ? ' dragging' : ''
+        }`}
+        draggable
+        onDragStart={(e) => {
+          setTriDraggingId(img.id);
+          if (e.dataTransfer) {
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData(
+              'application/x-library-tri-image',
+              String(img.id)
+            );
+          }
+        }}
+        onDragEnd={() => {
+          setTriDraggingId(null);
+          setTriActiveZone(null);
+        }}
+        onDrop={(e) => {
+          e.stopPropagation();
+          handleTriDrop(e, categoryId, index);
+        }}
+        onDragOver={(e) => {
+          handleTriDragOverZone(e, zoneId);
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setMenu({ id: img.id, x: e.clientX, y: e.clientY });
+        }}
+        onClick={isLoaded ? () => setLightbox(img) : undefined}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if ((e.key === 'Enter' || e.key === ' ') && isLoaded) {
+            e.preventDefault();
+            setLightbox(img);
+          }
+        }}
+        aria-label={`View ${title}`}
+        title={title}
+      >
+        {isLoaded ? (
+          <img src={img.dataUrl} alt={title} draggable={false} />
+        ) : (
+          <div className="tri-image-placeholder" role="status">
+            <div className="image-loading-spinner" aria-hidden="true" />
+            <span className="image-loading-text">Loading…</span>
+          </div>
+        )}
+        <div className="tri-image-label">
+          {img.color && (
+            <span className="color-dot" style={{ background: img.color }} />
+          )}
+          <span className="tri-image-title">{title}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const renderTriView = () => {
+    const drawerImages = triAssignments.drawer;
+    const message = images.length
+      ? 'Drag images from the drawer into a category to lock them in place.'
+      : 'Upload images to start sorting them into Form, Semi-Formless, and Formless.';
+    return (
+      <div className="tri-view">
+        <p className="tri-instructions">{message}</p>
+        <div className="tri-columns">
+          {TRI_VIEW_CATEGORIES.map(({ id, label }) => {
+            const items = triAssignments.categories[id] || [];
+            return (
+              <div
+                key={id}
+                className={`tri-column${
+                  triActiveZone === id ? ' active-drop' : ''
+                }`}
+              >
+                <div className="tri-column-header">
+                  <h3>{label}</h3>
+                  <span className="tri-column-count">{items.length}</span>
+                </div>
+                <div
+                  className={`tri-column-body${
+                    triActiveZone === id ? ' active-drop' : ''
+                  }`}
+                  onDragOver={(e) => handleTriDragOverZone(e, id)}
+                  onDrop={(e) => handleTriDrop(e, id)}
+                >
+                  {items.length ? (
+                    items.map((img, index) => renderTriTile(img, id, index))
+                  ) : (
+                    <div className="tri-column-empty">Drop images here</div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="tri-drawer">
+          <div className="tri-drawer-header">
+            <span>Library Drawer</span>
+            <span className="tri-drawer-count">{drawerImages.length}</span>
+          </div>
+          <div
+            className={`tri-drawer-body${
+              triActiveZone === 'drawer' ? ' active-drop' : ''
+            }`}
+            onDragOver={(e) => handleTriDragOverZone(e, 'drawer')}
+            onDrop={(e) => handleTriDrop(e, null)}
+          >
+            {drawerImages.length ? (
+              drawerImages.map((img, index) => renderTriTile(img, null, index))
+            ) : (
+              <div className="tri-drawer-empty">
+                Images you add appear here until you place them in a category.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const lightboxOrientation = getOrientationTag(lightbox?.tags);
   const lightboxCategory = findPresetTag(lightbox?.tags, CATEGORY_TAGS);
   const lightboxGender = findPresetTag(lightbox?.tags, GENDER_TAGS);
@@ -1622,7 +1987,7 @@ export default function Library({ onBack }) {
     <div
       className={`library-container ${
         isDragging ? 'dragging' : ''
-      } ${libraryTheme === 'light' ? 'light-mode' : 'dark-mode'}`}
+      } ${libraryTheme === 'light' ? 'light-mode' : 'dark-mode'} library-view-${libraryView}`}
       onDragOver={handleDragOver}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
@@ -1637,6 +2002,67 @@ export default function Library({ onBack }) {
           </button>
           <h2>Library</h2>
           <div className="library-actions">
+            <div className="library-view-selector">
+              <button
+                type="button"
+                className={`library-view-button${
+                  viewMenuOpen ? ' open' : ''
+                }`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setViewMenuOpen((open) => !open);
+                  setSettingsOpen(false);
+                  setSortMenuOpen(false);
+                }}
+                aria-haspopup="true"
+                aria-expanded={viewMenuOpen}
+              >
+                View
+              </button>
+              {viewMenuOpen && (
+                <div
+                  className="library-view-menu"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    type="button"
+                    className={libraryView === 'classic' ? 'active' : ''}
+                    onClick={() => {
+                      setLibraryView('classic');
+                      setViewMenuOpen(false);
+                    }}
+                  >
+                    <span>Classic</span>
+                    {libraryView === 'classic' && (
+                      <span
+                        className="library-view-check"
+                        aria-hidden="true"
+                      >
+                        ✓
+                      </span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    className={libraryView === 'tri' ? 'active' : ''}
+                    onClick={() => {
+                      setLibraryView('tri');
+                      setViewMenuOpen(false);
+                    }}
+                  >
+                    <span>Tri</span>
+                    {libraryView === 'tri' && (
+                      <span
+                        className="library-view-check"
+                        aria-hidden="true"
+                      >
+                        ✓
+                      </span>
+                    )}
+                  </button>
+                </div>
+              )}
+            </div>
             <div className="library-settings">
               <button
                 type="button"
@@ -1849,148 +2275,151 @@ export default function Library({ onBack }) {
             Sounds
           </button>
         </div>
-        {(activeTab === 'all' || activeTab === 'images') && (
-          sortMode === 'color' ? (
-            <div className="color-groups">
-              {palette.map((c) => {
-                const groupImgs = filteredImages.filter((img) => img.color === c);
-                const groupSounds = sounds.filter((s) => s.color === c);
-                if (!groupImgs.length && !groupSounds.length) return null;
-                return (
-                  <div key={c} className="color-group">
-                    <h3 className="color-title" style={{ color: c }}>
-                      {hexToName(c)}
-                    </h3>
-                      <div style={{ width: '100%', overflow: 'hidden' }}>
-                        <div
-                          className="image-grid"
-                          style={{
-                            gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
-                            gridAutoRows: `${rowHeight}px`,
-                            gap: `${gridGap}px`,
+        {(activeTab === 'all' || activeTab === 'images') &&
+          (libraryView === 'tri'
+            ? renderTriView()
+            : sortMode === 'color'
+            ? (
+              <div className="color-groups">
+                {palette.map((c) => {
+                  const groupImgs = filteredImages.filter((img) => img.color === c);
+                  const groupSounds = sounds.filter((s) => s.color === c);
+                  if (!groupImgs.length && !groupSounds.length) return null;
+                  return (
+                    <div key={c} className="color-group">
+                      <h3 className="color-title" style={{ color: c }}>
+                        {hexToName(c)}
+                      </h3>
+                        <div style={{ width: '100%', overflow: 'hidden' }}>
+                          <div
+                            className="image-grid"
+                            style={{
+                              gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
+                              gridAutoRows: `${rowHeight}px`,
+                              gap: `${gridGap}px`,
+                            }}
+                            onDragOver={(e) => {
+                            if (e.dataTransfer.files?.length) {
+                              handleDragOver(e);
+                            } else {
+                              e.preventDefault();
+                            }
                           }}
-                          onDragOver={(e) => {
-                          if (e.dataTransfer.files?.length) {
-                            handleDragOver(e);
-                          } else {
+                          onDrop={(e) => {
+                            if (e.dataTransfer.files?.length) {
+                              handleDrop(e);
+                              return;
+                            }
                             e.preventDefault();
-                          }
-                        }}
-                        onDrop={(e) => {
+                            if (draggedId) {
+                              const updated = images.filter((img) => img.id !== draggedId);
+                              const moved = images.find((img) => img.id === draggedId);
+                              if (moved) {
+                                moved.color = c;
+                                moved.title = hexToName(c);
+                                updated.push(moved);
+                                saveImages(updated);
+                              }
+                              setDraggedId(null);
+                            }
+                          }}
+                        >
+                          {groupImgs.map((img) => renderImageCard(img))}
+                          {activeTab === 'all' &&
+                            groupSounds.map((s) => renderSoundCard(s))}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+                {activeTab === 'all' && sounds.length > 0 && (
+                  <div className="color-group">
+                    <h3 className="color-title" style={{ color: '#fff' }}>
+                      Sounds
+                    </h3>
+                        <div style={{ width: '100%', overflow: 'hidden' }}>
+                          <div
+                            className="image-grid"
+                            style={{
+                              gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
+                              gridAutoRows: `${rowHeight}px`,
+                              gap: `${gridGap}px`,
+                            }}
+                          >
+                          {sounds.map((s) => renderSoundCard(s))}
+                        </div>
+                      </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div
+                className="image-grid"
+                style={{
+                  gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
+                  gridAutoRows: `${rowHeight}px`,
+                  gap: `${gridGap}px`,
+                }}
+                onDragOver={
+                  sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
+                    ? (e) => {
+                        if (e.dataTransfer.files?.length) {
+                          handleDragOver(e);
+                        } else {
+                          e.preventDefault();
+                        }
+                      }
+                    : undefined
+                }
+                  onDrop={
+                    sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
+                      ? (e) => {
                           if (e.dataTransfer.files?.length) {
                             handleDrop(e);
                             return;
                           }
                           e.preventDefault();
                           if (draggedId) {
-                            const updated = images.filter((img) => img.id !== draggedId);
-                            const moved = images.find((img) => img.id === draggedId);
-                            if (moved) {
-                              moved.color = c;
-                              moved.title = hexToName(c);
+                            const fromIndex = images.findIndex(
+                              (img) => img.id === draggedId
+                            );
+                            if (fromIndex !== -1) {
+                              const updated = [...images];
+                              const [moved] = updated.splice(fromIndex, 1);
                               updated.push(moved);
                               saveImages(updated);
                             }
                             setDraggedId(null);
                           }
-                        }}
-                      >
-                        {groupImgs.map((img) => renderImageCard(img))}
-                        {activeTab === 'all' &&
-                          groupSounds.map((s) => renderSoundCard(s))}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
-              {activeTab === 'all' && sounds.length > 0 && (
-                <div className="color-group">
-                  <h3 className="color-title" style={{ color: '#fff' }}>
-                    Sounds
-                  </h3>
-                      <div style={{ width: '100%', overflow: 'hidden' }}>
-                        <div
-                          className="image-grid"
-                          style={{
-                            gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
-                            gridAutoRows: `${rowHeight}px`,
-                            gap: `${gridGap}px`,
-                          }}
-                        >
-                        {sounds.map((s) => renderSoundCard(s))}
-                      </div>
-                    </div>
-                </div>
-              )}
-            </div>
-          ) : (
-            <div
-              className="image-grid"
-              style={{
-                gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
-                gridAutoRows: `${rowHeight}px`,
-                gap: `${gridGap}px`,
-              }}
-              onDragOver={
-                sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
-                  ? (e) => {
-                      if (e.dataTransfer.files?.length) {
-                        handleDragOver(e);
-                      } else {
-                        e.preventDefault();
-                      }
-                    }
-                  : undefined
-              }
-                onDrop={
-                  sortMode !== 'title' && sortMode !== 'date' && sortMode !== 'rating'
-                    ? (e) => {
-                        if (e.dataTransfer.files?.length) {
-                          handleDrop(e);
-                          return;
                         }
-                        e.preventDefault();
-                        if (draggedId) {
-                          const fromIndex = images.findIndex(
-                            (img) => img.id === draggedId
+                      : undefined
+                  }
+                  >
+                    {activeTab === 'all'
+                      ? (() => {
+                          const combined = [
+                            ...filteredImages.map((img) => ({
+                              type: 'image',
+                              item: img,
+                            })),
+                            ...sounds.map((s) => ({ type: 'sound', item: s })),
+                          ];
+                          const ordered =
+                            sortMode === 'date'
+                              ? combined
+                                  .slice()
+                                  .sort((a, b) => a.item.id - b.item.id)
+                              : combined;
+                          return ordered.map(({ type, item }) =>
+                            type === 'image'
+                              ? renderImageCard(item)
+                              : renderSoundCard(item)
                           );
-                          if (fromIndex !== -1) {
-                            const updated = [...images];
-                            const [moved] = updated.splice(fromIndex, 1);
-                            updated.push(moved);
-                            saveImages(updated);
-                          }
-                          setDraggedId(null);
-                        }
-                      }
-                    : undefined
-                }
-                >
-                  {activeTab === 'all'
-                    ? (() => {
-                        const combined = [
-                          ...filteredImages.map((img) => ({
-                            type: 'image',
-                            item: img,
-                          })),
-                          ...sounds.map((s) => ({ type: 'sound', item: s })),
-                        ];
-                        const ordered =
-                          sortMode === 'date'
-                            ? combined
-                                .slice()
-                                .sort((a, b) => a.item.id - b.item.id)
-                            : combined;
-                        return ordered.map(({ type, item }) =>
-                          type === 'image'
-                            ? renderImageCard(item)
-                            : renderSoundCard(item)
-                        );
-                      })()
-                    : filteredImages.map((img) => renderImageCard(img))}
-                </div>
-            ))}
-          {(activeTab === 'all' || activeTab === 'words') && (
+                        })()
+                      : filteredImages.map((img) => renderImageCard(img))}
+                  </div>
+              ))}
+        {(activeTab === 'all' || activeTab === 'words') && (
           <div className="word-section">
             {activeTab === 'words' && (
               <form onSubmit={handleAddWord} className="word-form">
@@ -2012,6 +2441,22 @@ export default function Library({ onBack }) {
                 </li>
               ))}
             </ul>
+          </div>
+        )}
+        {libraryView === 'tri' && activeTab === 'all' && sounds.length > 0 && (
+          <div className="sound-section tri-sound-section">
+            <div style={{ width: '100%', overflow: 'hidden' }}>
+              <div
+                className="image-grid"
+                style={{
+                  gridTemplateColumns: `repeat(auto-fill, ${colWidth}px)`,
+                  gridAutoRows: `${rowHeight}px`,
+                  gap: `${gridGap}px`,
+                }}
+              >
+                {sounds.map((s) => renderSoundCard(s))}
+              </div>
+            </div>
           </div>
         )}
         {activeTab === 'sounds' && (

--- a/src/library.css
+++ b/src/library.css
@@ -153,6 +153,82 @@
   gap: 12px;
 }
 
+.library-view-selector {
+  position: relative;
+}
+
+.library-view-button {
+  background: var(--library-button-bg);
+  color: var(--library-button-text);
+  border: 1px solid var(--library-button-border);
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease, box-shadow 0.3s ease;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.library-view-button:hover {
+  background: var(--library-accent);
+  color: var(--library-accent-contrast);
+  border-color: transparent;
+  box-shadow: var(--library-glow);
+}
+
+.library-view-button.open {
+  background: var(--library-accent);
+  color: var(--library-accent-contrast);
+  border-color: transparent;
+  box-shadow: var(--library-glow);
+}
+
+.library-view-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  background: var(--library-menu-bg);
+  border: 1px solid var(--library-menu-border);
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  z-index: 12;
+  box-shadow: var(--library-dropdown-shadow);
+  backdrop-filter: blur(12px);
+  min-width: 140px;
+}
+
+.library-view-menu button {
+  background: transparent;
+  border: none;
+  color: var(--library-text);
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.library-view-menu button:hover {
+  background: var(--library-menu-hover);
+  color: var(--library-accent);
+}
+
+.library-view-menu button.active {
+  color: var(--library-accent);
+}
+
+.library-view-check {
+  font-weight: bold;
+  color: var(--library-accent);
+}
+
 .library-settings {
   position: relative;
 }
@@ -721,6 +797,222 @@
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--library-muted-text);
+}
+
+.library-view-tri .tri-view {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.tri-instructions {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--library-muted-text);
+}
+
+.tri-columns {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.tri-column {
+  background: var(--library-surface);
+  border: 1px solid var(--library-surface-border);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--library-shadow);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tri-column.active-drop {
+  border-color: var(--library-accent);
+  box-shadow: var(--library-glow);
+}
+
+.tri-column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  color: var(--library-text);
+}
+
+.tri-column-count,
+.tri-drawer-count {
+  background: var(--library-soft-highlight);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  color: var(--library-accent);
+}
+
+.tri-column-body {
+  flex: 1;
+  min-height: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px dashed var(--library-surface-border);
+  background: rgba(255, 255, 255, 0.03);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.library-container.light-mode .tri-column-body {
+  background: rgba(90, 96, 255, 0.08);
+}
+
+.tri-column-body.active-drop {
+  border-color: var(--library-accent);
+  box-shadow: inset 0 0 0 1px var(--library-accent);
+}
+
+.tri-column-empty,
+.tri-drawer-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 16px;
+  font-size: 0.9rem;
+  color: var(--library-muted-text);
+  border-radius: 10px;
+  border: 1px dashed transparent;
+}
+
+.tri-image-tile {
+  position: relative;
+  background: var(--library-surface);
+  border: 1px solid var(--library-surface-border);
+  border-radius: 14px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  box-shadow: var(--library-shadow);
+  cursor: grab;
+  min-height: 200px;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.tri-image-tile:active {
+  cursor: grabbing;
+}
+
+.tri-image-tile.dragging {
+  opacity: 0.65;
+  border-color: var(--library-accent);
+  box-shadow: var(--library-glow);
+}
+
+.tri-image-tile img,
+.tri-image-placeholder {
+  width: 100%;
+  flex: 1;
+  border-radius: 10px;
+  object-fit: cover;
+}
+
+.tri-image-placeholder {
+  background: var(--library-placeholder-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--library-placeholder-text);
+  font-size: 0.85rem;
+}
+
+.tri-image-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--library-text);
+}
+
+.tri-image-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tri-drawer {
+  background: var(--library-surface);
+  border: 1px solid var(--library-surface-border);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--library-shadow);
+}
+
+.tri-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--library-text);
+}
+
+.tri-drawer-body {
+  display: flex;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px dashed var(--library-surface-border);
+  background: rgba(255, 255, 255, 0.03);
+  overflow-x: auto;
+  scroll-snap-type: x proximity;
+}
+
+.library-container.light-mode .tri-drawer-body {
+  background: rgba(90, 96, 255, 0.08);
+}
+
+.tri-drawer-body.active-drop {
+  border-color: var(--library-accent);
+  box-shadow: inset 0 0 0 1px var(--library-accent);
+}
+
+.tri-drawer-body .tri-image-tile {
+  flex: 0 0 150px;
+  scroll-snap-align: start;
+}
+
+.tri-drawer-body::-webkit-scrollbar {
+  height: 8px;
+}
+
+.tri-drawer-body::-webkit-scrollbar-thumb {
+  background: var(--library-surface-border);
+  border-radius: 999px;
+}
+
+.tri-drawer-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.tri-sound-section {
+  margin-top: 32px;
 }
 
 .sound-tag-group {


### PR DESCRIPTION
## Summary
- add a Tri view that organizes images into Form, Semi-Formless, and Formless columns with persistent placement
- wire drag-and-drop handlers, state, and menu integration so users can sort images via a bottom drawer and keep assignments
- style the new Tri layout, drawer, and supporting sound section to match the library aesthetic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebac3a6cec8322b1a77082d735dec2