### PR TITLE
Add Tips app for capturing advice with media

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ import ActivityLog from './ActivityLog.jsx';
 import Orb from '../Orb.jsx';
 import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
+import Tips from './Tips.jsx';
 import CharacterEvolve from './CharacterEvolve.jsx';
 import Weakness from './Weakness.jsx';
 import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
@@ -91,6 +92,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   const [showAccessLog, setShowAccessLog] = useState(false);
   const [showIdeaBoard, setShowIdeaBoard] = useState(false);
   const [showImplementationIdeas, setShowImplementationIdeas] = useState(false);
+  const [showTips, setShowTips] = useState(false);
   const [showOrb, setShowOrb] = useState(false);
   const [showWatchdog, setShowWatchdog] = useState(false);
   const [showAkashicRecords, setShowAkashicRecords] = useState(false);
@@ -131,6 +133,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       accessLog: 'Semi-Formless',
       ideaBoard: 'Form',
       implementationIdeas: 'Form',
+      tips: 'Form',
       orb: 'Form',
       watchdog: 'Form',
     };
@@ -205,6 +208,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showSemiCharacter ||
     showIdeaBoard ||
     showImplementationIdeas ||
+    showTips ||
     showOrb ||
     showWatchdog ||
     showToolsBlog ||
@@ -239,6 +243,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     setShowSemiCharacter(false);
     setShowIdeaBoard(false);
     setShowImplementationIdeas(false);
+    setShowTips(false);
     setShowOrb(false);
     setShowWatchdog(false);
     setShowToolsBlog(false);
