### PR TITLE
Add desktop overlay for activity tracker

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -1,4 +1,13 @@
-const { app, BrowserWindow, Menu, ipcMain, Tray, nativeImage, globalShortcut } = require('electron');
+const {
+  app,
+  BrowserWindow,
+  Menu,
+  ipcMain,
+  Tray,
+  nativeImage,
+  globalShortcut,
+  screen,
+} = require('electron');
 const activeWindow = require('active-win');
 const path = require('path');
 const fs = require('fs');
@@ -8,6 +17,9 @@ const { spawn } = require('child_process');
 let mainWindow;
 let tray;
 let isQuitting = false;
+let activityOverlayWindow = null;
+let activityOverlayEnabled = false;
+let activityOverlayState = null;
 
 const LIBRARY_DIR_NAME = 'LibraryStorage';
 const LIBRARY_IMAGES_SUBDIR = 'images';
@@ -126,6 +138,169 @@ const findFallbackImageData = async (dir) => {
     }
   }
   return null;
+};
+
+const sanitizeOverlaySession = (session) => {
+  if (!session || typeof session !== 'object') {
+    return null;
+  }
+
+  const name = typeof session.name === 'string' ? session.name.trim() : '';
+  if (!name) {
+    return null;
+  }
+
+  const toIsoString = (value) =>
+    typeof value === 'string' && value.trim() !== '' ? value : null;
+
+  const elapsedValue = Number(session.elapsed);
+  const elapsed = Number.isFinite(elapsedValue) && elapsedValue > 0 ? elapsedValue : 0;
+
+  return {
+    id: session.id != null ? String(session.id) : null,
+    name,
+    startedAt: toIsoString(session.startedAt),
+    activeSegmentStart: toIsoString(session.activeSegmentStart),
+    elapsed,
+  };
+};
+
+const broadcastActivityOverlayEnabled = () => {
+  try {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('activity-overlay:enabled', activityOverlayEnabled);
+    }
+    if (activityOverlayWindow && !activityOverlayWindow.isDestroyed()) {
+      activityOverlayWindow.webContents.send(
+        'activity-overlay:enabled',
+        activityOverlayEnabled
+      );
+    }
+  } catch (error) {
+    console.error('Failed to broadcast overlay enabled state', error);
+  }
+};
+
+const defaultOverlayBounds = () => {
+  const width = 280;
+  const height = 160;
+  const margin = 24;
+
+  try {
+    const display = screen.getPrimaryDisplay();
+    if (!display) {
+      return { width, height, x: 120, y: 120 };
+    }
+    const workArea = display.workArea || {
+      x: display.bounds?.x || 0,
+      y: display.bounds?.y || 0,
+      width: display.bounds?.width || width,
+      height: display.bounds?.height || height,
+    };
+    const x = Math.round(workArea.x + workArea.width - width - margin);
+    const y = Math.round(workArea.y + margin);
+    return { width, height, x, y };
+  } catch (error) {
+    console.error('Failed to determine overlay bounds', error);
+    return { width, height, x: 120, y: 120 };
+  }
+};
+
+const ensureActivityOverlayWindow = () => {
+  if (activityOverlayWindow && !activityOverlayWindow.isDestroyed()) {
+    return activityOverlayWindow;
+  }
+
+  const { width, height, x, y } = defaultOverlayBounds();
+
+  activityOverlayWindow = new BrowserWindow({
+    width,
+    height,
+    x,
+    y,
+    frame: false,
+    transparent: true,
+    resizable: false,
+    movable: true,
+    skipTaskbar: true,
+    fullscreenable: false,
+    focusable: true,
+    hasShadow: false,
+    show: false,
+    backgroundColor: '#00000000',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+    },
+  });
+
+  activityOverlayWindow.setMenu(null);
+
+  if (process.platform === 'darwin') {
+    try {
+      activityOverlayWindow.setVisibleOnAllWorkspaces(true, {
+        visibleOnFullScreen: true,
+      });
+    } catch (error) {
+      console.error('Failed to mark overlay visible on all workspaces', error);
+    }
+  }
+
+  const devServerURL = process.env.VITE_DEV_SERVER_URL;
+  if (devServerURL) {
+    activityOverlayWindow.loadURL(`${devServerURL}?overlay=activity`);
+  } else {
+    activityOverlayWindow.loadFile(path.join(__dirname, 'dist/index.html'), {
+      query: { overlay: 'activity' },
+    });
+  }
+
+  activityOverlayWindow.on('closed', () => {
+    activityOverlayWindow = null;
+    if (!isQuitting && activityOverlayEnabled) {
+      activityOverlayEnabled = false;
+      broadcastActivityOverlayEnabled();
+    }
+  });
+
+  activityOverlayWindow.webContents.on('did-finish-load', () => {
+    if (!activityOverlayWindow || activityOverlayWindow.isDestroyed()) {
+      return;
+    }
+    activityOverlayWindow.webContents.send('activity-overlay:update', activityOverlayState);
+    activityOverlayWindow.webContents.send(
+      'activity-overlay:enabled',
+      activityOverlayEnabled
+    );
+  });
+
+  return activityOverlayWindow;
+};
+
+const showActivityOverlayWindow = () => {
+  const win = ensureActivityOverlayWindow();
+  if (!win) {
+    return;
+  }
+
+  try {
+    win.setAlwaysOnTop(true, 'screen-saver');
+  } catch {
+    win.setAlwaysOnTop(true);
+  }
+
+  if (typeof win.showInactive === 'function') {
+    win.showInactive();
+  } else {
+    win.show();
+  }
+};
+
+const hideActivityOverlayWindow = () => {
+  if (!activityOverlayWindow || activityOverlayWindow.isDestroyed()) {
+    return;
+  }
+  activityOverlayWindow.hide();
 };
 
 function findTrayIcon() {
@@ -906,6 +1081,35 @@ function registerGlobalShortcuts() {
     `Failed to register a global shortcut to toggle Mazed. Tried: ${tried.join(', ')}`
   );
 }
