### PR TITLE
Add content counts to library tabs

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -684,6 +684,11 @@ export default function Library({ onBack }) {
     [sortMode, sounds]
   );
 
+  const imageCount = filteredImages.length;
+  const wordCount = displayedWords.length;
+  const soundCount = displayedSounds.length;
+  const totalCount = imageCount + wordCount + soundCount;
+
   const ratingSummary = useMemo(() => {
     if (!images.length) {
       return new Map();
@@ -3188,25 +3193,25 @@ export default function Library({ onBack }) {
             className={activeTab === 'all' ? 'active' : ''}
             onClick={() => setActiveTab('all')}
           >
-            All
+            All ({totalCount})
           </button>
           <button
             className={activeTab === 'images' ? 'active' : ''}
             onClick={() => setActiveTab('images')}
           >
-            Images
+            Images ({imageCount})
           </button>
           <button
             className={activeTab === 'words' ? 'active' : ''}
             onClick={() => setActiveTab('words')}
           >
-            Words
+            Words ({wordCount})
           </button>
           <button
             className={activeTab === 'sounds' ? 'active' : ''}
             onClick={() => setActiveTab('sounds')}
           >
-            Sounds
+            Sounds ({soundCount})
           </button>
         </div>
         {(activeTab === 'all' || activeTab === 'images') &&


### PR DESCRIPTION
## Summary
- display the number of items for each Library tab, including the aggregate count
- derive totals from the current filtered images, words, and sounds collections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f20f3c1590832292d37193fafb3085