### PR TITLE
Fix overlay entry bootstrap

### DIFF
--- a/main.jsx
+++ b/main.jsx
@@ -1,18 +1,39 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import PageRouter from './PageRouter.jsx';
-import ActivityOverlay from './src/ActivityOverlay.jsx';
 
 const rootElement = document.getElementById('root');
 const root = ReactDOM.createRoot(rootElement);
 const params = new URLSearchParams(window.location.search);
 const overlayMode = params.get('overlay');
 
-if (overlayMode === 'activity') {
+const renderOverlay = async () => {
+  const { default: ActivityOverlay } = await import('./src/ActivityOverlay.jsx');
   root.render(<ActivityOverlay />);
-} else {
+};
+
+const renderApp = async () => {
   if (window.electronAPI && window.electronAPI.setWindowSize) {
     window.electronAPI.setWindowSize(1600, 900);
   }
+  const { default: PageRouter } = await import('./PageRouter.jsx');
   root.render(<PageRouter />);
-}
+};
+
+const bootstrap = async () => {
+  try {
+    if (overlayMode === 'activity') {
+      await renderOverlay();
+    } else {
+      await renderApp();
+    }
+  } catch (error) {
+    console.error('Failed to start renderer', error);
+    root.render(
+      <div className="renderer-error">
+        <p>Failed to load Mazed. Please restart the app.</p>
+      </div>
+    );
+  }
+};
+
+bootstrap();

--- a/src/ActivityOverlay.jsx
+++ b/src/ActivityOverlay.jsx
@@ -92,9 +92,51 @@ export default function ActivityOverlay() {
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
-    document.body.classList.add('activity-overlay-body');
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const html = document.documentElement;
+    const body = document.body;
+    if (!html || !body) {
+      return undefined;
+    }
+
+    const prevHtmlOverflow = html.style.overflow;
+    const prevHtmlBackground = html.style.background;
+    const prevHtmlHeight = html.style.height;
+    const prevHtmlWidth = html.style.width;
+    const prevBodyOverflow = body.style.overflow;
+    const prevBodyBackground = body.style.background;
+    const prevBodyHeight = body.style.height;
+    const prevBodyWidth = body.style.width;
+    const prevBodyOverscroll = body.style.overscrollBehavior;
+
+    html.classList.add('activity-overlay-root');
+    body.classList.add('activity-overlay-body');
+
+    html.style.overflow = 'hidden';
+    html.style.background = 'transparent';
+    html.style.height = '100%';
+    html.style.width = '100%';
+    body.style.overflow = 'hidden';
+    body.style.background = 'transparent';
+    body.style.height = '100%';
+    body.style.width = '100%';
+    body.style.overscrollBehavior = 'none';
+
     return () => {
-      document.body.classList.remove('activity-overlay-body');
+      html.classList.remove('activity-overlay-root');
+      body.classList.remove('activity-overlay-body');
+      html.style.overflow = prevHtmlOverflow;
+      html.style.background = prevHtmlBackground;
+      html.style.height = prevHtmlHeight;
+      html.style.width = prevHtmlWidth;
+      body.style.overflow = prevBodyOverflow;
+      body.style.background = prevBodyBackground;
+      body.style.height = prevBodyHeight;
+      body.style.width = prevBodyWidth;
+      body.style.overscrollBehavior = prevBodyOverscroll;
     };
   }, []);
 
@@ -195,16 +237,24 @@ export default function ActivityOverlay() {
         </button>
       </div>
       {session ? (
-        <>
-          <div className="overlay-activity">{session.name}</div>
-          <div className="overlay-timer">{formattedElapsed}</div>
+        <div className="overlay-session">
+          <div className="overlay-section">
+            <span className="overlay-label">Activity</span>
+            <div className="overlay-activity" title={session.name}>
+              {session.name}
+            </div>
+          </div>
+          <div className="overlay-section">
+            <span className="overlay-label">Time Elapsed</span>
+            <div className="overlay-timer">{formattedElapsed}</div>
+          </div>
           <div className="overlay-meta">
             <span className={`overlay-status ${status === 'Tracking now' ? 'running' : 'paused'}`}>
               {status}
             </span>
             {startedAt ? <span className="overlay-start">Started {startedAt}</span> : null}
           </div>
-        </>
+        </div>
       ) : (
         <div className="overlay-empty">No activity running</div>
       )}

--- a/src/activity-overlay.css
+++ b/src/activity-overlay.css
@@ -1,5 +1,5 @@
-html,
-body {
+html.activity-overlay-root,
+body.activity-overlay-body {
   margin: 0;
   padding: 0;
   width: 100%;
@@ -7,15 +7,14 @@ body {
   background: transparent;
   color: #f7f9ff;
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
-#root {
+body.activity-overlay-body #root {
   width: 100%;
   height: 100%;
-}
-
-.activity-overlay-body {
-  background: transparent;
+  overflow: hidden;
 }
 
 .activity-overlay {
@@ -33,6 +32,7 @@ body {
   backdrop-filter: blur(14px);
   min-width: 220px;
   min-height: 120px;
+  overflow: hidden;
 }
 
 .activity-overlay.empty {
@@ -75,10 +75,32 @@ body {
   background: rgba(255, 255, 255, 0.18);
 }
 
+.overlay-session {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+  justify-content: center;
+}
+
+.overlay-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.overlay-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
 .overlay-activity {
   font-size: 1.05rem;
   font-weight: 600;
   line-height: 1.3;
+  word-break: break-word;
 }
 
 .overlay-timer {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,39 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import PageRouter from './PageRouter.jsx';
 
-if (window.electronAPI && window.electronAPI.setWindowSize) {
-  window.electronAPI.setWindowSize(1600, 900);
-}
+const rootElement = document.getElementById('root');
+const root = ReactDOM.createRoot(rootElement);
+const params = new URLSearchParams(window.location.search);
+const overlayMode = params.get('overlay');
 
-ReactDOM.createRoot(document.getElementById('root')).render(<PageRouter />);
+const renderOverlay = async () => {
+  const { default: ActivityOverlay } = await import('./ActivityOverlay.jsx');
+  root.render(<ActivityOverlay />);
+};
+
+const renderApp = async () => {
+  if (window.electronAPI && window.electronAPI.setWindowSize) {
+    window.electronAPI.setWindowSize(1600, 900);
+  }
+  const { default: PageRouter } = await import('./PageRouter.jsx');
+  root.render(<PageRouter />);
+};
+
+const bootstrap = async () => {
+  try {
+    if (overlayMode === 'activity') {
+      await renderOverlay();
+    } else {
+      await renderApp();
+    }
+  } catch (error) {
+    console.error('Failed to start renderer', error);
+    root.render(
+      <div className="renderer-error">
+        <p>Failed to load Mazed. Please restart the app.</p>
+      </div>
+    );
+  }
+};
+
+bootstrap();


### PR DESCRIPTION
## Summary
- update the renderer entrypoint to detect the activity overlay query parameter inside src/main.jsx
- lazy-load the overlay component so the desktop overlay window renders ActivityOverlay without pulling in the main app styles
- retain the window sizing logic exclusively for the full app bootstrap and show an error fallback if loading fails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa20e319fc83228c2077e9b46e95b2