### PR TITLE
Track running activities in the calendar

### DIFF
--- a/ActivityLog.test.js
+++ b/ActivityLog.test.js
@@ -101,16 +101,67 @@ describe('ActivityLog', () => {
 
       const calendarEvents = dispatchSpy.mock.calls
         .map(([event]) => event)
-        .filter((event) => event?.type === 'calendar-add-event');
+        .filter((event) => event?.type === 'calendar-add-event')
+        .map((event) => event.detail);
 
-      expect(calendarEvents).toHaveLength(1);
-      const detail = calendarEvents[0].detail;
-      expect(detail).toMatchObject({
+      const doneEvents = calendarEvents.filter((detail) => detail.kind === 'done');
+      expect(doneEvents).toHaveLength(1);
+      expect(doneEvents[0]).toMatchObject({
         title: 'Mazed',
         kind: 'done',
       });
-      expect(detail.start).toBe('2024-01-01T10:00:00.000Z');
-      expect(detail.end).toBe('2024-01-01T10:30:00.000Z');
+      expect(doneEvents[0].start).toBe('2024-01-01T10:00:00.000Z');
+      expect(doneEvents[0].end).toBe('2024-01-01T10:30:00.000Z');
+
+      const storedEvents = JSON.parse(localStorage.getItem('calendarEvents'));
+      expect(storedEvents).toHaveLength(1);
+      expect(storedEvents[0]).toMatchObject({
+        title: 'Mazed',
+        kind: 'done',
+        start: '2024-01-01T10:00:00.000Z',
+        end: '2024-01-01T10:30:00.000Z',
+        activitySessionId: expect.any(String),
+        segmentIndex: 0,
+      });
+    } finally {
+      dispatchSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('persists active sessions to the calendar while they are running', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01T10:00:00.000Z'));
+
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    try {
+      render(<ActivityLog onBack={() => {}} />);
+
+      const select = await screen.findByRole('combobox');
+      fireEvent.change(select, { target: { value: 'Mazed' } });
+
+      const startButton = screen.getByRole('button', { name: /start activity/i });
+      fireEvent.click(startButton);
+
+      await act(async () => {
+        jest.advanceTimersByTime(90 * 60 * 1000);
+      });
+
+      const storedEvents = JSON.parse(localStorage.getItem('calendarEvents'));
+      const activeEvent = storedEvents.find((event) => event.kind === 'active');
+      expect(activeEvent).toBeTruthy();
+      expect(activeEvent.title).toBe('Mazed');
+      expect(activeEvent.start).toBe('2024-01-01T10:00:00.000Z');
+      expect(activeEvent.end).toBe('2024-01-01T11:30:00.000Z');
+      expect(activeEvent.activitySessionId).toBeDefined();
+      expect(activeEvent.segmentIndex).toBe(0);
+
+      const activeEvents = dispatchSpy.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event?.type === 'calendar-add-event')
+        .map((event) => event.detail)
+        .filter((detail) => detail.kind === 'active');
+      expect(activeEvents.length).toBeGreaterThan(0);
     } finally {
       dispatchSpy.mockRestore();
       jest.useRealTimers();

--- a/Calendar.test.js
+++ b/Calendar.test.js
@@ -86,6 +86,34 @@ describe('Calendar', () => {
     expect(RbcCalendar.latestProps.events[0].kind).toBe('done');
   });
 
+  test('expands active events to the current time when rendered', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01T12:00:00.000Z'));
+
+    localStorage.setItem(
+      'calendarEvents',
+      JSON.stringify([
+        {
+          title: 'Deep Work',
+          start: '2024-01-01T09:00:00.000Z',
+          end: '2024-01-01T10:00:00.000Z',
+          kind: 'active',
+          id: 'session-1:0',
+        },
+      ])
+    );
+
+    render(<Calendar onBack={() => {}} />);
+
+    expect(RbcCalendar.latestProps.events).toHaveLength(1);
+    const event = RbcCalendar.latestProps.events[0];
+    expect(event.kind).toBe('active');
+    expect(event.end.getTime()).toBe(
+      new Date('2024-01-01T12:00:00.000Z').getTime()
+    );
+
+    jest.useRealTimers();
+  });
+
   test('removes original event when marking done with new object instance', async () => {
     const start = new Date();
     const end = new Date(start.getTime() + 30 * 60000);

--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   loadActivityBlogIndex,
   loadBlogPostsFromStorage,
@@ -12,6 +12,10 @@ import './activity-log.css';
 
 const ENTRIES_KEY = 'activityLogEntries';
 const CURRENT_KEY = 'activityLogCurrent';
+const CALENDAR_EVENTS_KEY = 'calendarEvents';
+const ACTIVE_EVENT_KIND = 'active';
+const DONE_EVENT_KIND = 'done';
+const ACTIVITY_EVENT_COLOR = '#34a853';
 
 const DEFAULT_ACTIVITIES = [
   'Mazed',
@@ -89,6 +93,95 @@ const sanitizeActivityName = (name) => {
   }
 
   return name.trim();
+};
+
+const parseDateValue = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const buildSessionId = (session) => {
+  if (!session) {
+    return null;
+  }
+
+  if (session.id != null) {
+    return String(session.id);
+  }
+
+  const started = parseDateValue(session.startedAt);
+  if (started) {
+    return String(started.getTime());
+  }
+
+  return String(Date.now());
+};
+
+const buildSegmentEventId = (sessionId, index) => `${sessionId}:${index}`;
+
+const eventEquals = (a, b) => {
+  if (!a || !b) {
+    return false;
+  }
+
+  const kindA = a.kind || 'planned';
+  const kindB = b.kind || 'planned';
+
+  return (
+    a.title === b.title &&
+    a.start === b.start &&
+    a.end === b.end &&
+    kindA === kindB &&
+    (a.color || '') === (b.color || '') &&
+    (a.id || null) === (b.id || null)
+  );
+};
+
+const upsertStoredEvent = (events, detail) => {
+  const normalizedDetail = {
+    ...detail,
+    kind: detail.kind || 'planned',
+  };
+
+  if (!Array.isArray(events) || events.length === 0) {
+    return { events: [normalizedDetail], changed: true };
+  }
+
+  if (normalizedDetail.id != null) {
+    const index = events.findIndex((event) => event.id === normalizedDetail.id);
+    if (index !== -1) {
+      if (eventEquals(events[index], normalizedDetail)) {
+        return { events, changed: false };
+      }
+      const next = [...events];
+      next[index] = { ...events[index], ...normalizedDetail };
+      return { events: next, changed: true };
+    }
+  }
+
+  const fallbackIndex = events.findIndex(
+    (event) =>
+      event &&
+      event.title === normalizedDetail.title &&
+      event.start === normalizedDetail.start &&
+      event.end === normalizedDetail.end &&
+      (event.kind || 'planned') === normalizedDetail.kind
+  );
+
+  if (fallbackIndex !== -1) {
+    if (eventEquals(events[fallbackIndex], normalizedDetail)) {
+      return { events, changed: false };
+    }
+    const next = [...events];
+    next[fallbackIndex] = { ...events[fallbackIndex], ...normalizedDetail };
+    return { events: next, changed: true };
+  }
+
+  return { events: [...events, normalizedDetail], changed: true };
 };
 
 const loadSanitizedBlogPosts = () => {
@@ -308,7 +401,49 @@ const recordSessionInBlog = (session) => {
   });
 };
 
-const recordSessionInCalendar = (session) => {
+const loadStoredCalendarEvents = () => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(CALENDAR_EVENTS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(
+      (event) =>
+        event &&
+        typeof event === 'object' &&
+        typeof event.title === 'string' &&
+        typeof event.start === 'string' &&
+        typeof event.end === 'string'
+    );
+  } catch (error) {
+    console.error('Failed to read calendar events from storage', error);
+    return [];
+  }
+};
+
+const persistCalendarEvents = (events) => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(CALENDAR_EVENTS_KEY, JSON.stringify(events));
+    window.dispatchEvent(new Event('calendar-updated'));
+  } catch (error) {
+    console.error('Failed to persist calendar events to storage', error);
+  }
+};
+
+const recordSessionInCalendar = (session, { now } = {}) => {
   if (typeof window === 'undefined') {
     return;
   }
@@ -318,43 +453,128 @@ const recordSessionInCalendar = (session) => {
     return;
   }
 
-  const segments = Array.isArray(session?.segments) && session.segments.length > 0
-    ? session.segments
-    : [
-        {
-          start: session?.startedAt,
-          end: session?.endedAt,
-        },
-      ];
+  const nowDate =
+    now instanceof Date ? now : now ? new Date(now) : new Date();
+  if (Number.isNaN(nowDate.getTime())) {
+    return;
+  }
 
-  segments.forEach((segment) => {
-    const startDate = segment?.start ? new Date(segment.start) : null;
-    const endDate = segment?.end ? new Date(segment.end) : null;
+  const sessionId = buildSessionId(session);
+  let storedEvents = [...loadStoredCalendarEvents()];
+  let hasChanges = false;
 
-    if (
-      !startDate ||
-      !endDate ||
-      Number.isNaN(startDate.getTime()) ||
-      Number.isNaN(endDate.getTime()) ||
-      endDate.getTime() <= startDate.getTime()
-    ) {
+  const segments = Array.isArray(session?.segments) ? session.segments : [];
+
+  const upsert = (detail) => {
+    const { events, changed } = upsertStoredEvent(storedEvents, detail);
+    if (changed) {
+      storedEvents = events;
+      hasChanges = true;
+      try {
+        window.dispatchEvent(new CustomEvent('calendar-add-event', { detail }));
+      } catch (error) {
+        console.error('Failed to broadcast calendar event update', error);
+      }
+    }
+  };
+
+  segments.forEach((segment, index) => {
+    const startDate = parseDateValue(segment?.start);
+    const endDate = parseDateValue(segment?.end);
+
+    if (!startDate || !endDate || endDate.getTime() <= startDate.getTime()) {
       return;
     }
 
     const detail = {
+      id: buildSegmentEventId(sessionId, index),
       title: name,
       start: startDate.toISOString(),
       end: endDate.toISOString(),
-      kind: 'done',
-      color: '#34a853',
+      kind: DONE_EVENT_KIND,
+      color: ACTIVITY_EVENT_COLOR,
+      activitySessionId: sessionId,
+      segmentIndex: index,
     };
 
-    try {
-      window.dispatchEvent(new CustomEvent('calendar-add-event', { detail }));
-    } catch (error) {
-      console.error('Failed to record activity session in calendar', error);
-    }
+    upsert(detail);
   });
+
+  const activeStart = parseDateValue(session?.activeSegmentStart);
+  if (activeStart && nowDate.getTime() > activeStart.getTime()) {
+    const activeIndex = segments.length;
+    const detail = {
+      id: buildSegmentEventId(sessionId, activeIndex),
+      title: name,
+      start: activeStart.toISOString(),
+      end: nowDate.toISOString(),
+      kind: ACTIVE_EVENT_KIND,
+      color: ACTIVITY_EVENT_COLOR,
+      activitySessionId: sessionId,
+      segmentIndex: activeIndex,
+      updatedAt: nowDate.toISOString(),
+    };
+
+    upsert(detail);
+  }
+
+  if (hasChanges) {
+    persistCalendarEvents(storedEvents);
+  }
+};
+
+const clearActiveCalendarEventsForSession = (session) => {
+  if (typeof window === 'undefined' || !session) {
+    return;
+  }
+
+  const sessionId = buildSessionId(session);
+  if (!sessionId) {
+    return;
+  }
+
+  const storedEvents = loadStoredCalendarEvents();
+  const nextEvents = storedEvents.filter(
+    (event) =>
+      !(
+        event &&
+        event.activitySessionId === sessionId &&
+        (event.kind || 'planned') === ACTIVE_EVENT_KIND
+      )
+  );
+
+  if (nextEvents.length !== storedEvents.length) {
+    persistCalendarEvents(nextEvents);
+  }
+};
+
+const pruneOrphanedActiveEvents = (activeSessionId) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const targetId = activeSessionId != null ? String(activeSessionId) : null;
+  const storedEvents = loadStoredCalendarEvents();
+  const nextEvents = storedEvents.filter((event) => {
+    if (!event || typeof event !== 'object') {
+      return true;
+    }
+    const kind = event.kind || 'planned';
+    if (kind !== ACTIVE_EVENT_KIND) {
+      return true;
+    }
+    if (!event.activitySessionId) {
+      return false;
+    }
+    if (targetId == null) {
+      return false;
+    }
+    return String(event.activitySessionId) === targetId;
+  });
+
+  if (nextEvents.length !== storedEvents.length) {
+    persistCalendarEvents(nextEvents);
+  }
 };
 
 export default function ActivityLog({ onBack }) {
@@ -391,6 +611,7 @@ export default function ActivityLog({ onBack }) {
   const [isAddingActivity, setIsAddingActivity] = useState(false);
   const [newActivityName, setNewActivityName] = useState('');
   const [tick, setTick] = useState(() => Date.now());
+  const lastCalendarSyncRef = useRef(null);
 
   const refreshActivityOptions = useCallback(() => {
     setActivityOptions(buildOptionsFromStorage());
@@ -400,6 +621,30 @@ export default function ActivityLog({ onBack }) {
     const id = setInterval(() => setTick(Date.now()), 1000);
     return () => clearInterval(id);
   }, []);
+
+  useEffect(() => {
+    if (!current?.activeSegmentStart) {
+      if (!current) {
+        lastCalendarSyncRef.current = null;
+      }
+      return;
+    }
+
+    const nowMs = typeof tick === 'number' ? tick : Date.now();
+    if (!Number.isFinite(nowMs)) {
+      return;
+    }
+
+    if (
+      lastCalendarSyncRef.current &&
+      nowMs - lastCalendarSyncRef.current < 30000
+    ) {
+      return;
+    }
+
+    lastCalendarSyncRef.current = nowMs;
+    recordSessionInCalendar(current, { now: new Date(nowMs) });
+  }, [current, tick]);
 
   useEffect(() => {
     try {
@@ -419,6 +664,19 @@ export default function ActivityLog({ onBack }) {
     } catch (error) {
       console.error('Failed to persist current activity session', error);
     }
+  }, [current]);
+
+  useEffect(() => {
+    if (!current) {
+      lastCalendarSyncRef.current = null;
+      pruneOrphanedActiveEvents(null);
+      return;
+    }
+
+    lastCalendarSyncRef.current = null;
+    const sessionId = buildSessionId(current);
+    pruneOrphanedActiveEvents(sessionId);
+    recordSessionInCalendar(current);
   }, [current]);
 
   useEffect(() => {
@@ -568,6 +826,8 @@ export default function ActivityLog({ onBack }) {
         activeSegmentStart: now.toISOString(),
       };
       persistCurrent(resumed);
+      recordSessionInCalendar(resumed, { now });
+      lastCalendarSyncRef.current = now.getTime();
     } else {
       const nextSession = {
         id: now.getTime(),
@@ -578,6 +838,8 @@ export default function ActivityLog({ onBack }) {
         activeSegmentStart: now.toISOString(),
       };
       persistCurrent(nextSession);
+      recordSessionInCalendar(nextSession, { now });
+      lastCalendarSyncRef.current = now.getTime();
       setActivityName(sanitizedSelectedName);
     }
   };
@@ -602,6 +864,8 @@ export default function ActivityLog({ onBack }) {
       activeSegmentStart: null,
     };
     persistCurrent(next);
+    recordSessionInCalendar(next);
+    lastCalendarSyncRef.current = null;
   };
 
   const handleStop = () => {
@@ -613,14 +877,19 @@ export default function ActivityLog({ onBack }) {
       recordSessionInCalendar(finished);
     }
     persistCurrent(null);
+    lastCalendarSyncRef.current = null;
   };
 
   const handleClear = () => {
     if (!entries.length && !current) return;
     if (window.confirm('Clear all logged activities? This cannot be undone.')) {
       persistEntries([]);
+      if (current) {
+        clearActiveCalendarEventsForSession(current);
+      }
       persistCurrent(null);
       setActivityName('');
+      lastCalendarSyncRef.current = null;
     }
   };
 

--- a/src/ActivityLogger.jsx
+++ b/src/ActivityLogger.jsx
@@ -19,14 +19,25 @@ export default function ActivityLogger({ enabled }) {
         if (!enabledRef.current) return;
         // Only create aggregated blocks rather than individual done events
         // Remove old event log storage to keep the interface clean
-        localStorage.setItem(
-          'calendarEvents',
-          JSON.stringify(
-            (JSON.parse(localStorage.getItem('calendarEvents') || '[]') || []).filter(
-              (e) => e && (e.kind === 'planned')
-            )
-          )
-        );
+        const sanitizedEvents = (() => {
+          try {
+            const parsed = JSON.parse(localStorage.getItem('calendarEvents') || '[]');
+            if (!Array.isArray(parsed)) return [];
+            return parsed.filter(
+              (event) =>
+                event &&
+                event.start &&
+                event.end &&
+                typeof event.title === 'string' &&
+                event.title.trim() !== ''
+            );
+          } catch (error) {
+            console.error('Failed to sanitize stored calendar events', error);
+            return [];
+          }
+        })();
+
+        localStorage.setItem('calendarEvents', JSON.stringify(sanitizedEvents));
 
         const blockStart = roundSlot(data.start);
         const blockEnd = new Date(blockStart.getTime() + 30 * 60000);

--- a/src/Calendar.jsx
+++ b/src/Calendar.jsx
@@ -10,6 +10,7 @@ import BlockModal from "./BlockModal.jsx";
 
 const localizer = momentLocalizer(moment);
 const DnDCalendar = withDragAndDrop(RBCalendar);
+const ACTIVE_EVENT_KIND = "active";
 
 function CalendarEvent({ event, onDelete, onMarkDone }) {
   return (
@@ -64,7 +65,74 @@ export default function Calendar({
     return d;
   };
 
-  const [events, setEvents] = useState(() => {
+  const hydrateEvent = (event) => {
+    if (!event || !event.start || !event.end) {
+      return null;
+    }
+
+    const start = new Date(event.start);
+    const end = new Date(event.end);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+      return null;
+    }
+
+    const kind = event.kind || "planned";
+    let adjustedEnd = end;
+    if (kind === ACTIVE_EVENT_KIND) {
+      const now = new Date();
+      if (!Number.isNaN(now.getTime()) && now.getTime() > start.getTime()) {
+        if (now.getTime() > adjustedEnd.getTime()) {
+          adjustedEnd = now;
+        }
+      }
+    }
+
+    return {
+      ...event,
+      start,
+      end: adjustedEnd,
+      kind,
+    };
+  };
+
+  const serializeEvents = (list) =>
+    [...list]
+      .map((event) => ({
+        id: event.id ?? null,
+        title: event.title,
+        start:
+          event.start instanceof Date
+            ? event.start.getTime()
+            : new Date(event.start).getTime(),
+        end:
+          event.end instanceof Date
+            ? event.end.getTime()
+            : new Date(event.end).getTime(),
+        kind: event.kind || "planned",
+        color: event.color || "",
+      }))
+      .sort((a, b) => {
+        if (a.id != null && b.id != null && a.id !== b.id) {
+          return String(a.id).localeCompare(String(b.id));
+        }
+        if (a.start !== b.start) return a.start - b.start;
+        if (a.end !== b.end) return a.end - b.end;
+        if (a.title !== b.title) return a.title.localeCompare(b.title);
+        if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
+        return a.color.localeCompare(b.color);
+      });
+
+  const eventsAreEqual = (prev, next) => {
+    if (prev.length !== next.length) {
+      return false;
+    }
+    return (
+      JSON.stringify(serializeEvents(prev)) ===
+      JSON.stringify(serializeEvents(next))
+    );
+  };
+
+  const parseStoredEvents = () => {
     const stored = localStorage.getItem("calendarEvents");
     if (!stored) return [];
     try {
@@ -77,16 +145,14 @@ export default function Calendar({
             typeof e.title === "string" &&
             e.title.trim() !== ""
         )
-        .map((e) => ({
-          ...e,
-          start: new Date(e.start),
-          end: new Date(e.end),
-          kind: e.kind || "planned",
-        }));
+        .map(hydrateEvent)
+        .filter(Boolean);
     } catch {
       return [];
     }
-  });
+  };
+
+  const [events, setEvents] = useState(() => parseStoredEvents());
   const [blocks, setBlocks] = useState(() => {
     const stored = localStorage.getItem('calendarBlocks');
     if (!stored) return [];
@@ -116,19 +182,78 @@ export default function Calendar({
 
   useEffect(() => {
     const handleAdd = (e) => {
-      const ev = e.detail;
-      setEvents((prev) => [
-        ...prev,
-        {
-          ...ev,
-          start: new Date(ev.start),
-          end: new Date(ev.end),
-          kind: ev.kind || "planned",
-        },
-      ]);
+      const incoming = hydrateEvent(e.detail);
+      if (!incoming) {
+        return;
+      }
+
+      setEvents((prev) => {
+        const byIdIndex =
+          incoming.id != null
+            ? prev.findIndex((event) => event.id === incoming.id)
+            : -1;
+        if (byIdIndex !== -1) {
+          const updated = [...prev];
+          updated[byIdIndex] = { ...prev[byIdIndex], ...incoming };
+          return updated;
+        }
+
+        const fallbackIndex = prev.findIndex(
+          (event) =>
+            event.title === incoming.title &&
+            event.start.getTime() === incoming.start.getTime() &&
+            event.end.getTime() === incoming.end.getTime() &&
+            (event.kind || "planned") === incoming.kind
+        );
+
+        if (fallbackIndex !== -1) {
+          const updated = [...prev];
+          updated[fallbackIndex] = { ...prev[fallbackIndex], ...incoming };
+          return updated;
+        }
+
+        return [...prev, incoming];
+      });
     };
     window.addEventListener("calendar-add-event", handleAdd);
     return () => window.removeEventListener("calendar-add-event", handleAdd);
+  }, []);
+
+  useEffect(() => {
+    const handleUpdated = () => {
+      setEvents((prev) => {
+        const parsed = parseStoredEvents();
+        if (eventsAreEqual(prev, parsed)) {
+          return prev;
+        }
+        return parsed;
+      });
+    };
+    window.addEventListener('calendar-updated', handleUpdated);
+    return () => window.removeEventListener('calendar-updated', handleUpdated);
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setEvents((prev) =>
+        prev.map((event) => {
+          if ((event.kind || 'planned') !== ACTIVE_EVENT_KIND) {
+            return event;
+          }
+          const now = new Date();
+          if (
+            Number.isNaN(now.getTime()) ||
+            now.getTime() <= event.start.getTime() ||
+            now.getTime() - event.end.getTime() < 30000
+          ) {
+            return event;
+          }
+          return { ...event, end: now };
+        })
+      );
+    }, 30000);
+
+    return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {
@@ -250,6 +375,12 @@ export default function Calendar({
     if (event.kind === "done") {
       return {
         className: "done-event",
+        style: { ...base, left: "50%", width: "50%" },
+      };
+    }
+    if (event.kind === ACTIVE_EVENT_KIND) {
+      return {
+        className: "done-event active-event",
         style: { ...base, left: "50%", width: "50%" },
       };
     }


### PR DESCRIPTION
## Summary
- sync running ActivityLog sessions into calendar storage with stable identifiers and active blocks
- update the calendar component to hydrate, merge, and refresh active events so in-progress sessions stretch to the current time
- extend ActivityLog and Calendar unit tests to cover active-session persistence and rendering

## Testing
- npm test -- ActivityLog.test.js
- npm test -- Calendar.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f777cb19b8832292d2c7abf77d84d5