### PR TITLE
Improve activity overlay layout

### DIFF
--- a/src/ActivityOverlay.jsx
+++ b/src/ActivityOverlay.jsx
@@ -195,16 +195,24 @@ export default function ActivityOverlay() {
         </button>
       </div>
       {session ? (
-        <>
-          <div className="overlay-activity">{session.name}</div>
-          <div className="overlay-timer">{formattedElapsed}</div>
+        <div className="overlay-session">
+          <div className="overlay-section">
+            <span className="overlay-label">Activity</span>
+            <div className="overlay-activity" title={session.name}>
+              {session.name}
+            </div>
+          </div>
+          <div className="overlay-section">
+            <span className="overlay-label">Time Elapsed</span>
+            <div className="overlay-timer">{formattedElapsed}</div>
+          </div>
           <div className="overlay-meta">
             <span className={`overlay-status ${status === 'Tracking now' ? 'running' : 'paused'}`}>
               {status}
             </span>
             {startedAt ? <span className="overlay-start">Started {startedAt}</span> : null}
           </div>
-        </>
+        </div>
       ) : (
         <div className="overlay-empty">No activity running</div>
       )}

--- a/src/activity-overlay.css
+++ b/src/activity-overlay.css
@@ -7,11 +7,14 @@ body {
   background: transparent;
   color: #f7f9ff;
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 #root {
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .activity-overlay-body {
@@ -33,6 +36,7 @@ body {
   backdrop-filter: blur(14px);
   min-width: 220px;
   min-height: 120px;
+  overflow: hidden;
 }
 
 .activity-overlay.empty {
@@ -75,10 +79,32 @@ body {
   background: rgba(255, 255, 255, 0.18);
 }
 
+.overlay-session {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+  justify-content: center;
+}
+
+.overlay-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.overlay-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
 .overlay-activity {
   font-size: 1.05rem;
   font-weight: 600;
   line-height: 1.3;
+  word-break: break-word;
 }
 
 .overlay-timer {


### PR DESCRIPTION
## Summary
- restructure the desktop activity overlay to show labelled activity and elapsed time details
- center the active session content while keeping overlay metadata visible
- prevent scrollbars in the overlay window and allow long titles to wrap cleanly

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa20e319fc83228c2077e9b46e95b2