+
+ipcMain.handle('activity-overlay:set-enabled', (_event, enabled) => {
+  const next = Boolean(enabled);
+  activityOverlayEnabled = next;
+  if (next) {
+    showActivityOverlayWindow();
+  } else {
+    hideActivityOverlayWindow();
+  }
+  broadcastActivityOverlayEnabled();
+  return next;
+});
+
+ipcMain.handle('activity-overlay:get-state', () => ({
+  enabled: activityOverlayEnabled,
+  session: activityOverlayState,
+}));
+
+ipcMain.on('activity-overlay:update', (_event, payload) => {
+  try {
+    const sanitized = sanitizeOverlaySession(payload);
+    activityOverlayState = sanitized;
+    if (activityOverlayWindow && !activityOverlayWindow.isDestroyed()) {
+      activityOverlayWindow.webContents.send('activity-overlay:update', sanitized);
+    }
+  } catch (error) {
+    console.error('Failed to update activity overlay state', error);
+  }
+});
 
 ipcMain.removeHandler('set-window-size');
 ipcMain.handle('set-window-size', (_e, { width, height }) => {

--- a/main.jsx
+++ b/main.jsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import PageRouter from './PageRouter.jsx';
+import ActivityOverlay from './src/ActivityOverlay.jsx';
 
-if (window.electronAPI && window.electronAPI.setWindowSize) {
-  window.electronAPI.setWindowSize(1600, 900);
+const rootElement = document.getElementById('root');
+const root = ReactDOM.createRoot(rootElement);
+const params = new URLSearchParams(window.location.search);
+const overlayMode = params.get('overlay');
+
+if (overlayMode === 'activity') {
+  root.render(<ActivityOverlay />);
+} else {
+  if (window.electronAPI && window.electronAPI.setWindowSize) {
+    window.electronAPI.setWindowSize(1600, 900);
+  }
+  root.render(<PageRouter />);
 }
-
-ReactDOM.createRoot(document.getElementById('root')).render(<PageRouter />);

--- a/preload.js
+++ b/preload.js
@@ -16,6 +16,28 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('library-save-image', { id, dataUrl, mimeType }),
   loadLibraryImage: (id) => ipcRenderer.invoke('library-load-image', id),
   deleteLibraryImage: (id) => ipcRenderer.invoke('library-delete-image', id),
+  setActivityOverlayEnabled: (enabled) =>
+    ipcRenderer.invoke('activity-overlay:set-enabled', Boolean(enabled)),
+  updateActivityOverlay: (session) =>
+    ipcRenderer.send('activity-overlay:update', session),
+  requestActivityOverlayState: () =>
+    ipcRenderer.invoke('activity-overlay:get-state'),
+  onActivityOverlayUpdate: (callback) => {
+    if (typeof callback !== 'function') {
+      return () => {};
+    }
+    const listener = (_event, payload) => callback(payload);
+    ipcRenderer.on('activity-overlay:update', listener);
+    return () => ipcRenderer.removeListener('activity-overlay:update', listener);
+  },
+  onActivityOverlayEnabled: (callback) => {
+    if (typeof callback !== 'function') {
+      return () => {};
+    }
+    const listener = (_event, enabled) => callback(enabled);
+    ipcRenderer.on('activity-overlay:enabled', listener);
+    return () => ipcRenderer.removeListener('activity-overlay:enabled', listener);
+  },
 });
 
 /* =================================

--- a/src/ActivityLog.jsx
+++ b/src/ActivityLog.jsx
@@ -13,6 +13,7 @@ import './activity-log.css';
 const ENTRIES_KEY = 'activityLogEntries';
 const CURRENT_KEY = 'activityLogCurrent';
 const CALENDAR_EVENTS_KEY = 'calendarEvents';
+const OVERLAY_ENABLED_KEY = 'activityOverlayEnabled';
 
 const ACTIVE_EVENT_KIND = 'active';
 const DONE_EVENT_KIND = 'done';
@@ -237,6 +238,31 @@ const sanitizeSessionForBlog = (session) => {
   }
 
   return sanitizedSession;
+};
+
+const sanitizeSessionForOverlay = (session) => {
+  if (!session || typeof session !== 'object') {
+    return null;
+  }
+
+  const name = sanitizeActivityName(session.name);
+  if (!name) {
+    return null;
+  }
+
+  const elapsedValue = Number(session.elapsed);
+  const elapsed = Number.isFinite(elapsedValue) && elapsedValue > 0 ? elapsedValue : 0;
+
+  return {
+    id: buildSessionId(session),
+    name,
+    startedAt: typeof session.startedAt === 'string' ? session.startedAt : null,
+    activeSegmentStart:
+      typeof session.activeSegmentStart === 'string'
+        ? session.activeSegmentStart
+        : null,
+    elapsed,
+  };
 };
 
 const safeSanitizeBlogPostRecord = (post) => {
@@ -640,11 +666,39 @@ export default function ActivityLog({ onBack }) {
   const [isAddingActivity, setIsAddingActivity] = useState(false);
   const [newActivityName, setNewActivityName] = useState('');
   const [tick, setTick] = useState(() => Date.now());
+  const [overlayEnabled, setOverlayEnabled] = useState(() => {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return false;
+    }
+    try {
+      return window.localStorage.getItem(OVERLAY_ENABLED_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+  const overlaySupported =
+    typeof window !== 'undefined' &&
+    Boolean(window?.electronAPI?.setActivityOverlayEnabled);
   const lastCalendarSyncRef = useRef(null);
 
   const refreshActivityOptions = useCallback(() => {
     setActivityOptions(buildOptionsFromStorage());
   }, [buildOptionsFromStorage]);
+
+  const notifyOverlay = useCallback(
+    (session) => {
+      if (!window?.electronAPI?.updateActivityOverlay) {
+        return;
+      }
+      try {
+        const payload = sanitizeSessionForOverlay(session);
+        window.electronAPI.updateActivityOverlay(payload);
+      } catch (error) {
+        console.error('Failed to notify desktop overlay', error);
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     const id = setInterval(() => setTick(Date.now()), 1000);
@@ -694,6 +748,10 @@ export default function ActivityLog({ onBack }) {
       console.error('Failed to persist current activity session', error);
     }
   }, [current]);
+
+  useEffect(() => {
+    notifyOverlay(current);
+  }, [current, notifyOverlay]);
 
   useEffect(() => {
     if (!current) {
@@ -759,6 +817,44 @@ export default function ActivityLog({ onBack }) {
       window.removeEventListener('storage', handleStorage);
     };
   }, [buildOptionsFromStorage]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      try {
+        window.localStorage.setItem(
+          OVERLAY_ENABLED_KEY,
+          overlayEnabled ? 'true' : 'false'
+        );
+      } catch (error) {
+        console.error('Failed to persist overlay preference', error);
+      }
+    }
+
+    if (overlaySupported && window.electronAPI?.setActivityOverlayEnabled) {
+      try {
+        window.electronAPI.setActivityOverlayEnabled(overlayEnabled);
+      } catch (error) {
+        console.error('Failed to toggle desktop overlay', error);
+      }
+    }
+  }, [overlayEnabled, overlaySupported]);
+
+  useEffect(() => {
+    if (!overlaySupported || !window.electronAPI?.onActivityOverlayEnabled) {
+      return undefined;
+    }
+    const unsubscribe = window.electronAPI.onActivityOverlayEnabled((enabled) => {
+      setOverlayEnabled((prev) => {
+        const next = Boolean(enabled);
+        return prev === next ? prev : next;
+      });
+    });
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, [overlaySupported]);
 
   useEffect(() => {
     const sanitizedCurrent = sanitizeActivityName(activityName);
@@ -961,6 +1057,10 @@ export default function ActivityLog({ onBack }) {
     setNewActivityName('');
   };
 
+  const handleToggleOverlay = () => {
+    setOverlayEnabled((prev) => !prev);
+  };
+
   return (
     <div className="placeholder-app activity-log">
       <button className="back-button" onClick={onBack}>
@@ -981,8 +1081,20 @@ export default function ActivityLog({ onBack }) {
             )}
           </p>
         </div>
-        <div className="current-activity-time">
-          {formatDuration(currentElapsed)}
+        <div className="current-activity-actions">
+          <div className="current-activity-time">
+            {formatDuration(currentElapsed)}
+          </div>
+          {overlaySupported ? (
+            <button
+              type="button"
+              className={`overlay-toggle-button ${overlayEnabled ? 'active' : ''}`}
+              onClick={handleToggleOverlay}
+              aria-pressed={overlayEnabled}
+            >
+              {overlayEnabled ? 'Hide desktop overlay' : 'Show desktop overlay'}
+            </button>
+          ) : null}
         </div>
       </div>
 

--- a/src/ActivityOverlay.jsx
+++ b/src/ActivityOverlay.jsx
@@ -1,0 +1,213 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './activity-overlay.css';
+
+const OVERLAY_ENABLED_KEY = 'activityOverlayEnabled';
+const CURRENT_SESSION_KEY = 'activityLogCurrent';
+
+const sanitizeOverlaySession = (session) => {
+  if (!session || typeof session !== 'object') {
+    return null;
+  }
+
+  const name = typeof session.name === 'string' ? session.name.trim() : '';
+  if (!name) {
+    return null;
+  }
+
+  const parseDate = (value) =>
+    typeof value === 'string' && value.trim() !== '' ? value : null;
+
+  const elapsedValue = Number(session.elapsed);
+  const elapsed = Number.isFinite(elapsedValue) && elapsedValue > 0 ? elapsedValue : 0;
+
+  return {
+    id: session.id != null ? String(session.id) : null,
+    name,
+    startedAt: parseDate(session.startedAt),
+    activeSegmentStart: parseDate(session.activeSegmentStart),
+    elapsed,
+  };
+};
+
+const readStoredSession = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(CURRENT_SESSION_KEY);
+    if (!raw) {
+      return null;
+    }
+    return sanitizeOverlaySession(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+};
+
+const computeElapsed = (session, nowMs) => {
+  if (!session) {
+    return 0;
+  }
+  const base = Number.isFinite(session.elapsed) ? session.elapsed : 0;
+  if (!session.activeSegmentStart) {
+    return base;
+  }
+  const startMs = new Date(session.activeSegmentStart).getTime();
+  if (Number.isNaN(startMs) || nowMs <= startMs) {
+    return base;
+  }
+  return base + (nowMs - startMs);
+};
+
+const formatDuration = (ms) => {
+  if (!ms || ms <= 0) {
+    return '0m 00s';
+  }
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  parts.push(`${hours > 0 ? String(minutes).padStart(2, '0') : minutes}m`);
+  parts.push(String(seconds).padStart(2, '0') + 's');
+  return parts.join(' ');
+};
+
+const formatStartTime = (value) => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+};
+
+export default function ActivityOverlay() {
+  const [session, setSession] = useState(() => readStoredSession());
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    document.body.classList.add('activity-overlay-body');
+    return () => {
+      document.body.classList.remove('activity-overlay-body');
+    };
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (!window || !window.addEventListener) {
+      return undefined;
+    }
+    const handleStorage = (event) => {
+      if (event && event.key && event.key !== CURRENT_SESSION_KEY) {
+        return;
+      }
+      setSession(readStoredSession());
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    if (window.electronAPI?.requestActivityOverlayState) {
+      window.electronAPI
+        .requestActivityOverlayState()
+        .then((state) => {
+          if (disposed) return;
+          if (state && state.session) {
+            setSession(sanitizeOverlaySession(state.session));
+          } else {
+            setSession(null);
+          }
+        })
+        .catch(() => {
+          if (!disposed) {
+            setSession((prev) => prev);
+          }
+        });
+    }
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!window.electronAPI?.onActivityOverlayUpdate) {
+      return undefined;
+    }
+    const unsubscribe = window.electronAPI.onActivityOverlayUpdate((next) => {
+      if (next) {
+        setSession(sanitizeOverlaySession(next));
+      } else {
+        setSession(null);
+      }
+    });
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, []);
+
+  const elapsed = useMemo(() => computeElapsed(session, now), [session, now]);
+  const formattedElapsed = formatDuration(elapsed);
+  const status = session
+    ? session.activeSegmentStart
+      ? 'Tracking now'
+      : 'Paused'
+    : 'Idle';
+  const startedAt = session ? formatStartTime(session.startedAt) : null;
+
+  const handleClose = () => {
+    try {
+      if (window.localStorage) {
+        window.localStorage.setItem(OVERLAY_ENABLED_KEY, 'false');
+      }
+    } catch {}
+    if (window.electronAPI?.setActivityOverlayEnabled) {
+      window.electronAPI.setActivityOverlayEnabled(false);
+    }
+  };
+
+  return (
+    <div className={`activity-overlay ${session ? '' : 'empty'}`}>
+      <div className="overlay-header">
+        <span className="overlay-title">Activity Focus</span>
+        <button
+          type="button"
+          className="overlay-close"
+          onClick={handleClose}
+          aria-label="Hide overlay"
+        >
+          ×
+        </button>
+      </div>
+      {session ? (
+        <>
+          <div className="overlay-activity">{session.name}</div>
+          <div className="overlay-timer">{formattedElapsed}</div>
+          <div className="overlay-meta">
+            <span className={`overlay-status ${status === 'Tracking now' ? 'running' : 'paused'}`}>
+              {status}
+            </span>
+            {startedAt ? <span className="overlay-start">Started {startedAt}</span> : null}
+          </div>
+        </>
+      ) : (
+        <div className="overlay-empty">No activity running</div>
+      )}
+    </div>
+  );
+}

--- a/src/activity-log.css
+++ b/src/activity-log.css
@@ -46,6 +46,43 @@
   text-shadow: 0 0 12px rgba(118, 255, 176, 0.4);
 }
 
+.current-activity-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.overlay-toggle-button {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.45);
+  color: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.overlay-toggle-button:hover {
+  border-color: rgba(118, 255, 176, 0.6);
+  color: #d7ffe8;
+  background: rgba(118, 255, 176, 0.18);
+}
+
+.overlay-toggle-button.active {
+  background: rgba(118, 255, 176, 0.28);
+  border-color: rgba(118, 255, 176, 0.65);
+  color: #d7ffe8;
+  box-shadow: 0 0 12px rgba(118, 255, 176, 0.25);
+}
+
+.overlay-toggle-button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(118, 255, 176, 0.35);
+}
+
 .pill {
   display: inline-flex;
   padding: 4px 10px;

--- a/src/activity-overlay.css
+++ b/src/activity-overlay.css
@@ -1,0 +1,129 @@
+html,
+body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  color: #f7f9ff;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+#root {
+  width: 100%;
+  height: 100%;
+}
+
+.activity-overlay-body {
+  background: transparent;
+}
+
+.activity-overlay {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(32, 36, 54, 0.82), rgba(12, 14, 24, 0.78));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(14px);
+  min-width: 220px;
+  min-height: 120px;
+}
+
+.activity-overlay.empty {
+  justify-content: space-between;
+}
+
+.overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  -webkit-app-region: drag;
+}
+
+.overlay-title {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.overlay-close {
+  -webkit-app-region: no-drag;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  cursor: pointer;
+  line-height: 1;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+}
+
+.overlay-close:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.overlay-activity {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.overlay-timer {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #7dffb8;
+  text-shadow: 0 0 18px rgba(125, 255, 184, 0.45);
+}
+
+.overlay-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: rgba(247, 249, 255, 0.7);
+}
+
+.overlay-status {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.overlay-status.running {
+  color: #0f7d3d;
+  background: rgba(125, 255, 184, 0.25);
+}
+
+.overlay-status.paused {
+  color: rgba(247, 249, 255, 0.85);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.overlay-start {
+  opacity: 0.75;
+}
+
+.overlay-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  color: rgba(247, 249, 255, 0.7);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add a dedicated activity overlay window with transparent styling and session display
- expose overlay controls through the preload bridge and ActivityLog UI so the desktop overlay can be toggled
- update the Electron main process to create, manage, and synchronize the always-on-top overlay window

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fa151114588322b12960768eb5899a