@@ -725,6 +730,8 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
               <IdeaBoard onBack={() => setShowIdeaBoard(false)} />
             ) : showImplementationIdeas ? (
               <ImplementationIdeas onBack={() => setShowImplementationIdeas(false)} />
+            ) : showTips ? (
+              <Tips onBack={() => setShowTips(false)} />
             ) : showOrb ? (
               <Orb onBack={() => setShowOrb(false)} />
             ) : showWatchdog ? (
@@ -1043,6 +1050,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
                   >
                     <div className="star-icon">📑</div>
                     <span>Implementation Ideas</span>
+                  </div>
+                )}
+                {appLayers.tips === activeLayer && (
+                  <div
+                    className="app-card"
+                    onClick={() => setShowTips(true)}
+                    onContextMenu={(e) => handleContextMenu(e, 'tips')}
+                    draggable
+                    onDragStart={(e) => handleDragStart(e, 'tips')}
+                  >
+                    <div className="star-icon">💡</div>
+                    <span>Tips</span>
                   </div>
                 )}
                 {!showToolsBlog && activeLayer === 'Form' && (

--- a/src/PageRouter.jsx
+++ b/src/PageRouter.jsx
@@ -35,6 +35,7 @@ import SemiFormlessCharacter from './SemiFormlessCharacter.jsx';
 import FormlessCharacter from './FormlessCharacter.jsx';
 import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
+import Tips from './Tips.jsx';
 import Orb from './Orb.jsx';
 import Watchdog from './Watchdog.jsx';
 import Collective from './Collective.jsx';
@@ -235,6 +236,7 @@ export default function PageRouter() {
       formlessCharacter: <FormlessCharacter onBack={goBack} />,
       ideaBoard: <IdeaBoard onBack={goBack} />,
       implementationIdeas: <ImplementationIdeas onBack={goBack} />,
+      tips: <Tips onBack={goBack} />,
       orb: <Orb onBack={goBack} />,
       watchdog: <Watchdog onBack={goBack} />,
     };

--- a/src/Tips.jsx
+++ b/src/Tips.jsx
@@ -1,0 +1,307 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './placeholder-app.css';
+import './tips.css';
+
+const STORAGE_KEY = 'tipsAppEntries';
+
+const createId = () =>
+  typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export default function Tips({ onBack }) {
+  const [tips, setTips] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch (error) {
+      console.error('Failed to parse stored tips', error);
+      return [];
+    }
+  });
+  const [headline, setHeadline] = useState('');
+  const [tipText, setTipText] = useState('');
+  const [person, setPerson] = useState('');
+  const [linkInput, setLinkInput] = useState('');
+  const [links, setLinks] = useState([]);
+  const [images, setImages] = useState([]);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tips));
+  }, [tips]);
+
+  const hasFormContent = useMemo(() => {
+    return (
+      headline.trim() !== '' ||
+      tipText.trim() !== '' ||
+      person.trim() !== '' ||
+      links.length > 0 ||
+      images.length > 0
+    );
+  }, [headline, tipText, person, links, images]);
+
+  const resetForm = () => {
+    setHeadline('');
+    setTipText('');
+    setPerson('');
+    setLinkInput('');
+    setLinks([]);
+    setImages([]);
+    setErrorMessage('');
+  };
+
+  const handleAddLink = () => {
+    const trimmed = linkInput.trim();
+    if (!trimmed) {
+      return;
+    }
+    setLinks((prev) => {
+      if (prev.includes(trimmed)) {
+        return prev;
+      }
+      return [...prev, trimmed];
+    });
+    setLinkInput('');
+  };
+
+  const handleRemoveLink = (link) => {
+    setLinks((prev) => prev.filter((item) => item !== link));
+  };
+
+  const handleImageUpload = async (event) => {
+    const fileList = Array.from(event.target.files || []);
+    if (!fileList.length) return;
+
+    const readers = fileList
+      .filter((file) => file.type.startsWith('image/'))
+      .map(
+        (file) =>
+          new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () =>
+              resolve({ id: createId(), url: reader.result, name: file.name });
+            reader.onerror = () => resolve(null);
+            reader.readAsDataURL(file);
+          })
+      );
+
+    const uploaded = await Promise.all(readers);
+    setImages((prev) => [...prev, ...uploaded.filter(Boolean)]);
+    event.target.value = '';
+  };
+
+  const handleRemoveImage = (id) => {
+    setImages((prev) => prev.filter((image) => image.id !== id));
+  };
+
+  const handleSaveTip = () => {
+    if (!tipText.trim()) {
+      setErrorMessage('Write at least one helpful insight before saving.');
+      return;
+    }
+
+    const newTip = {
+      id: createId(),
+      headline: headline.trim(),
+      text: tipText.trim(),
+      person: person.trim(),
+      links: links.map((value) => value.trim()),
+      images: images.map((image) => ({ ...image })),
+      createdAt: new Date().toISOString(),
+    };
+
+    setTips((prev) => [newTip, ...prev]);
+    resetForm();
+  };
+
+  const handleDeleteTip = (id) => {
+    setTips((prev) => prev.filter((tip) => tip.id !== id));
+  };
+
+  return (
+    <div className="placeholder-app tips-app">
+      <div className="tips-header">
+        <button className="back-button" onClick={onBack}>
+          Back
+        </button>
+        <div className="tips-title-group">
+          <h2>Tips</h2>
+          <p className="tips-subtitle">
+            Capture the advice you would share, along with the people and visuals that inspire it.
+          </p>
+        </div>
+      </div>
+
+      <div className="tips-form">
+        <label className="tips-field">
+          <span>Headline (optional)</span>
+          <input
+            type="text"
+            value={headline}
+            onChange={(e) => setHeadline(e.target.value)}
+            placeholder="Summarize your tip in a few words"
+          />
+        </label>
+
+        <label className="tips-field">
+          <span>Tip</span>
+          <textarea
+            value={tipText}
+            onChange={(e) => setTipText(e.target.value)}
+            placeholder="Write the advice you would give"
+            rows={4}
+          />
+        </label>
+
+        <div className="tips-inline">
+          <label className="tips-field">
+            <span>Who is this about?</span>
+            <input
+              type="text"
+              value={person}
+              onChange={(e) => setPerson(e.target.value)}
+              placeholder="Add a name or group"
+            />
+          </label>
+
+          <label className="tips-field">
+            <span>Add a link</span>
+            <div className="tips-link-input">
+              <input
+                type="url"
+                value={linkInput}
+                placeholder="https://example.com"
+                onChange={(e) => setLinkInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAddLink();
+                  }
+                }}
+              />
+              <button type="button" className="tips-secondary-button" onClick={handleAddLink}>
+                Add link
+              </button>
+            </div>
+          </label>
+        </div>
+
+        {links.length > 0 && (
+          <ul className="tips-link-list">
+            {links.map((link) => (
+              <li key={link}>
+                <a href={link} target="_blank" rel="noopener noreferrer">
+                  {link}
+                </a>
+                <button
+                  type="button"
+                  className="tips-icon-button"
+                  onClick={() => handleRemoveLink(link)}
+                  aria-label="Remove link"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <label className="tips-field">
+          <span>Add images</span>
+          <input type="file" accept="image/*" multiple onChange={handleImageUpload} />
+        </label>
+
+        {images.length > 0 && (
+          <div className="tips-image-previews">
+            {images.map((image) => (
+              <div key={image.id} className="tips-image-preview">
+                <img src={image.url} alt={image.name || 'Attached'} />
+                <button
+                  type="button"
+                  className="tips-icon-button"
+                  onClick={() => handleRemoveImage(image.id)}
+                  aria-label="Remove image"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {errorMessage && <div className="tips-error">{errorMessage}</div>}
+
+        <div className="tips-actions">
+          <button
+            type="button"
+            className="tips-primary-button"
+            onClick={handleSaveTip}
+            disabled={!hasFormContent || !tipText.trim()}
+          >
+            Save tip
+          </button>
+          <button
+            type="button"
+            className="tips-secondary-button"
+            onClick={resetForm}
+            disabled={!hasFormContent}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div className="tips-list">
+        {tips.length === 0 ? (
+          <p className="tips-empty">No tips saved yet. Start by writing your first insight above.</p>
+        ) : (
+          tips.map((tip) => (
+            <article key={tip.id} className="tip-card">
+              <header className="tip-card-header">
+                <div>
+                  <h3>{tip.headline || 'Untitled tip'}</h3>
+                  <p className="tip-card-person">
+                    {tip.person ? `About: ${tip.person}` : 'About: Everyone'}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="tips-icon-button"
+                  onClick={() => handleDeleteTip(tip.id)}
+                  aria-label="Delete tip"
+                >
+                  Delete
+                </button>
+              </header>
+              <p className="tip-card-text">{tip.text}</p>
+              {tip.links.length > 0 && (
+                <ul className="tip-card-links">
+                  {tip.links.map((link) => (
+                    <li key={link}>
+                      <a href={link} target="_blank" rel="noopener noreferrer">
+                        {link}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {tip.images.length > 0 && (
+                <div className="tip-card-images">
+                  {tip.images.map((image) => (
+                    <img key={image.id} src={image.url} alt={image.name || 'Tip attachment'} />
+                  ))}
+                </div>
+              )}
+              <footer className="tip-card-footer">
+                <time dateTime={tip.createdAt}>
+                  {new Date(tip.createdAt).toLocaleString()}
+                </time>
+              </footer>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/tips.css
+++ b/src/tips.css
@@ -1,0 +1,358 @@
+.tips-app {
+  width: min(960px, 100%);
+  align-items: stretch;
+}
+
+.tips-header {
+  width: 100%;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.tips-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tips-title-group h2 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.tips-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.tips-form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+}
+
+.tips-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  font-size: 0.95rem;
+}
+
+.tips-field input,
+.tips-field textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tips-field input:focus,
+.tips-field textarea:focus {
+  outline: none;
+  border-color: rgba(98, 182, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(98, 182, 255, 0.2);
+}
+
+.tips-field textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.tips-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.tips-inline .tips-field {
+  flex: 1 1 260px;
+}
+
+.tips-link-input {
+  display: flex;
+  gap: 10px;
+}
+
+.tips-link-input input {
+  flex: 1;
+}
+
+.tips-link-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tips-link-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.tips-link-list a {
+  color: #9fd8ff;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.tips-link-list a:hover {
+  text-decoration: underline;
+}
+
+.tips-image-previews {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.tips-image-preview {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.tips-image-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.tips-icon-button {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 4px 6px;
+  border-radius: 6px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tips-icon-button:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.tips-icon-button:focus-visible {
+  outline: 2px solid rgba(98, 182, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.tips-primary-button,
+.tips-secondary-button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.tips-primary-button {
+  background: linear-gradient(135deg, #5b8eff, #8f7bff);
+  color: #fff;
+  box-shadow: 0 8px 16px rgba(91, 142, 255, 0.3);
+}
+
+.tips-primary-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.tips-primary-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(91, 142, 255, 0.4);
+}
+
+.tips-secondary-button {
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.tips-secondary-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.tips-secondary-button:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.tips-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.tips-error {
+  color: #ff8c8c;
+  font-size: 0.9rem;
+}
+
+.tips-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 26px;
+}
+
+.tip-card {
+  padding: 18px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
+
+.tip-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.tip-card-header h3 {
+  margin: 0;
+}
+
+.tip-card-person {
+  margin: 4px 0 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.tip-card-text {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.tip-card-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tip-card-links li {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.tip-card-links a {
+  color: #9fd8ff;
+  text-decoration: none;
+}
+
+.tip-card-links a:hover {
+  text-decoration: underline;
+}
+
+.tip-card-images {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.tip-card-images img {
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.tip-card-footer {
+  display: flex;
+  justify-content: flex-end;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.tips-empty {
+  margin: 0;
+  text-align: center;
+  padding: 24px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+}
+
+body.light-theme .tips-subtitle {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+body.light-theme .tips-form,
+body.light-theme .tip-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(0, 0, 0, 0.08);
+  color: #1f1f1f;
+}
+
+body.light-theme .tips-field input,
+body.light-theme .tips-field textarea {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(0, 0, 0, 0.12);
+  color: inherit;
+}
+
+body.light-theme .tips-link-list li,
+body.light-theme .tip-card-links li {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .tips-link-list a,
+body.light-theme .tip-card-links a {
+  color: #2155cd;
+}
+
+body.light-theme .tips-empty {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (max-width: 640px) {
+  .tips-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .tips-actions {
+    flex-direction: column;
+  }
+
+  .tips-primary-button,
+  .tips-secondary-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Tips mini-app for saving personal advice along with people, links, and image attachments
- persist tips in local storage and allow attachments management with previews and deletion
- register the Tips app throughout the launcher so it can be opened like other tools

## Testing
- `npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68f8b9b9230c8322b2973b55d6018e4d