### PR TITLE
Restore full-width layout for TasteT semi-formless view

### DIFF
--- a/src/world.css
+++ b/src/world.css
@@ -11,6 +11,8 @@
 .semi-formless-world {
   padding: 60px 40px 80px;
   box-sizing: border-box;
+  align-items: stretch;
+  overflow: auto;
 }
 
 .semi-formless-hub {
@@ -103,7 +105,9 @@
 }
 
 .semi-formless-stage {
-  width: min(1200px, 100%);
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -137,6 +141,13 @@
   padding: 24px;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.semi-formless-app-frame > * {
+  flex: 1 1 auto;
 }
 
 .resource-box {


### PR DESCRIPTION
## Summary
- allow the semi-formless world container to stretch and scroll
- expand the semi-formless stage and app frame so TasteT can use the full width

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed5c16f47c83228eedf72630ace3a8