### PR TITLE
Refine TasteT lobby layout into single-screen dashboard

### DIFF
--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -3105,6 +3105,10 @@ function TasteT() {
   const hasActiveSwiss = mode === "swiss" && activeSwiss;
   const hasPlacement = mode === "placement" && placementQueue;
 
+  const topRankings = rankingData.filtered.slice(0, 6);
+  const topTierSnapshots = rankingData.perTier.slice(0, 3);
+  const recentDuels = duelLog.slice(0, 5);
+
   const expandedImageSrc = expandedImage?.dataUrl || expandedImage?.imageUrl;
 
   return (
@@ -3141,87 +3145,82 @@ function TasteT() {
             />
           </div>
         ) : (
-          <div className="taste-t-lobby">
-            <div className="taste-t-lobby-primary">
-              <section className="taste-t-hero">
-                <div className="taste-t-hero-top">
-                  <div>
-                    <h1>TierT</h1>
-                    <p>
-                      {hasImages
-                        ? "Queue a Swiss mini to keep refining your favourites."
-                        : "Add images in your Library to start ranking them."}
-                    </p>
-                  </div>
-                  <div className="taste-t-hero-actions">
-                    <label className="mini-size-control">
-                      <span>Mini size</span>
-                      <select value={miniSize} onChange={(event) => setMiniSize(Number(event.target.value))}>
-                        {MINI_SIZE_OPTIONS.map((size) => (
-                          <option key={size} value={size}>
-                            {size}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <button
-                      type="button"
-                      className="taste-t-play-button"
-                      onClick={handleStartSwiss}
-                      disabled={!canStartSwiss || mode !== "lobby"}
-                    >
-                      Play
-                    </button>
-                    <button type="button" className="ghost" onClick={refreshLibrary}>
-                      Refresh Library
-                    </button>
-                  </div>
+          <div className="taste-t-dashboard">
+            <section className="taste-t-overview-panel">
+              <div className="taste-t-overview-header">
+                <div>
+                  <span className="taste-t-overview-tag">Swiss minis</span>
+                  <h1>TierT</h1>
+                  <p>
+                    {hasImages
+                      ? "Queue a Swiss mini to keep refining your favourites."
+                      : "Add images in your Library to start ranking them."}
+                  </p>
                 </div>
-                <div className="taste-t-hero-stats">
-                  <div className="taste-t-stat-card">
-                    <span className="stat-label">Library images</span>
-                    <strong>{images.length}</strong>
-                    <p>{hasImages ? "Ready to rank" : "Visit the Library to add images."}</p>
-                  </div>
-                  <div className="taste-t-stat-card">
-                    <span className="stat-label">Placements</span>
-                    <strong>{pendingPlacementRounds}</strong>
-                    <p>{placementQueue ? "Duels to settle your newest image." : "All images are placed."}</p>
-                  </div>
-                  <div className="taste-t-stat-card">
-                    <span className="stat-label">Recent duels</span>
-                    <strong>{duelLog.length}</strong>
-                    <p>{duelLog.length ? "Tracked below in your duel log." : "Play a mini to build history."}</p>
-                  </div>
+                <div className="taste-t-overview-actions">
+                  <label className="mini-size-control">
+                    <span>Mini size</span>
+                    <select value={miniSize} onChange={(event) => setMiniSize(Number(event.target.value))}>
+                      {MINI_SIZE_OPTIONS.map((size) => (
+                        <option key={size} value={size}>
+                          {size}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <button
+                    type="button"
+                    className="taste-t-primary"
+                    onClick={handleStartSwiss}
+                    disabled={!canStartSwiss || mode !== "lobby"}
+                  >
+                    Play mini
+                  </button>
+                  <button type="button" className="taste-t-secondary" onClick={refreshLibrary}>
+                    Refresh library
+                  </button>
                 </div>
-                {!canStartSwiss ? (
-                  <p className="taste-t-hero-note">Add at least two images to start a Swiss mini.</p>
-                ) : null}
-              </section>
-
+              </div>
+              <div className="taste-t-overview-stats">
+                <div className="taste-t-stat-card">
+                  <span className="stat-label">Library images</span>
+                  <strong>{images.length}</strong>
+                  <p>{hasImages ? "Ready to rank" : "Visit the Library to add images."}</p>
+                </div>
+                <div className="taste-t-stat-card">
+                  <span className="stat-label">Placements</span>
+                  <strong>{pendingPlacementRounds}</strong>
+                  <p>{placementQueue ? "Duels to settle your newest image." : "All images are placed."}</p>
+                </div>
+                <div className="taste-t-stat-card">
+                  <span className="stat-label">Recent duels</span>
+                  <strong>{duelLog.length}</strong>
+                  <p>{duelLog.length ? "Tracked below in your duel log." : "Play a mini to build history."}</p>
+                </div>
+              </div>
+              {!canStartSwiss ? (
+                <p className="taste-t-hero-note">Add at least two images to start a Swiss mini.</p>
+              ) : null}
               {showPlacementCallout ? (
-                <section className="taste-t-panel taste-t-placement-callout">
+                <div className="taste-t-placement-card">
                   <div>
                     <h2>Placement ready</h2>
                     <p>
                       {placementImage ? placementImage.name : "New image"} has {pendingPlacementRounds} duels remaining.
                     </p>
                   </div>
-                  <div className="panel-actions">
-                    <button type="button" onClick={handleEnterPlacement}>
-                      Start placement
-                    </button>
-                  </div>
-                </section>
+                  <button type="button" onClick={handleEnterPlacement}>
+                    Start placement
+                  </button>
+                </div>
               ) : null}
-            </div>
-
-            <div className="taste-t-lobby-grid">
-              <section className="taste-t-panel">
-                <header className="panel-header">
+            </section>
+            <div className="taste-t-summary-column">
+              <section className="taste-t-card taste-t-card--global">
+                <header className="taste-t-card-header">
                   <div>
-                    <h2>Global Order</h2>
-                    <p className="panel-subtitle">
+                    <h2>Global order</h2>
+                    <p>
                       {selectedTag
                         ? `Filtering by ${selectedTag}`
                         : hasImages
@@ -3229,20 +3228,18 @@ function TasteT() {
                         : "No images available"}
                     </p>
                   </div>
-                  <div className="panel-actions">
-                    <select value={selectedTag} onChange={(event) => setSelectedTag(event.target.value)}>
-                      <option value="">All tags</option>
-                      {availableTags.map((tag) => (
-                        <option key={tag} value={tag}>
-                          {tag}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                  <select value={selectedTag} onChange={(event) => setSelectedTag(event.target.value)}>
+                    <option value="">All tags</option>
+                    {availableTags.map((tag) => (
+                      <option key={tag} value={tag}>
+                        {tag}
+                      </option>
+                    ))}
+                  </select>
                 </header>
-                {rankingData.filtered.length ? (
-                  <ol className="ranking-list">
-                    {rankingData.filtered.slice(0, 12).map((image, index) => (
+                {topRankings.length ? (
+                  <ol className="taste-t-ranking-list">
+                    {topRankings.map((image, index) => (
                       <li key={image.id}>
                         <span className="rank-index">#{index + 1}</span>
                         <div className="ranking-meta">
@@ -3255,7 +3252,7 @@ function TasteT() {
                             )}`}
                           </p>
                           <p className="ranking-tags">
-                            #{image.tierKey} · {image.tags.slice(0, 3).join(" · ")}
+                            #{image.tierKey} · {image.tags.slice(0, 2).join(" · ")}
                           </p>
                         </div>
                         <span className="rank-rating">{Math.round(image.rating)}</span>
@@ -3263,190 +3260,105 @@ function TasteT() {
                     ))}
                   </ol>
                 ) : (
-                  <div className="panel-placeholder">
+                  <div className="taste-t-card-empty">
                     {hasImages
                       ? "No rankings match the selected tag."
                       : "Add images in your Library to begin ranking."}
                   </div>
                 )}
               </section>
-
-              <section className="taste-t-panel">
-                <h2>Tier Snapshots</h2>
-                <div className="tier-grid">
-                  {rankingData.perTier.map(({ tier, images: tierImages }) => (
-                    <div key={tier.key} className="tier-card">
-                      <header style={{ borderColor: tier.color }}>
-                        <h3>{tier.label}</h3>
-                        <p>{tier.tagline}</p>
-                      </header>
-                      <ol>
-                        {tierImages.slice(0, 5).map((image) => (
-                          <li key={image.id}>
-                            <span>{image.name}</span>
-                            <span>{Math.round(image.rating)}</span>
+              <div className="taste-t-summary-grid">
+                <section className="taste-t-card taste-t-card--tiers">
+                  <header className="taste-t-card-header">
+                    <div>
+                      <h2>Tier snapshots</h2>
+                      <p>Highlights from your recent placements.</p>
+                    </div>
+                  </header>
+                  {topTierSnapshots.length ? (
+                    <div className="tier-grid tier-grid--compact">
+                      {topTierSnapshots.map(({ tier, images: tierImages }) => (
+                        <div key={tier.key} className="tier-card">
+                          <header style={{ borderColor: tier.color }}>
+                            <h3>{tier.label}</h3>
+                            <p>{tier.tagline}</p>
+                          </header>
+                          <ol>
+                            {tierImages.slice(0, 3).map((image) => (
+                              <li key={image.id}>
+                                <span>{image.name}</span>
+                                <span>{Math.round(image.rating)}</span>
+                              </li>
+                            ))}
+                            {!tierImages.length ? <li className="empty">No images yet</li> : null}
+                          </ol>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="taste-t-card-empty">Play a mini to build your tiers.</div>
+                  )}
+                </section>
+                <section className="taste-t-card taste-t-card--activity">
+                  <div className="taste-t-activity-group">
+                    <h2>Recent duels</h2>
+                    {recentDuels.length ? (
+                      <ul className="taste-t-duel-list">
+                        {recentDuels.map((entry) => (
+                          <li key={entry.id}>
+                            <div className="duel-names">
+                              <strong>{entry.leftName}</strong>
+                              <span>vs</span>
+                              <strong>{entry.rightName}</strong>
+                            </div>
+                            <div className="duel-meta">
+                              <span className="duel-outcome">
+                                {entry.outcome === "draw"
+                                  ? "Draw"
+                                  : `${entry.winnerId === entry.leftId ? entry.leftName : entry.rightName} won`}
+                              </span>
+                              <span className="duel-delta">
+                                {formatDelta(entry.leftDelta)} / {formatDelta(entry.rightDelta)}
+                              </span>
+                              <span className="duel-time">{formatRelativeTime(entry.timestamp)}</span>
+                            </div>
                           </li>
                         ))}
-                        {!tierImages.length ? <li className="empty">No images yet</li> : null}
-                      </ol>
-                    </div>
-                  ))}
-                </div>
-              </section>
-
-              <section className="taste-t-panel">
-                <h2>Recent Duels</h2>
-                {duelLog.length ? (
-                  <ul className="duel-log">
-                    {duelLog.map((entry) => (
-                      <li key={entry.id}>
-                        <span className="duel-log-names">
-                          {entry.leftName} vs {entry.rightName}
-                        </span>
-                        <span className="duel-log-outcome">
-                          {entry.outcome === "draw"
-                            ? "Draw"
-                            : `${entry.winnerId === entry.leftId ? entry.leftName : entry.rightName} won`}
-                        </span>
-                        <span className="duel-log-delta">
-                          {formatDelta(entry.leftDelta)} / {formatDelta(entry.rightDelta)}
-                        </span>
-                        <span className="duel-log-time">{formatRelativeTime(entry.timestamp)}</span>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <div className="panel-placeholder">Play duels to populate your log.</div>
-                )}
-              </section>
-
-              <section className="taste-t-panel">
-                <h2>Swiss History</h2>
-                {swissHistoryPreview.length ? (
-                  <>
-                    <ul className="swiss-history">
-                      {swissHistoryPreview.map((entry) => {
-                        const winner =
-                          entry.participants.find((participant) => participant.id === entry.championId) ||
-                          entry.participants[0];
-                        const galleryItems = Array.isArray(entry.gallery) && entry.gallery.length
-                          ? entry.gallery
-                          : entry.participants.slice(0, 4).map((participant) => ({
-                              id: participant.id,
-                              rank: participant.rank,
-                              name: participant.name,
-                            }));
-                        const finalOutcome = entry.finalMatch;
-                        const finalLeftName = finalOutcome
-                          ? imagesById[finalOutcome.leftId]?.name ||
-                            entry.participants.find((p) => p.id === finalOutcome.leftId)?.name ||
-                            galleryItems.find((g) => g.id === finalOutcome.leftId)?.name ||
-                            "Left"
-                          : null;
-                        const finalRightName = finalOutcome
-                          ? imagesById[finalOutcome.rightId]?.name ||
-                            entry.participants.find((p) => p.id === finalOutcome.rightId)?.name ||
-                            galleryItems.find((g) => g.id === finalOutcome.rightId)?.name ||
-                            "Right"
-                          : null;
-                        const finalSummary = finalOutcome
-                          ? `${finalLeftName} vs ${finalRightName} · ${
-                              finalOutcome.result === "draw"
-                                ? "Draw"
-                                : `${
-                                    finalOutcome.winnerId === finalOutcome.leftId
-                                      ? finalLeftName
-                                      : finalRightName
-                                  } won`
-                            }`
-                          : null;
-                        return (
-                          <li key={entry.id} className="swiss-history-card">
-                            <div className="swiss-history-header">
-                              <div>
-                                <h3>
-                                  {entry.size || entry.participants.length} image Swiss · {entry.totalRounds} rounds
-                                </h3>
-                                <p>
-                                  Finished {formatRelativeTime(entry.completedAt)} · ID {entry.id}
-                                </p>
-                              </div>
-                              <div className="swiss-history-winner">
-                                <span>Champion</span>
+                      </ul>
+                    ) : (
+                      <div className="taste-t-card-empty">Play duels to populate your log.</div>
+                    )}
+                  </div>
+                  <div className="taste-t-activity-group">
+                    <h2>Swiss history</h2>
+                    {swissHistoryPreview.length ? (
+                      <ul className="taste-t-swiss-list">
+                        {swissHistoryPreview.map((entry) => {
+                          const winner =
+                            entry.participants.find((participant) => participant.id === entry.championId) ||
+                            entry.participants[0];
+                          const size = entry.size || entry.participants.length;
+                          return (
+                            <li key={entry.id}>
+                              <div className="swiss-summary">
                                 <strong>{winner?.name || "—"}</strong>
-                                {typeof winner?.points === "number" ? (
-                                  <em>{`${winner.points} pts`}</em>
-                                ) : null}
-                                {finalOutcome ? (
-                                  <span className="swiss-history-final-label">
-                                    Final: {finalSummary}
-                                  </span>
-                                ) : null}
+                                <span>{` won a ${size}-image mini`}</span>
                               </div>
-                            </div>
-                            <div className="swiss-history-gallery">
-                              {galleryItems.slice(0, 4).map((participant) => {
-                                const preview = participant.preview || getPreviewFor(participant.id);
-                                return (
-                                  <figure key={participant.id} className="swiss-history-figure">
-                                    {preview ? (
-                                      <img src={preview} alt={participant.name} />
-                                    ) : (
-                                      <div className="swiss-history-placeholder">#{participant.rank}</div>
-                                    )}
-                                    <figcaption>{`#${participant.rank} · ${participant.name}`}</figcaption>
-                                  </figure>
-                                );
-                              })}
-                            </div>
-                            <ol className="swiss-standings">
-                              {entry.participants.map((participant, index) => {
-                                const rank = participant.rank ?? index + 1;
-                                const ratingLabel =
-                                  typeof participant.rating === "number"
-                                    ? Math.round(participant.rating)
-                                    : "—";
-                                const buchholzLabel =
-                                  typeof participant.buchholz === "number" && participant.buchholz
-                                    ? ` · Buchholz ${roundTo(participant.buchholz, 1)}`
-                                    : "";
-                                return (
-                                  <li key={participant.id}>
-                                    <span className="standing-rank">#{rank}</span>
-                                    <div className="standing-meta">
-                                      <span className="standing-name">{participant.name}</span>
-                                      <span className="standing-record">
-                                        {formatRecord(
-                                          participant.wins,
-                                          participant.losses,
-                                          participant.draws,
-                                        )}
-                                        {typeof participant.points === "number"
-                                          ? ` · ${participant.points} pts`
-                                          : ""}
-                                        {buchholzLabel}
-                                      </span>
-                                    </div>
-                                    <div className="standing-right">
-                                      <span className="standing-rating">{ratingLabel}</span>
-                                      <span className="standing-tier">#{participant.tierKey}</span>
-                                    </div>
-                                  </li>
-                                );
-                              })}
-                            </ol>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                    {swissHistory.length > swissHistoryPreview.length ? (
-                      <p className="swiss-history-note">Showing latest {swissHistoryPreview.length} minis.</p>
-                    ) : null}
-                  </>
-                ) : (
-                  <div className="panel-placeholder">Finish a Swiss mini to see it logged here.</div>
-                )}
-              </section>
+                              <div className="swiss-meta">
+                                <span>{entry.totalRounds} rounds</span>
+                                <span>·</span>
+                                <span>{formatRelativeTime(entry.completedAt)}</span>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    ) : (
+                      <div className="taste-t-card-empty">Finish a Swiss mini to see it logged here.</div>
+                    )}
+                  </div>
+                </section>
+              </div>
             </div>
           </div>
         )}

--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -1,20 +1,24 @@
 .taste-t-app {
   display: flex;
   flex-direction: column;
-  height: min(100%, 100vh);
-  min-height: 0;
+  height: 100vh;
+  min-height: 100vh;
   width: 100%;
-  padding: clamp(24px, 5vw, 48px) clamp(20px, 6vw, 72px);
-  color: #f7f8ff;
-  background: radial-gradient(circle at top, #1d2240 0%, #101324 55%, #080914 100%);
+  padding: clamp(24px, 4vw, 48px);
+  color: #0f172a;
+  background: linear-gradient(135deg, #f9fbff 0%, #eef2ff 60%, #e0e7ff 100%);
   box-sizing: border-box;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .taste-t-app.is-playing {
   padding: clamp(16px, 4vw, 32px);
+  color: #f7f8ff;
+  background: radial-gradient(circle at top, #1d2240 0%, #101324 55%, #080914 100%);
   overflow-y: auto;
+  height: auto;
+  min-height: 100vh;
 }
 
 .taste-t-app.is-playing .taste-t-frame {
@@ -76,6 +80,100 @@
   align-items: center;
   gap: 12px;
   width: 100%;
+}
+
+.taste-t-dashboard {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: clamp(20px, 4vw, 32px);
+  min-height: 0;
+  height: 100%;
+  align-items: stretch;
+}
+
+.taste-t-summary-column {
+  display: grid;
+  grid-template-rows: minmax(0, 0.55fr) minmax(0, 1fr);
+  gap: clamp(18px, 3vw, 28px);
+  min-height: 0;
+  height: 100%;
+}
+
+.taste-t-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(16px, 3vw, 24px);
+  min-height: 0;
+}
+
+.taste-t-overview-panel,
+.taste-t-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.12);
+  padding: clamp(24px, 4vw, 36px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2vw, 24px);
+  min-height: 0;
+}
+
+.taste-t-card {
+  gap: clamp(14px, 2vw, 20px);
+}
+
+.taste-t-overview-panel h1,
+.taste-t-overview-panel h2,
+.taste-t-card h2,
+.taste-t-card h3 {
+  color: #0f172a;
+}
+
+.taste-t-overview-panel p,
+.taste-t-card p,
+.taste-t-card span {
+  color: #475569;
+}
+
+.taste-t-overview-header {
+  display: flex;
+  justify-content: space-between;
+  gap: clamp(20px, 3vw, 32px);
+  align-items: flex-start;
+}
+
+.taste-t-overview-header h1 {
+  margin: 6px 0 8px;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  letter-spacing: -0.01em;
+}
+
+.taste-t-overview-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #4f46e5;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+}
+
+.taste-t-overview-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.taste-t-overview-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
 }
 
 .taste-t-toolbar .ghost {
@@ -153,18 +251,34 @@
   display: flex;
   flex-direction: column;
   font-size: 0.85rem;
-  gap: 4px;
-  color: rgba(238, 241, 255, 0.75);
+  gap: 6px;
+  color: #475569;
+  font-weight: 600;
 }
 
 .mini-size-control select,
-.panel-actions select {
-  background: rgba(12, 16, 32, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.16);
+.taste-t-card select {
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.25);
   border-radius: 12px;
   padding: 8px 12px;
-  color: #f7f8ff;
+  color: #312e81;
   font-size: 0.95rem;
+  font-weight: 600;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.mini-size-control select:focus,
+.taste-t-card select:focus {
+  outline: none;
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.18);
+}
+
+.taste-t-app.is-playing .panel-actions select {
+  background: rgba(12, 16, 32, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  color: #f7f8ff;
 }
 
 .taste-t-play-button {
@@ -182,49 +296,304 @@
 }
 
 .taste-t-stat-card {
-  flex: 1 1 220px;
-  background: rgba(12, 16, 32, 0.55);
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  padding: 16px 20px;
+  flex: 1 1 180px;
+  background: rgba(248, 250, 255, 0.9);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  padding: 18px 20px;
   display: flex;
   flex-direction: column;
   gap: 6px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
 }
 
 .taste-t-stat-card .stat-label {
   text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.16em;
-  color: rgba(238, 241, 255, 0.6);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  color: #6366f1;
+  font-weight: 700;
 }
 
 .taste-t-stat-card strong {
-  font-size: 1.6rem;
-  letter-spacing: 0.05em;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  letter-spacing: -0.02em;
+  color: #0f172a;
 }
 
 .taste-t-stat-card p {
   margin: 0;
-  font-size: 0.9rem;
-  color: rgba(238, 241, 255, 0.72);
+  font-size: 0.85rem;
+  color: #64748b;
 }
 
 .taste-t-hero-note {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(255, 186, 107, 0.9);
+  color: #f97316;
+  font-weight: 600;
 }
 
-.taste-t-lobby-grid {
-  flex: 1 1 520px;
+.taste-t-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.taste-t-card-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  letter-spacing: -0.01em;
+}
+
+.taste-t-card-header p {
+  margin: 4px 0 0;
+  font-size: 0.95rem;
+  color: #64748b;
+}
+
+.taste-t-card-empty {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 24px;
+  border-radius: 20px;
+  border: 1px dashed rgba(99, 102, 241, 0.28);
+  color: #94a3b8;
+  font-weight: 600;
+  background: rgba(248, 250, 255, 0.6);
+}
+
+.taste-t-ranking-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.taste-t-ranking-list li {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: clamp(16px, 3vw, 28px);
-  width: 100%;
-  align-content: start;
-  min-height: 0;
-  grid-auto-rows: minmax(0, 1fr);
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-radius: 20px;
+  background: rgba(248, 250, 255, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.taste-t-card .rank-index {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #4338ca;
+  width: auto;
+}
+
+.taste-t-card .ranking-meta h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.taste-t-card .ranking-meta p {
+  margin: 2px 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.taste-t-card .ranking-tags {
+  color: #6366f1;
+  font-weight: 600;
+}
+
+.taste-t-card .rank-rating {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: #1e293b;
+}
+
+.taste-t-card .tier-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.tier-grid--compact {
+  gap: 14px;
+}
+
+.taste-t-card .tier-card {
+  background: rgba(248, 250, 255, 0.72);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.taste-t-card .tier-card header {
+  padding: 14px 16px;
+  border-top: 0;
+  border-right: 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  border-left: 4px solid rgba(99, 102, 241, 0.4);
+}
+
+.taste-t-card .tier-card header h3 {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.taste-t-card .tier-card header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.taste-t-card .tier-card ol {
+  list-style: none;
+  margin: 0;
+  padding: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.taste-t-card .tier-card li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.taste-t-card .tier-card li.empty {
+  color: #94a3b8;
+  font-style: italic;
+}
+
+.taste-t-card--activity {
+  gap: 24px;
+}
+
+.taste-t-activity-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.taste-t-activity-group h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.taste-t-duel-list,
+.taste-t-swiss-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.taste-t-duel-list li,
+.taste-t-swiss-list li {
+  background: rgba(248, 250, 255, 0.75);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.duel-names {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  color: #1e293b;
+}
+
+.duel-names strong {
+  color: #0f172a;
+}
+
+.duel-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.82rem;
+  color: #64748b;
+}
+
+.duel-outcome {
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.duel-delta {
+  font-variant-numeric: tabular-nums;
+}
+
+.duel-time {
+  color: #94a3b8;
+}
+
+.swiss-summary {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.swiss-summary strong {
+  color: #0f172a;
+}
+
+.swiss-meta {
+  display: flex;
+  gap: 6px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.taste-t-placement-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 24px;
+  border-radius: 20px;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.22);
+}
+
+.taste-t-placement-card h2 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  color: #312e81;
+}
+
+.taste-t-placement-card p {
+  margin: 0;
+  color: #4338ca;
+  font-weight: 500;
+}
+
+.taste-t-placement-card button {
+  white-space: nowrap;
 }
 
 .taste-t-game {
@@ -234,49 +603,86 @@
   width: 100%;
 }
 
-.taste-t-placement-callout {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  background: rgba(18, 24, 48, 0.78);
-  flex: 0 0 auto;
-}
-
-.taste-t-placement-callout h2 {
-  margin: 0 0 4px;
-}
-
-.taste-t-placement-callout p {
-  margin: 0;
-  color: rgba(238, 241, 255, 0.75);
-}
-
 .taste-t-app button {
   font: inherit;
-  border: none;
-  border-radius: 14px;
+  border-radius: 12px;
   padding: 10px 18px;
-  background: linear-gradient(120deg, #ffba6b, #ff6e8f);
-  color: #0c0f1a;
-  cursor: pointer;
   font-weight: 600;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease, color 0.2s ease;
+  border: none;
 }
 
-.taste-t-app button:hover {
+.taste-t-app:not(.is-playing) button {
+  background: #e2e8f0;
+  color: #0f172a;
+  box-shadow: none;
+}
+
+.taste-t-app:not(.is-playing) button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.18);
+}
+
+.taste-t-app:not(.is-playing) button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.taste-t-primary {
+  background: linear-gradient(135deg, #6366f1, #4f46e5) !important;
+  color: #ffffff !important;
+  box-shadow: 0 14px 24px rgba(99, 102, 241, 0.28);
+}
+
+.taste-t-primary:hover {
+  box-shadow: 0 18px 32px rgba(99, 102, 241, 0.34);
+}
+
+.taste-t-secondary {
+  background: rgba(99, 102, 241, 0.12) !important;
+  color: #4338ca !important;
+  border: 1px solid rgba(99, 102, 241, 0.28) !important;
+  box-shadow: none;
+}
+
+.taste-t-secondary:hover {
+  background: rgba(99, 102, 241, 0.18) !important;
+}
+
+.taste-t-app:not(.is-playing) button.ghost {
+  background: transparent;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  color: #1e293b;
+  box-shadow: none;
+}
+
+.taste-t-app:not(.is-playing) button.ghost:hover {
+  border-color: rgba(15, 23, 42, 0.2);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+}
+
+.taste-t-app.is-playing button {
+  background: linear-gradient(120deg, #ffba6b, #ff6e8f);
+  color: #0c0f1a;
+  box-shadow: none;
+}
+
+.taste-t-app.is-playing button:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px rgba(255, 144, 171, 0.35);
 }
 
-.taste-t-app button:disabled {
+.taste-t-app.is-playing button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
   box-shadow: none;
   transform: none;
 }
 
-.taste-t-app button.ghost {
+.taste-t-app.is-playing button.ghost {
   background: transparent;
   color: rgba(238, 241, 255, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.15);


### PR DESCRIPTION
## Summary
- Rebuild the TasteT lobby into a condensed dashboard layout with hero metrics, ranking, tier, and activity cards.
- Limit lobby lists and add a placement call-to-action so the page fits within a single screen.
- Refresh TasteT styling with a lighter palette plus new card, button, and select treatments.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee45f3def88322954379cfbebfb18d