### PR TITLE
Reflow TasteT lobby to fit within the viewport

### DIFF
--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -2432,6 +2432,7 @@ function TasteT() {
     mode === "lobby" && placementQueue && placementImage && pendingPlacementRounds > 0;
   const isPlaying = mode === "swiss" || mode === "placement";
   const canUndo = undoStack.length > 0;
+  const swissHistoryPreview = useMemo(() => swissHistory.slice(0, 3), [swissHistory]);
 
   const getPreviewFor = useCallback(
     (id) => {
@@ -3141,77 +3142,79 @@ function TasteT() {
           </div>
         ) : (
           <div className="taste-t-lobby">
-            <section className="taste-t-hero">
-              <div className="taste-t-hero-top">
-                <div>
-                  <h1>TierT</h1>
-                  <p>
-                    {hasImages
-                      ? "Queue a Swiss mini to keep refining your favourites."
-                      : "Add images in your Library to start ranking them."}
-                  </p>
+            <div className="taste-t-lobby-primary">
+              <section className="taste-t-hero">
+                <div className="taste-t-hero-top">
+                  <div>
+                    <h1>TierT</h1>
+                    <p>
+                      {hasImages
+                        ? "Queue a Swiss mini to keep refining your favourites."
+                        : "Add images in your Library to start ranking them."}
+                    </p>
+                  </div>
+                  <div className="taste-t-hero-actions">
+                    <label className="mini-size-control">
+                      <span>Mini size</span>
+                      <select value={miniSize} onChange={(event) => setMiniSize(Number(event.target.value))}>
+                        {MINI_SIZE_OPTIONS.map((size) => (
+                          <option key={size} value={size}>
+                            {size}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <button
+                      type="button"
+                      className="taste-t-play-button"
+                      onClick={handleStartSwiss}
+                      disabled={!canStartSwiss || mode !== "lobby"}
+                    >
+                      Play
+                    </button>
+                    <button type="button" className="ghost" onClick={refreshLibrary}>
+                      Refresh Library
+                    </button>
+                  </div>
                 </div>
-                <div className="taste-t-hero-actions">
-                  <label className="mini-size-control">
-                    <span>Mini size</span>
-                    <select value={miniSize} onChange={(event) => setMiniSize(Number(event.target.value))}>
-                      {MINI_SIZE_OPTIONS.map((size) => (
-                        <option key={size} value={size}>
-                          {size}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <button
-                    type="button"
-                    className="taste-t-play-button"
-                    onClick={handleStartSwiss}
-                    disabled={!canStartSwiss || mode !== "lobby"}
-                  >
-                    Play
-                  </button>
-                  <button type="button" className="ghost" onClick={refreshLibrary}>
-                    Refresh Library
-                  </button>
+                <div className="taste-t-hero-stats">
+                  <div className="taste-t-stat-card">
+                    <span className="stat-label">Library images</span>
+                    <strong>{images.length}</strong>
+                    <p>{hasImages ? "Ready to rank" : "Visit the Library to add images."}</p>
+                  </div>
+                  <div className="taste-t-stat-card">
+                    <span className="stat-label">Placements</span>
+                    <strong>{pendingPlacementRounds}</strong>
+                    <p>{placementQueue ? "Duels to settle your newest image." : "All images are placed."}</p>
+                  </div>
+                  <div className="taste-t-stat-card">
+                    <span className="stat-label">Recent duels</span>
+                    <strong>{duelLog.length}</strong>
+                    <p>{duelLog.length ? "Tracked below in your duel log." : "Play a mini to build history."}</p>
+                  </div>
                 </div>
-              </div>
-              <div className="taste-t-hero-stats">
-                <div className="taste-t-stat-card">
-                  <span className="stat-label">Library images</span>
-                  <strong>{images.length}</strong>
-                  <p>{hasImages ? "Ready to rank" : "Visit the Library to add images."}</p>
-                </div>
-                <div className="taste-t-stat-card">
-                  <span className="stat-label">Placements</span>
-                  <strong>{pendingPlacementRounds}</strong>
-                  <p>{placementQueue ? "Duels to settle your newest image." : "All images are placed."}</p>
-                </div>
-                <div className="taste-t-stat-card">
-                  <span className="stat-label">Recent duels</span>
-                  <strong>{duelLog.length}</strong>
-                  <p>{duelLog.length ? "Tracked below in your duel log." : "Play a mini to build history."}</p>
-                </div>
-              </div>
-              {!canStartSwiss ? (
-                <p className="taste-t-hero-note">Add at least two images to start a Swiss mini.</p>
-              ) : null}
-            </section>
-
-            {showPlacementCallout ? (
-              <section className="taste-t-panel taste-t-placement-callout">
-                <div>
-                  <h2>Placement ready</h2>
-                  <p>
-                    {placementImage ? placementImage.name : "New image"} has {pendingPlacementRounds} duels remaining.
-                  </p>
-                </div>
-                <div className="panel-actions">
-                  <button type="button" onClick={handleEnterPlacement}>
-                    Start placement
-                  </button>
-                </div>
+                {!canStartSwiss ? (
+                  <p className="taste-t-hero-note">Add at least two images to start a Swiss mini.</p>
+                ) : null}
               </section>
-            ) : null}
+
+              {showPlacementCallout ? (
+                <section className="taste-t-panel taste-t-placement-callout">
+                  <div>
+                    <h2>Placement ready</h2>
+                    <p>
+                      {placementImage ? placementImage.name : "New image"} has {pendingPlacementRounds} duels remaining.
+                    </p>
+                  </div>
+                  <div className="panel-actions">
+                    <button type="button" onClick={handleEnterPlacement}>
+                      Start placement
+                    </button>
+                  </div>
+                </section>
+              ) : null}
+            </div>
 
             <div className="taste-t-lobby-grid">
               <section className="taste-t-panel">
@@ -3319,122 +3322,127 @@ function TasteT() {
 
               <section className="taste-t-panel">
                 <h2>Swiss History</h2>
-                {swissHistory.length ? (
-                  <ul className="swiss-history">
-                    {swissHistory.map((entry) => {
-                      const winner =
-                        entry.participants.find((participant) => participant.id === entry.championId) ||
-                        entry.participants[0];
-                      const galleryItems = Array.isArray(entry.gallery) && entry.gallery.length
-                        ? entry.gallery
-                        : entry.participants.slice(0, 4).map((participant) => ({
-                            id: participant.id,
-                            rank: participant.rank,
-                            name: participant.name,
-                          }));
-                      const finalOutcome = entry.finalMatch;
-                      const finalLeftName = finalOutcome
-                        ? imagesById[finalOutcome.leftId]?.name ||
-                          entry.participants.find((p) => p.id === finalOutcome.leftId)?.name ||
-                          galleryItems.find((g) => g.id === finalOutcome.leftId)?.name ||
-                          "Left"
-                        : null;
-                      const finalRightName = finalOutcome
-                        ? imagesById[finalOutcome.rightId]?.name ||
-                          entry.participants.find((p) => p.id === finalOutcome.rightId)?.name ||
-                          galleryItems.find((g) => g.id === finalOutcome.rightId)?.name ||
-                          "Right"
-                        : null;
-                      const finalSummary = finalOutcome
-                        ? `${finalLeftName} vs ${finalRightName} · ${
-                            finalOutcome.result === "draw"
-                              ? "Draw"
-                              : `${
-                                  finalOutcome.winnerId === finalOutcome.leftId
-                                    ? finalLeftName
-                                    : finalRightName
-                                } won`
-                          }`
-                        : null;
-                      return (
-                        <li key={entry.id} className="swiss-history-card">
-                          <div className="swiss-history-header">
-                            <div>
-                              <h3>
-                                {entry.size || entry.participants.length} image Swiss · {entry.totalRounds} rounds
-                              </h3>
-                              <p>
-                                Finished {formatRelativeTime(entry.completedAt)} · ID {entry.id}
-                              </p>
+                {swissHistoryPreview.length ? (
+                  <>
+                    <ul className="swiss-history">
+                      {swissHistoryPreview.map((entry) => {
+                        const winner =
+                          entry.participants.find((participant) => participant.id === entry.championId) ||
+                          entry.participants[0];
+                        const galleryItems = Array.isArray(entry.gallery) && entry.gallery.length
+                          ? entry.gallery
+                          : entry.participants.slice(0, 4).map((participant) => ({
+                              id: participant.id,
+                              rank: participant.rank,
+                              name: participant.name,
+                            }));
+                        const finalOutcome = entry.finalMatch;
+                        const finalLeftName = finalOutcome
+                          ? imagesById[finalOutcome.leftId]?.name ||
+                            entry.participants.find((p) => p.id === finalOutcome.leftId)?.name ||
+                            galleryItems.find((g) => g.id === finalOutcome.leftId)?.name ||
+                            "Left"
+                          : null;
+                        const finalRightName = finalOutcome
+                          ? imagesById[finalOutcome.rightId]?.name ||
+                            entry.participants.find((p) => p.id === finalOutcome.rightId)?.name ||
+                            galleryItems.find((g) => g.id === finalOutcome.rightId)?.name ||
+                            "Right"
+                          : null;
+                        const finalSummary = finalOutcome
+                          ? `${finalLeftName} vs ${finalRightName} · ${
+                              finalOutcome.result === "draw"
+                                ? "Draw"
+                                : `${
+                                    finalOutcome.winnerId === finalOutcome.leftId
+                                      ? finalLeftName
+                                      : finalRightName
+                                  } won`
+                            }`
+                          : null;
+                        return (
+                          <li key={entry.id} className="swiss-history-card">
+                            <div className="swiss-history-header">
+                              <div>
+                                <h3>
+                                  {entry.size || entry.participants.length} image Swiss · {entry.totalRounds} rounds
+                                </h3>
+                                <p>
+                                  Finished {formatRelativeTime(entry.completedAt)} · ID {entry.id}
+                                </p>
+                              </div>
+                              <div className="swiss-history-winner">
+                                <span>Champion</span>
+                                <strong>{winner?.name || "—"}</strong>
+                                {typeof winner?.points === "number" ? (
+                                  <em>{`${winner.points} pts`}</em>
+                                ) : null}
+                                {finalOutcome ? (
+                                  <span className="swiss-history-final-label">
+                                    Final: {finalSummary}
+                                  </span>
+                                ) : null}
+                              </div>
                             </div>
-                            <div className="swiss-history-winner">
-                              <span>Champion</span>
-                              <strong>{winner?.name || "—"}</strong>
-                              {typeof winner?.points === "number" ? (
-                                <em>{`${winner.points} pts`}</em>
-                              ) : null}
-                              {finalOutcome ? (
-                                <span className="swiss-history-final-label">
-                                  Final: {finalSummary}
-                                </span>
-                              ) : null}
+                            <div className="swiss-history-gallery">
+                              {galleryItems.slice(0, 4).map((participant) => {
+                                const preview = participant.preview || getPreviewFor(participant.id);
+                                return (
+                                  <figure key={participant.id} className="swiss-history-figure">
+                                    {preview ? (
+                                      <img src={preview} alt={participant.name} />
+                                    ) : (
+                                      <div className="swiss-history-placeholder">#{participant.rank}</div>
+                                    )}
+                                    <figcaption>{`#${participant.rank} · ${participant.name}`}</figcaption>
+                                  </figure>
+                                );
+                              })}
                             </div>
-                          </div>
-                          <div className="swiss-history-gallery">
-                            {galleryItems.slice(0, 4).map((participant) => {
-                              const preview = participant.preview || getPreviewFor(participant.id);
-                              return (
-                                <figure key={participant.id} className="swiss-history-figure">
-                                  {preview ? (
-                                    <img src={preview} alt={participant.name} />
-                                  ) : (
-                                    <div className="swiss-history-placeholder">#{participant.rank}</div>
-                                  )}
-                                  <figcaption>{`#${participant.rank} · ${participant.name}`}</figcaption>
-                                </figure>
-                              );
-                            })}
-                          </div>
-                          <ol className="swiss-standings">
-                            {entry.participants.map((participant, index) => {
-                              const rank = participant.rank ?? index + 1;
-                              const ratingLabel =
-                                typeof participant.rating === "number"
-                                  ? Math.round(participant.rating)
-                                  : "—";
-                              const buchholzLabel =
-                                typeof participant.buchholz === "number" && participant.buchholz
-                                  ? ` · Buchholz ${roundTo(participant.buchholz, 1)}`
-                                  : "";
-                              return (
-                                <li key={participant.id}>
-                                  <span className="standing-rank">#{rank}</span>
-                                  <div className="standing-meta">
-                                    <span className="standing-name">{participant.name}</span>
-                                    <span className="standing-record">
-                                      {formatRecord(
-                                        participant.wins,
-                                        participant.losses,
-                                        participant.draws,
-                                      )}
-                                      {typeof participant.points === "number"
-                                        ? ` · ${participant.points} pts`
-                                        : ""}
-                                      {buchholzLabel}
-                                    </span>
-                                  </div>
-                                  <div className="standing-right">
-                                    <span className="standing-rating">{ratingLabel}</span>
-                                    <span className="standing-tier">#{participant.tierKey}</span>
-                                  </div>
-                                </li>
-                              );
-                            })}
-                          </ol>
-                        </li>
-                      );
-                    })}
-                  </ul>
+                            <ol className="swiss-standings">
+                              {entry.participants.map((participant, index) => {
+                                const rank = participant.rank ?? index + 1;
+                                const ratingLabel =
+                                  typeof participant.rating === "number"
+                                    ? Math.round(participant.rating)
+                                    : "—";
+                                const buchholzLabel =
+                                  typeof participant.buchholz === "number" && participant.buchholz
+                                    ? ` · Buchholz ${roundTo(participant.buchholz, 1)}`
+                                    : "";
+                                return (
+                                  <li key={participant.id}>
+                                    <span className="standing-rank">#{rank}</span>
+                                    <div className="standing-meta">
+                                      <span className="standing-name">{participant.name}</span>
+                                      <span className="standing-record">
+                                        {formatRecord(
+                                          participant.wins,
+                                          participant.losses,
+                                          participant.draws,
+                                        )}
+                                        {typeof participant.points === "number"
+                                          ? ` · ${participant.points} pts`
+                                          : ""}
+                                        {buchholzLabel}
+                                      </span>
+                                    </div>
+                                    <div className="standing-right">
+                                      <span className="standing-rating">{ratingLabel}</span>
+                                      <span className="standing-tier">#{participant.tierKey}</span>
+                                    </div>
+                                  </li>
+                                );
+                              })}
+                            </ol>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    {swissHistory.length > swissHistoryPreview.length ? (
+                      <p className="swiss-history-note">Showing latest {swissHistoryPreview.length} minis.</p>
+                    ) : null}
+                  </>
                 ) : (
                   <div className="panel-placeholder">Finish a Swiss mini to see it logged here.</div>
                 )}

--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -1,7 +1,8 @@
 .taste-t-app {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: min(100%, 100vh);
+  min-height: 0;
   width: 100%;
   padding: clamp(24px, 5vw, 48px) clamp(20px, 6vw, 72px);
   color: #f7f8ff;
@@ -13,6 +14,7 @@
 
 .taste-t-app.is-playing {
   padding: clamp(16px, 4vw, 32px);
+  overflow-y: auto;
 }
 
 .taste-t-app.is-playing .taste-t-frame {
@@ -59,12 +61,13 @@
 }
 
 .taste-t-frame {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   width: 100%;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: clamp(20px, 3vw, 32px);
+  min-height: 0;
 }
 
 .taste-t-toolbar {
@@ -88,10 +91,21 @@
 }
 
 .taste-t-lobby {
+  flex: 1 1 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(20px, 4vw, 40px);
+  width: 100%;
+  align-items: stretch;
+  min-height: 0;
+}
+
+.taste-t-lobby-primary {
+  flex: 1 1 360px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  width: 100%;
+  gap: clamp(16px, 3vw, 28px);
+  min-height: 0;
 }
 
 .taste-t-hero {
@@ -105,6 +119,9 @@
   box-shadow: 0 18px 64px rgba(6, 7, 19, 0.45);
   width: 100%;
   box-sizing: border-box;
+  flex: 1 1 auto;
+  min-height: 0;
+  justify-content: space-between;
 }
 
 .taste-t-hero h1 {
@@ -200,10 +217,14 @@
 }
 
 .taste-t-lobby-grid {
+  flex: 1 1 520px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(16px, 3vw, 28px);
   width: 100%;
+  align-content: start;
+  min-height: 0;
+  grid-auto-rows: minmax(0, 1fr);
 }
 
 .taste-t-game {
@@ -219,6 +240,7 @@
   justify-content: space-between;
   gap: 16px;
   background: rgba(18, 24, 48, 0.78);
+  flex: 0 0 auto;
 }
 
 .taste-t-placement-callout h2 {
@@ -272,6 +294,8 @@
   box-shadow: 0 12px 48px rgba(4, 6, 15, 0.6);
   width: 100%;
   box-sizing: border-box;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .panel-header {
@@ -596,6 +620,10 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 6px;
 }
 
 .ranking-list li {
@@ -640,6 +668,10 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 16px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 6px;
 }
 
 .tier-card {
@@ -751,6 +783,10 @@
   flex-direction: column;
   gap: 10px;
   font-size: 0.85rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 6px;
 }
 
 .duel-log li {
@@ -788,6 +824,17 @@
   flex-direction: column;
   gap: 16px;
   font-size: 0.85rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.swiss-history-note {
+  margin: 12px 6px 0 0;
+  font-size: 0.75rem;
+  color: rgba(238, 241, 255, 0.58);
+  text-align: right;
 }
 
 .swiss-history-card {

--- a/src/world.css
+++ b/src/world.css
@@ -11,6 +11,8 @@
 .semi-formless-world {
   padding: 60px 40px 80px;
   box-sizing: border-box;
+  align-items: stretch;
+  overflow: auto;
 }
 
 .semi-formless-hub {
@@ -103,7 +105,9 @@
 }
 
 .semi-formless-stage {
-  width: min(1200px, 100%);
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -137,6 +141,13 @@
   padding: 24px;
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.semi-formless-app-frame > * {
+  flex: 1 1 auto;
 }
 
 .resource-box {


### PR DESCRIPTION
## Summary
- split the TasteT lobby into a primary column and panel grid so the UI fills the available viewport without stacking endlessly
- cap the rendered Swiss history to the three latest minis and add a note when older entries are hidden
- tighten the lobby panel styling to share vertical space, letting long lists scroll inside their cards instead of pushing the whole layout off screen

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ed5c16f47c83228eedf72630ace3a8