### PR TITLE
Ensure activity sessions persist to calendar storage

### DIFF
--- a/ActivityLog.test.js
+++ b/ActivityLog.test.js
@@ -111,6 +111,15 @@ describe('ActivityLog', () => {
       });
       expect(detail.start).toBe('2024-01-01T10:00:00.000Z');
       expect(detail.end).toBe('2024-01-01T10:30:00.000Z');
+
+      const storedEvents = JSON.parse(localStorage.getItem('calendarEvents'));
+      expect(storedEvents).toHaveLength(1);
+      expect(storedEvents[0]).toMatchObject({
+        title: 'Mazed',
+        kind: 'done',
+        start: '2024-01-01T10:00:00.000Z',
+        end: '2024-01-01T10:30:00.000Z',
+      });
     } finally {
       dispatchSpy.mockRestore();
       jest.useRealTimers();

--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -12,6 +12,7 @@ import './activity-log.css';
 
 const ENTRIES_KEY = 'activityLogEntries';
 const CURRENT_KEY = 'activityLogCurrent';
+const CALENDAR_EVENTS_KEY = 'calendarEvents';
 
 const DEFAULT_ACTIVITIES = [
   'Mazed',
@@ -308,6 +309,64 @@ const recordSessionInBlog = (session) => {
   });
 };
 
+const loadStoredCalendarEvents = () => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(CALENDAR_EVENTS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(
+      (event) =>
+        event &&
+        typeof event === 'object' &&
+        typeof event.title === 'string' &&
+        typeof event.start === 'string' &&
+        typeof event.end === 'string'
+    );
+  } catch (error) {
+    console.error('Failed to read calendar events from storage', error);
+    return [];
+  }
+};
+
+const persistCalendarEvents = (events) => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(CALENDAR_EVENTS_KEY, JSON.stringify(events));
+    window.dispatchEvent(new Event('calendar-updated'));
+  } catch (error) {
+    console.error('Failed to persist calendar events to storage', error);
+  }
+};
+
+const eventsMatch = (a, b) => {
+  if (!a || !b) {
+    return false;
+  }
+
+  const kindA = a.kind || 'planned';
+  const kindB = b.kind || 'planned';
+
+  return (
+    a.title === b.title &&
+    a.start === b.start &&
+    a.end === b.end &&
+    kindA === kindB
+  );
+};
+
 const recordSessionInCalendar = (session) => {
   if (typeof window === 'undefined') {
     return;
@@ -317,6 +376,9 @@ const recordSessionInCalendar = (session) => {
   if (!name) {
     return;
   }
+
+  let storedEvents = loadStoredCalendarEvents();
+  let hasChanges = false;
 
   const segments = Array.isArray(session?.segments) && session.segments.length > 0
     ? session.segments
@@ -349,12 +411,21 @@ const recordSessionInCalendar = (session) => {
       color: '#34a853',
     };
 
+    if (!storedEvents.some((event) => eventsMatch(event, detail))) {
+      storedEvents = [...storedEvents, detail];
+      hasChanges = true;
+    }
+
     try {
       window.dispatchEvent(new CustomEvent('calendar-add-event', { detail }));
     } catch (error) {
       console.error('Failed to record activity session in calendar', error);
     }
   });
+
+  if (hasChanges) {
+    persistCalendarEvents(storedEvents);
+  }
 };
 
 export default function ActivityLog({ onBack }) {

--- a/src/ActivityLogger.jsx
+++ b/src/ActivityLogger.jsx
@@ -19,14 +19,25 @@ export default function ActivityLogger({ enabled }) {
         if (!enabledRef.current) return;
         // Only create aggregated blocks rather than individual done events
         // Remove old event log storage to keep the interface clean
-        localStorage.setItem(
-          'calendarEvents',
-          JSON.stringify(
-            (JSON.parse(localStorage.getItem('calendarEvents') || '[]') || []).filter(
-              (e) => e && (e.kind === 'planned')
-            )
-          )
-        );
+        const sanitizedEvents = (() => {
+          try {
+            const parsed = JSON.parse(localStorage.getItem('calendarEvents') || '[]');
+            if (!Array.isArray(parsed)) return [];
+            return parsed.filter(
+              (event) =>
+                event &&
+                event.start &&
+                event.end &&
+                typeof event.title === 'string' &&
+                event.title.trim() !== ''
+            );
+          } catch (error) {
+            console.error('Failed to sanitize stored calendar events', error);
+            return [];
+          }
+        })();
+
+        localStorage.setItem('calendarEvents', JSON.stringify(sanitizedEvents));
 
         const blockStart = roundSlot(data.start);
         const blockEnd = new Date(blockStart.getTime() + 30 * 60000);


### PR DESCRIPTION
## Summary
- persist completed activity sessions to the calendar event store so they appear even if the calendar is closed
- prevent the activity auto-logger from stripping recorded calendar entries when sanitizing storage
- extend the activity log test suite to cover calendar persistence

## Testing
- npm test -- ActivityLog.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f777cb19b8832292d2c7abf77d84d5