### PR TITLE
Log completed activities to calendar

### DIFF
--- a/ActivityLog.test.js
+++ b/ActivityLog.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('./src/ToolsBlog.jsx', () => {
@@ -76,5 +76,44 @@ describe('ActivityLog', () => {
         'Yoga',
       ]);
     });
+  });
+
+  it('records completed sessions in the calendar', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01T10:00:00.000Z'));
+
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    try {
+      render(<ActivityLog onBack={() => {}} />);
+
+      const select = await screen.findByRole('combobox');
+      fireEvent.change(select, { target: { value: 'Mazed' } });
+
+      const startButton = screen.getByRole('button', { name: /start activity/i });
+      fireEvent.click(startButton);
+
+      await act(async () => {
+        jest.advanceTimersByTime(30 * 60 * 1000);
+      });
+
+      const stopButton = screen.getByRole('button', { name: /stop & save/i });
+      fireEvent.click(stopButton);
+
+      const calendarEvents = dispatchSpy.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event?.type === 'calendar-add-event');
+
+      expect(calendarEvents).toHaveLength(1);
+      const detail = calendarEvents[0].detail;
+      expect(detail).toMatchObject({
+        title: 'Mazed',
+        kind: 'done',
+      });
+      expect(detail.start).toBe('2024-01-01T10:00:00.000Z');
+      expect(detail.end).toBe('2024-01-01T10:30:00.000Z');
+    } finally {
+      dispatchSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -308,6 +308,55 @@ const recordSessionInBlog = (session) => {
   });
 };
 
+const recordSessionInCalendar = (session) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const name = sanitizeActivityName(session?.name);
+  if (!name) {
+    return;
+  }
+
+  const segments = Array.isArray(session?.segments) && session.segments.length > 0
+    ? session.segments
+    : [
+        {
+          start: session?.startedAt,
+          end: session?.endedAt,
+        },
+      ];
+
+  segments.forEach((segment) => {
+    const startDate = segment?.start ? new Date(segment.start) : null;
+    const endDate = segment?.end ? new Date(segment.end) : null;
+
+    if (
+      !startDate ||
+      !endDate ||
+      Number.isNaN(startDate.getTime()) ||
+      Number.isNaN(endDate.getTime()) ||
+      endDate.getTime() <= startDate.getTime()
+    ) {
+      return;
+    }
+
+    const detail = {
+      title: name,
+      start: startDate.toISOString(),
+      end: endDate.toISOString(),
+      kind: 'done',
+      color: '#34a853',
+    };
+
+    try {
+      window.dispatchEvent(new CustomEvent('calendar-add-event', { detail }));
+    } catch (error) {
+      console.error('Failed to record activity session in calendar', error);
+    }
+  });
+};
+
 export default function ActivityLog({ onBack }) {
   const buildOptionsFromStorage = useCallback(() => {
     let storedNames = [];
@@ -508,6 +557,7 @@ export default function ActivityLog({ onBack }) {
       if (finished) {
         persistEntries([...entries, finished]);
         recordSessionInBlog(finished);
+        recordSessionInCalendar(finished);
       }
     }
 
@@ -560,6 +610,7 @@ export default function ActivityLog({ onBack }) {
     if (finished) {
       persistEntries([...entries, finished]);
       recordSessionInBlog(finished);
+      recordSessionInCalendar(finished);
     }
     persistCurrent(null);
   };


### PR DESCRIPTION
## Summary
- dispatch completed activity log sessions to the calendar as done events
- add a regression test that verifies calendar updates when stopping a session

## Testing
- npm test -- ActivityLog.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f67db8b55083228aa42813e46513ca