### PR TITLE
Add tip editing support to the Tips app

### DIFF
--- a/src/Tips.jsx
+++ b/src/Tips.jsx
@@ -26,6 +26,7 @@ export default function Tips({ onBack }) {
   const [links, setLinks] = useState([]);
   const [images, setImages] = useState([]);
   const [errorMessage, setErrorMessage] = useState('');
+  const [editingTipId, setEditingTipId] = useState(null);
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(tips));
@@ -49,6 +50,7 @@ export default function Tips({ onBack }) {
     setLinks([]);
     setImages([]);
     setErrorMessage('');
+    setEditingTipId(null);
   };
 
   const handleAddLink = () => {
@@ -101,23 +103,66 @@ export default function Tips({ onBack }) {
       return;
     }
 
-    const newTip = {
-      id: createId(),
-      headline: headline.trim(),
-      text: tipText.trim(),
-      person: person.trim(),
-      links: links.map((value) => value.trim()),
-      images: images.map((image) => ({ ...image })),
-      createdAt: new Date().toISOString(),
-    };
+    const normalizedLinks = links.map((value) => value.trim());
+    const normalizedImages = images.map((image) => ({ ...image }));
 
-    setTips((prev) => [newTip, ...prev]);
+    if (editingTipId) {
+      setTips((prev) =>
+        prev.map((tip) =>
+          tip.id === editingTipId
+            ? {
+                ...tip,
+                headline: headline.trim(),
+                text: tipText.trim(),
+                person: person.trim(),
+                links: normalizedLinks,
+                images: normalizedImages,
+                updatedAt: new Date().toISOString(),
+              }
+            : tip
+        )
+      );
+    } else {
+      const newTip = {
+        id: createId(),
+        headline: headline.trim(),
+        text: tipText.trim(),
+        person: person.trim(),
+        links: normalizedLinks,
+        images: normalizedImages,
+        createdAt: new Date().toISOString(),
+      };
+
+      setTips((prev) => [newTip, ...prev]);
+    }
     resetForm();
   };
 
   const handleDeleteTip = (id) => {
     setTips((prev) => prev.filter((tip) => tip.id !== id));
+    if (editingTipId === id) {
+      resetForm();
+    }
   };
+
+  const handleEditTip = (tip) => {
+    setEditingTipId(tip.id);
+    setHeadline(tip.headline || '');
+    setTipText(tip.text || '');
+    setPerson(tip.person || '');
+    setLinks(Array.isArray(tip.links) ? [...tip.links] : []);
+    setImages(
+      Array.isArray(tip.images)
+        ? tip.images.map((image) => ({
+            ...image,
+            id: image?.id || createId(),
+          }))
+        : []
+    );
+    setErrorMessage('');
+  };
+
+  const isEditing = Boolean(editingTipId);
 
   return (
     <div className="placeholder-app tips-app">
@@ -237,17 +282,17 @@ export default function Tips({ onBack }) {
             type="button"
             className="tips-primary-button"
             onClick={handleSaveTip}
-            disabled={!hasFormContent || !tipText.trim()}
+            disabled={!tipText.trim()}
           >
-            Save tip
+            {isEditing ? 'Update tip' : 'Save tip'}
           </button>
           <button
             type="button"
             className="tips-secondary-button"
             onClick={resetForm}
-            disabled={!hasFormContent}
+            disabled={!hasFormContent && !isEditing}
           >
-            Clear
+            {isEditing ? 'Cancel editing' : 'Clear'}
           </button>
         </div>
       </div>
@@ -265,14 +310,24 @@ export default function Tips({ onBack }) {
                     {tip.person ? `About: ${tip.person}` : 'About: Everyone'}
                   </p>
                 </div>
-                <button
-                  type="button"
-                  className="tips-icon-button"
-                  onClick={() => handleDeleteTip(tip.id)}
-                  aria-label="Delete tip"
-                >
-                  Delete
-                </button>
+                <div className="tip-card-actions">
+                  <button
+                    type="button"
+                    className="tips-icon-button"
+                    onClick={() => handleEditTip(tip)}
+                    aria-label="Edit tip"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    className="tips-icon-button"
+                    onClick={() => handleDeleteTip(tip.id)}
+                    aria-label="Delete tip"
+                  >
+                    Delete
+                  </button>
+                </div>
               </header>
               <p className="tip-card-text">{tip.text}</p>
               {tip.links.length > 0 && (
@@ -296,6 +351,9 @@ export default function Tips({ onBack }) {
               <footer className="tip-card-footer">
                 <time dateTime={tip.createdAt}>
                   {new Date(tip.createdAt).toLocaleString()}
+                  {tip.updatedAt
+                    ? ` · Edited ${new Date(tip.updatedAt).toLocaleString()}`
+                    : ''}
                 </time>
               </footer>
             </article>

--- a/src/tips.css
+++ b/src/tips.css
@@ -238,6 +238,11 @@
   gap: 12px;
 }
 
+.tip-card-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .tip-card-header h3 {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- allow previously saved tips to be edited by reusing the capture form
- add an Edit action next to Delete on each tip card and show when a tip was updated
- adjust styling to accommodate the new action buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa21c606b08322a384c06e9424aab0