### PR TITLE
Add TasteT tagging tab and seed activity defaults

### DIFF
--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -14,6 +14,7 @@ const ENTRIES_KEY = 'activityLogEntries';
 const CURRENT_KEY = 'activityLogCurrent';
 
 const DEFAULT_ACTIVITIES = [
+  'Mazed',
   'Meditation - Vipassana',
   'Meditation - Ramana',
   'Yoga',
@@ -323,7 +324,7 @@ export default function ActivityLog({ onBack }) {
       ? buildActivityOptions(storedNames)
       : [];
     if (sanitizedStored.length > 0) {
-      return sanitizedStored;
+      return buildActivityOptions([...DEFAULT_ACTIVITIES, ...sanitizedStored]);
     }
     return buildActivityOptions(DEFAULT_ACTIVITIES);
   }, []);

--- a/src/TasteT.jsx
+++ b/src/TasteT.jsx
@@ -69,6 +69,20 @@ const TIER_LOOKUP = TIER_RULES.reduce((acc, tier, index) => {
 }, {});
 
 const MINI_SIZE_OPTIONS = [4, 6, 8, 10, 12, 16];
+const TASTET_TABS = [
+  { key: "ranking", label: "Ranking suite" },
+  { key: "tagging", label: "Tag forge" },
+];
+const TAGGING_MODES = [
+  { key: "dual", label: "Dual" },
+  { key: "tri", label: "Tri" },
+  { key: "quadrant", label: "Quadrants" },
+];
+const DEFAULT_TAGGING_MODE = TAGGING_MODES[0].key;
+const DUAL_GENDER_TAGS = ["feminine", "masculine"];
+const DUAL_FLOW_TAGS = ["up", "neutral", "down"];
+const TRI_TAGS = ["form", "semi-formless", "formless"];
+const QUADRANT_TAGS = ["II", "IE", "EI", "EE"];
 
 export function shouldFinalizeSwissStatus(status) {
   return status === "awaiting-finish" || status === "completed";
@@ -145,6 +159,70 @@ function normalizeLibraryTags(tags) {
   return tags
     .map((tag) => sanitizeText(typeof tag === "string" ? tag : ""))
     .filter((tag) => tag.length > 0);
+}
+
+function sanitizeTabKey(value) {
+  return value === "tagging" ? "tagging" : "ranking";
+}
+
+function sanitizeTaggingMode(value) {
+  return TAGGING_MODES.some((mode) => mode.key === value) ? value : DEFAULT_TAGGING_MODE;
+}
+
+function hasAnyTag(list, tags) {
+  if (!Array.isArray(list) || !list.length) return false;
+  return tags.some((tag) => list.includes(tag));
+}
+
+function formatTagLabel(tag) {
+  if (typeof tag !== "string" || !tag.length) {
+    return "";
+  }
+  if (/^[A-Z]{2,}$/.test(tag)) {
+    return tag;
+  }
+  return tag.charAt(0).toUpperCase() + tag.slice(1);
+}
+
+function getDualStatusFromTags(tags) {
+  const gender = DUAL_GENDER_TAGS.find((tag) => tags?.includes(tag)) || null;
+  const flow = DUAL_FLOW_TAGS.find((tag) => tags?.includes(tag)) || null;
+  return { gender, flow };
+}
+
+function imageNeedsDualTags(image) {
+  if (!image) return false;
+  const tags = Array.isArray(image.tags) ? image.tags : [];
+  const { gender, flow } = getDualStatusFromTags(tags);
+  return !gender || !flow;
+}
+
+function imageNeedsTriTag(image) {
+  if (!image) return false;
+  const tags = Array.isArray(image.tags) ? image.tags : [];
+  return !hasAnyTag(tags, TRI_TAGS);
+}
+
+function imageNeedsQuadrantTag(image) {
+  if (!image) return false;
+  const tags = Array.isArray(image.tags) ? image.tags : [];
+  return !hasAnyTag(tags, QUADRANT_TAGS);
+}
+
+function buildTaggingCandidates(images, mode) {
+  if (!Array.isArray(images) || !images.length) {
+    return [];
+  }
+  switch (mode) {
+    case "dual":
+      return images.filter(imageNeedsDualTags);
+    case "tri":
+      return images.filter(imageNeedsTriTag);
+    case "quadrant":
+      return images.filter(imageNeedsQuadrantTag);
+    default:
+      return images.filter(imageNeedsDualTags);
+  }
 }
 
 function sanitizeLedgerEntry(raw) {
@@ -1160,6 +1238,8 @@ function loadInitialState() {
     selectedTag: "",
     miniSize: 8,
     libraryEntries,
+    activeTab: "ranking",
+    taggingMode: DEFAULT_TAGGING_MODE,
   };
 
   if (typeof window === "undefined") {
@@ -1253,8 +1333,10 @@ function loadInitialState() {
       activeSwiss,
       placementQueue,
       placementQueueRestored,
-      selectedTag: parsed.selectedTag || base.selectedTag,
-      miniSize: parsed.miniSize || base.miniSize,
+      selectedTag: typeof parsed.selectedTag === "string" ? parsed.selectedTag : base.selectedTag,
+      miniSize: MINI_SIZE_OPTIONS.includes(parsed.miniSize) ? parsed.miniSize : base.miniSize,
+      activeTab: sanitizeTabKey(parsed.activeTab),
+      taggingMode: sanitizeTaggingMode(parsed.taggingMode),
       libraryEntries,
     };
   } catch (error) {
@@ -2381,6 +2463,153 @@ function PlacementPanel({ queue, imagesById, onResolve, onCancel, onViewImage })
   );
 }
 
+function TaggingPanel({
+  image,
+  previewSrc,
+  mode,
+  onModeChange,
+  onAssignTag,
+  onSkip,
+  onViewImage,
+  onRefreshLibrary,
+  remaining,
+  assignments,
+}) {
+  const renderModeToggle = () => (
+    <div className="tagging-mode-toggle" role="tablist" aria-label="Tagging modes">
+      {TAGGING_MODES.map(({ key, label }) => (
+        <button
+          key={key}
+          type="button"
+          className={`tagging-mode-button${mode === key ? " is-active" : ""}`}
+          onClick={() => onModeChange(key)}
+          aria-pressed={mode === key}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+
+  const renderOptionButtons = (options, activeValue, group) => (
+    <div className="tagging-buttons">
+      {options.map((option) => {
+        const isActive = activeValue === option;
+        return (
+          <button
+            key={option}
+            type="button"
+            className={`tagging-option${isActive ? " is-active" : ""}`}
+            onClick={() => onAssignTag(option, group)}
+            disabled={isActive}
+          >
+            {formatTagLabel(option)}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const renderControls = () => {
+    switch (mode) {
+      case "tri":
+        return (
+          <div className="tagging-option-group">
+            <h3>Form</h3>
+            {renderOptionButtons(TRI_TAGS, assignments.tri, "tri")}
+          </div>
+        );
+      case "quadrant":
+        return (
+          <div className="tagging-option-group">
+            <h3>Quadrant</h3>
+            {renderOptionButtons(QUADRANT_TAGS, assignments.quadrant, "quadrant")}
+          </div>
+        );
+      case "dual":
+      default:
+        return (
+          <>
+            <div className="tagging-option-group">
+              <h3>Gender</h3>
+              {renderOptionButtons(DUAL_GENDER_TAGS, assignments.gender, "gender")}
+            </div>
+            <div className="tagging-option-group">
+              <h3>Flow</h3>
+              {renderOptionButtons(DUAL_FLOW_TAGS, assignments.flow, "flow")}
+            </div>
+          </>
+        );
+    }
+  };
+
+  return (
+    <section className="taste-t-panel tagging-panel">
+      <header className="panel-header">
+        <div>
+          <h2>Tag forge</h2>
+          <p className="panel-subtitle">Quickly classify untagged library images.</p>
+        </div>
+        {renderModeToggle()}
+      </header>
+      {image ? (
+        <div className="tagging-content">
+          <div className="tagging-preview">
+            {previewSrc ? (
+              <img src={previewSrc} alt={image.name || "Library entry"} />
+            ) : (
+              <div className="tagging-preview-fallback">No preview available</div>
+            )}
+            <div className="tagging-preview-meta">
+              <strong>{image.name || "Untitled"}</strong>
+              <ul>
+                <li>Gender · {assignments.gender || "—"}</li>
+                <li>Flow · {assignments.flow || "—"}</li>
+                <li>Tri · {assignments.tri || "—"}</li>
+                <li>Quadrant · {assignments.quadrant || "—"}</li>
+              </ul>
+              <div className="tagging-preview-actions">
+                {onViewImage ? (
+                  <button type="button" className="taste-t-secondary" onClick={() => onViewImage(image)}>
+                    View full size
+                  </button>
+                ) : null}
+                <button type="button" className="ghost" onClick={onSkip}>
+                  Skip image
+                </button>
+              </div>
+              <p className="tagging-remaining">
+                {remaining > 1
+                  ? `${remaining} images still need a tag in this mode.`
+                  : "This is the last image waiting for this tag."}
+              </p>
+            </div>
+          </div>
+          <div className="tagging-options">{renderControls()}</div>
+        </div>
+      ) : (
+        <div className="tagging-empty">
+          <h3>All caught up</h3>
+          <p>
+            Every image already has the necessary tags for the selected mode. Choose another mode or refresh the
+            library to keep tagging.
+          </p>
+          <div className="tagging-empty-actions">
+            <button type="button" className="taste-t-secondary" onClick={() => onModeChange("dual")}>
+              Switch to Dual mode
+            </button>
+            {onRefreshLibrary ? (
+              <button type="button" className="ghost" onClick={onRefreshLibrary}>
+                Refresh library
+              </button>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
 
 function TasteT() {
   const initialState = useMemo(() => loadInitialState(), []);
@@ -2392,6 +2621,8 @@ function TasteT() {
   const [selectedTag, setSelectedTag] = useState(initialState.selectedTag);
   const [miniSize, setMiniSize] = useState(initialState.miniSize || 8);
   const [libraryEntries, setLibraryEntries] = useState(initialState.libraryEntries);
+  const [activeTab, setActiveTab] = useState(sanitizeTabKey(initialState.activeTab));
+  const [taggingMode, setTaggingMode] = useState(sanitizeTaggingMode(initialState.taggingMode));
   const [mode, setMode] = useState(() => {
     if (initialState.activeSwiss) {
       return initialState.activeSwiss.status === "awaiting-finish" ? "lobby" : "swiss";
@@ -2402,6 +2633,7 @@ function TasteT() {
   const pendingPreviewRef = useRef(new Set());
   const [expandedImage, setExpandedImage] = useState(null);
   const [undoStack, setUndoStack] = useState([]);
+  const [taggingImageId, setTaggingImageId] = useState(null);
 
   const imagesById = useMemo(() => {
     const map = {};
@@ -2423,14 +2655,16 @@ function TasteT() {
   const rankingData = useMemo(() => buildRankingData(images, selectedTag), [images, selectedTag]);
   const availableTags = rankingData.tags;
   const hasImages = images.length > 0;
+  const isRankingTab = activeTab === "ranking";
+  const isTaggingTab = activeTab === "tagging";
   const canStartSwiss = hasImages && images.length >= 2;
   const placementImage = placementQueue ? imagesById[placementQueue.imageId] : null;
   const pendingPlacementRounds = placementQueue
     ? Math.max(placementQueue.opponents.length - placementQueue.currentIndex, 0)
     : 0;
   const showPlacementCallout =
-    mode === "lobby" && placementQueue && placementImage && pendingPlacementRounds > 0;
-  const isPlaying = mode === "swiss" || mode === "placement";
+    isRankingTab && mode === "lobby" && placementQueue && placementImage && pendingPlacementRounds > 0;
+  const isPlaying = isRankingTab && (mode === "swiss" || mode === "placement");
   const canUndo = undoStack.length > 0;
   const swissHistoryPreview = useMemo(() => swissHistory.slice(0, 3), [swissHistory]);
 
@@ -2448,6 +2682,35 @@ function TasteT() {
     [imagesById, libraryById],
   );
 
+  const taggingCandidates = useMemo(
+    () => buildTaggingCandidates(images, taggingMode),
+    [images, taggingMode],
+  );
+
+  useEffect(() => {
+    if (!taggingCandidates.length) {
+      setTaggingImageId(null);
+      return;
+    }
+    setTaggingImageId((current) => {
+      if (current && taggingCandidates.some((candidate) => candidate.id === current)) {
+        return current;
+      }
+      const next = taggingCandidates[Math.floor(Math.random() * taggingCandidates.length)];
+      return next ? next.id : null;
+    });
+  }, [taggingCandidates]);
+
+  const taggingImage = taggingImageId ? imagesById[taggingImageId] : null;
+  const taggingPreview = taggingImage ? getPreviewFor(taggingImage.id) : null;
+  const taggingAssignments = useMemo(() => {
+    const tags = Array.isArray(taggingImage?.tags) ? taggingImage.tags : [];
+    const { gender, flow } = getDualStatusFromTags(tags);
+    const tri = TRI_TAGS.find((tag) => tags.includes(tag)) || null;
+    const quadrant = QUADRANT_TAGS.find((tag) => tags.includes(tag)) || null;
+    return { gender, flow, tri, quadrant };
+  }, [taggingImage]);
+
   const createUndoState = useCallback(() => ({
     images: deepClone(images),
     duelLog: deepClone(duelLog),
@@ -2460,6 +2723,111 @@ function TasteT() {
     if (!snapshot) return;
     setUndoStack((current) => [snapshot, ...current].slice(0, UNDO_STACK_LIMIT));
   }, []);
+
+  const persistLibraryTags = useCallback(
+    (imageId, tags) => {
+      if (typeof window === "undefined") return;
+      const targetId = coerceLibraryId(imageId);
+      if (!targetId) return;
+      try {
+        const entries = loadLibraryCatalog();
+        let changed = false;
+        const nextEntries = entries.map((entry) => {
+          if (!entry) return entry;
+          const entryId = coerceLibraryId(entry.id);
+          if (!entryId || entryId !== targetId) {
+            return entry;
+          }
+          const existingTags = normalizeLibraryTags(entry.tags);
+          if (arraysEqual(existingTags, tags)) {
+            return entry;
+          }
+          changed = true;
+          return { ...entry, tags };
+        });
+        if (changed) {
+          localStorage.setItem(LIBRARY_STORAGE_KEY, JSON.stringify(nextEntries));
+          setLibraryEntries(nextEntries);
+        }
+      } catch (error) {
+        console.warn("TierT: unable to persist library tags", error);
+      }
+    },
+    [setLibraryEntries],
+  );
+
+  const handleSelectTab = useCallback(
+    (tab) => {
+      const next = sanitizeTabKey(tab);
+      if (next === "tagging" && isPlaying) {
+        return;
+      }
+      setActiveTab((current) => (current === next ? current : next));
+    },
+    [isPlaying, setActiveTab],
+  );
+
+  const handleTaggingModeChange = useCallback(
+    (nextMode) => {
+      const sanitized = sanitizeTaggingMode(nextMode);
+      setTaggingMode((current) => (current === sanitized ? current : sanitized));
+      setTaggingImageId(null);
+    },
+    [setTaggingMode, setTaggingImageId],
+  );
+
+  const handleTaggingAssign = useCallback(
+    (tag, group) => {
+      const targetId = taggingImageId;
+      if (!targetId) return;
+      const image = imagesById[targetId];
+      if (!image) return;
+      const baseTags = Array.isArray(image.tags) ? image.tags : [];
+      let nextTags = baseTags.slice();
+      if (group === "gender") {
+        nextTags = nextTags.filter((entry) => !DUAL_GENDER_TAGS.includes(entry));
+      } else if (group === "flow") {
+        nextTags = nextTags.filter((entry) => !DUAL_FLOW_TAGS.includes(entry));
+      } else if (group === "tri") {
+        nextTags = nextTags.filter((entry) => !TRI_TAGS.includes(entry));
+      } else if (group === "quadrant") {
+        nextTags = nextTags.filter((entry) => !QUADRANT_TAGS.includes(entry));
+      }
+      if (!nextTags.includes(tag)) {
+        nextTags.push(tag);
+      }
+      const sanitizedTags = normalizeLibraryTags(nextTags);
+      const currentTags = normalizeLibraryTags(baseTags);
+      if (arraysEqual(currentTags, sanitizedTags)) {
+        return;
+      }
+      const now = Date.now();
+      setImages((current) => {
+        const index = current.findIndex((img) => img.id === targetId);
+        if (index === -1) return current;
+        const existing = normalizeLibraryTags(current[index].tags);
+        if (arraysEqual(existing, sanitizedTags)) {
+          return current;
+        }
+        const next = current.slice();
+        next[index] = { ...current[index], tags: sanitizedTags, updatedAt: now };
+        return next;
+      });
+      persistLibraryTags(targetId, sanitizedTags);
+    },
+    [imagesById, taggingImageId, persistLibraryTags, setImages],
+  );
+
+  const handleSkipTagging = useCallback(() => {
+    if (!taggingCandidates.length) {
+      setTaggingImageId(null);
+      return;
+    }
+    const alternatives = taggingCandidates.filter((candidate) => candidate.id !== taggingImageId);
+    const pool = alternatives.length ? alternatives : taggingCandidates;
+    const next = pool[Math.floor(Math.random() * pool.length)];
+    setTaggingImageId(next ? next.id : null);
+  }, [taggingCandidates, taggingImageId]);
 
   const handleViewImage = useCallback((image) => {
     if (!image) return;
@@ -2674,12 +3042,14 @@ function TasteT() {
         placementQueue,
         selectedTag,
         miniSize,
+        activeTab,
+        taggingMode,
       });
       localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
     } catch (error) {
       console.warn("TierT: unable to persist state", error);
     }
-  }, [images, duelLog, swissHistory, activeSwiss, placementQueue, selectedTag, miniSize]);
+  }, [images, duelLog, swissHistory, activeSwiss, placementQueue, selectedTag, miniSize, activeTab, taggingMode]);
 
   const applyResolution = useCallback(
     (resolution) => {
@@ -3102,8 +3472,10 @@ function TasteT() {
     [placementQueue, imagesById, applyResolution, createUndoState, pushUndoState],
   );
 
-  const hasActiveSwiss = mode === "swiss" && activeSwiss;
-  const hasPlacement = mode === "placement" && placementQueue;
+  const hasActiveSwiss = isRankingTab && mode === "swiss" && activeSwiss;
+  const hasPlacement = isRankingTab && mode === "placement" && placementQueue;
+  const showRankingDashboard = isRankingTab && !hasActiveSwiss && !hasPlacement;
+  const taggingRemaining = taggingCandidates.length;
 
   const topRankings = rankingData.filtered.slice(0, 6);
   const topTierSnapshots = rankingData.perTier.slice(0, 3);
@@ -3114,7 +3486,21 @@ function TasteT() {
   return (
     <div className={`taste-t-app${isPlaying ? " is-playing" : ""}`}>
       <div className="taste-t-frame">
-        {canUndo ? (
+        <div className="taste-t-tablist" role="tablist" aria-label="TasteT modes">
+          {TASTET_TABS.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              className={`taste-t-tab${activeTab === tab.key ? " is-active" : ""}`}
+              onClick={() => handleSelectTab(tab.key)}
+              aria-pressed={activeTab === tab.key}
+              disabled={tab.key === "tagging" && isPlaying}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        {isRankingTab && canUndo ? (
           <div className="taste-t-toolbar">
             <button type="button" className="ghost" onClick={handleUndo} disabled={!canUndo}>
               Undo last result
@@ -3144,7 +3530,7 @@ function TasteT() {
               onViewImage={handleViewImage}
             />
           </div>
-        ) : (
+        ) : showRankingDashboard ? (
           <div className="taste-t-dashboard">
             <section className="taste-t-overview-panel">
               <div className="taste-t-overview-header">
@@ -3361,7 +3747,23 @@ function TasteT() {
               </div>
             </div>
           </div>
-        )}
+        ) : null}
+        {isTaggingTab ? (
+          <div className="taste-t-game taste-t-game--tagging">
+            <TaggingPanel
+              image={taggingImage}
+              previewSrc={taggingPreview}
+              mode={taggingMode}
+              onModeChange={handleTaggingModeChange}
+              onAssignTag={handleTaggingAssign}
+              onSkip={handleSkipTagging}
+              onViewImage={handleViewImage}
+              onRefreshLibrary={refreshLibrary}
+              remaining={taggingRemaining}
+              assignments={taggingAssignments}
+            />
+          </div>
+        ) : null}
       </div>
       {expandedImageSrc ? (
         <div className="taste-t-lightbox" role="dialog" aria-modal="true">

--- a/src/taste-t.css
+++ b/src/taste-t.css
@@ -603,6 +603,47 @@
   width: 100%;
 }
 
+.taste-t-game--tagging {
+  flex: 1 1 auto;
+}
+
+.taste-t-tablist {
+  display: inline-flex;
+  gap: 12px;
+  padding: 6px;
+  background: rgba(15, 20, 40, 0.88);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  margin-bottom: 18px;
+}
+
+.taste-t-tab {
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  background: transparent !important;
+  color: rgba(226, 232, 240, 0.72) !important;
+  border: none !important;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.taste-t-tab:hover:not(:disabled) {
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.taste-t-tab.is-active {
+  background: linear-gradient(120deg, rgba(99, 102, 241, 0.2), rgba(236, 72, 153, 0.25)) !important;
+  color: #ffffff !important;
+  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.28);
+}
+
+.taste-t-tab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
 .taste-t-app button {
   font: inherit;
   border-radius: 12px;
@@ -702,6 +743,197 @@
   box-sizing: border-box;
   flex: 1 1 auto;
   min-height: 0;
+}
+
+.tagging-panel {
+  gap: 24px;
+}
+
+.tagging-mode-toggle {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.tagging-mode-button {
+  border-radius: 10px;
+  padding: 8px 16px;
+  background: rgba(129, 140, 248, 0.16) !important;
+  color: rgba(226, 232, 240, 0.86) !important;
+  border: 1px solid transparent !important;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.tagging-mode-button:hover {
+  transform: translateY(-1px);
+  background: rgba(129, 140, 248, 0.24) !important;
+}
+
+.tagging-mode-button.is-active {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.38), rgba(129, 140, 248, 0.45)) !important;
+  color: #ffffff !important;
+  border-color: rgba(244, 114, 182, 0.55) !important;
+  box-shadow: 0 10px 24px rgba(129, 140, 248, 0.25);
+}
+
+.tagging-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+@media (min-width: 960px) {
+  .tagging-content {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+}
+
+.tagging-preview {
+  flex: 1 1 50%;
+  background: rgba(18, 22, 42, 0.65);
+  border-radius: 20px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.tagging-preview img {
+  width: 100%;
+  max-height: 420px;
+  object-fit: contain;
+  border-radius: 16px;
+  background: rgba(9, 11, 24, 0.8);
+}
+
+.tagging-preview-fallback {
+  width: 100%;
+  height: 320px;
+  border-radius: 16px;
+  background: rgba(9, 11, 24, 0.8);
+  display: grid;
+  place-items: center;
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 0.95rem;
+}
+
+.tagging-preview-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tagging-preview-meta strong {
+  font-size: 1.1rem;
+}
+
+.tagging-preview-meta ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 6px;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.tagging-preview-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tagging-remaining {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.tagging-options {
+  flex: 1 1 45%;
+  display: grid;
+  gap: 18px;
+}
+
+.tagging-option-group {
+  background: rgba(18, 22, 42, 0.65);
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tagging-option-group h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+}
+
+.tagging-buttons {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tagging-option {
+  border-radius: 10px;
+  padding: 8px 16px;
+  background: rgba(79, 70, 229, 0.18) !important;
+  color: rgba(226, 232, 240, 0.85) !important;
+  border: 1px solid transparent !important;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.tagging-option:hover:not(:disabled) {
+  background: rgba(79, 70, 229, 0.26) !important;
+  transform: translateY(-1px);
+}
+
+.tagging-option.is-active {
+  background: linear-gradient(120deg, rgba(99, 102, 241, 0.42), rgba(244, 114, 182, 0.45)) !important;
+  color: #ffffff !important;
+  border-color: rgba(244, 114, 182, 0.55) !important;
+  cursor: default;
+  transform: none;
+}
+
+.tagging-option:disabled {
+  opacity: 0.6;
+}
+
+.tagging-empty {
+  background: rgba(18, 22, 42, 0.65);
+  border-radius: 20px;
+  padding: 40px 32px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.tagging-empty h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.tagging-empty p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.95rem;
+}
+
+.tagging-empty-actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 .panel-header {


### PR DESCRIPTION
## Summary
- add a Tag Forge tab to TasteT with dual/tri/quadrant tagging controls and toolbar navigation
- persist tagging selections, sync tags to the library, and style the new tagging panel
- include Mazed in default activity options and merge registered names with defaults

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ee4f3166bc8322884f7b9f3db5b84f