### PR TITLE
feat: add bottom command bar

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
@@ -27,6 +27,7 @@ import ActivityLogger from './ActivityLogger.jsx';
 import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
+import BottomBar from './BottomBar.jsx';
 
 const WindowControls = () => (
   <div className="custom-titlebar">
@@ -88,6 +89,8 @@ const [sidebarIndex, setSidebarIndex] = useState(() =>
   tabs.findIndex((t) => t.label === (initialTab || tabs[0].label))
 );
 
+const toolsTabIndex = tabs.findIndex((t) => t.label === 'Tools');
+
 const anyAppOpen =
   showJournal ||
   showNofap ||
@@ -109,6 +112,54 @@ const anyAppOpen =
   showAkashicRecords ||
   showProfile ||
   showSettings;
+
+const focusLabel = useMemo(() => {
+  const focusEntries = [
+    { condition: showJournal, label: 'Quest Journal' },
+    { condition: showNofap, label: 'NoFap Calendar' },
+    { condition: showRatings, label: 'Version Ratings' },
+    { condition: showWhoAmI, label: 'Who Am I?' },
+    { condition: showMusic, label: 'Music Search' },
+    { condition: showSinging, label: 'Singing Studio' },
+    { condition: showShadowWork, label: 'Shadow Work' },
+    { condition: showCalendarApp, label: 'Calendar' },
+    { condition: showTimeline, label: 'Timeline' },
+    { condition: showTypomancy, label: 'Typomancy' },
+    { condition: showMoodtracker, label: 'Moodtracker' },
+    { condition: showAnima, label: 'Anima' },
+    { condition: showMoodQuadrantGame, label: 'Mood Quadrant' },
+    { condition: showMomentoMori, label: 'Momento Mori' },
+    { condition: showWatchdog, label: 'Watchdog' },
+    { condition: showToolsBlog, label: 'Tools Blog' },
+    { condition: showSemiFormlessWorkbench, label: 'Semi-Formless Canvas' },
+    { condition: showProfile, label: 'Profile' },
+    { condition: showSettings, label: 'Settings' },
+  ];
+
+  const match = focusEntries.find(({ condition }) => condition);
+  return match ? match.label : activeTab;
+}, [
+  activeTab,
+  showAnima,
+  showCalendarApp,
+  showJournal,
+  showMoodQuadrantGame,
+  showMoodtracker,
+  showMomentoMori,
+  showMusic,
+  showNofap,
+  showProfile,
+  showRatings,
+  showSemiFormlessWorkbench,
+  showSettings,
+  showShadowWork,
+  showSinging,
+  showTimeline,
+  showToolsBlog,
+  showTypomancy,
+  showWatchdog,
+  showWhoAmI,
+]);
 
 const closeOpenApp = () => {
   setShowJournal(false);
@@ -132,6 +183,76 @@ const closeOpenApp = () => {
   setShowProfile(false);
   setShowSettings(false);
 };
+
+const toggleAutoLog = (nextValue) => {
+  if (typeof nextValue === 'boolean') {
+    setAutoLog(nextValue);
+  } else {
+    setAutoLog((prev) => !prev);
+  }
+};
+
+const toggleTheme = () => {
+  setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+};
+
+const focusToolsTab = () => {
+  if (activeTab !== 'Tools') {
+    setActiveTab('Tools');
+  }
+  if (toolsTabIndex !== -1) {
+    setSidebarIndex(toolsTabIndex);
+  }
+};
+
+const launchTool = (setter) => {
+  focusToolsTab();
+  closeOpenApp();
+  setSelectedAppIndex(-1);
+  setter(true);
+};
+
+const openQuestJournal = () => launchTool(setShowJournal);
+const openTimeline = () => launchTool(setShowTimeline);
+const openMoodtracker = () => launchTool(setShowMoodtracker);
+
+const openSettings = () => {
+  closeOpenApp();
+  setShowSettings(true);
+  setSidebarIndex(tabs.length);
+};
+
+const openProfile = () => {
+  closeOpenApp();
+  setShowProfile(true);
+  setSidebarIndex(tabs.length + 1);
+};
+
+const openAkashicRecords = () => {
+  closeOpenApp();
+  setShowAkashicRecords(true);
+};
+
+const bottomBarQuickActions = [
+  {
+    label: 'Quest Journal',
+    icon: '📓',
+    onClick: openQuestJournal,
+    active: showJournal,
+  },
+  {
+    label: 'Timeline',
+    icon: '🕒',
+    onClick: openTimeline,
+    active: showTimeline,
+  },
+  {
+    label: 'Moodtracker',
+    icon: '😊',
+    onClick: openMoodtracker,
+    active: showMoodtracker,
+  },
+];
 
   useEffect(() => {
     localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
@@ -482,14 +603,24 @@ useEffect(() => {
         <SettingsModal
           onClose={() => setShowSettings(false)}
           autoLog={autoLog}
-          onToggleAutoLog={setAutoLog}
+          onToggleAutoLog={toggleAutoLog}
           theme={theme}
-          onToggleTheme={() =>
-            setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
-          }
-          onOpenAkashicRecords={() => setShowAkashicRecords(true)}
+          onToggleTheme={toggleTheme}
+          onOpenAkashicRecords={openAkashicRecords}
         />
       )}
+      <BottomBar
+        focusLabel={focusLabel}
+        quickActions={bottomBarQuickActions}
+        autoLog={autoLog}
+        onToggleAutoLog={toggleAutoLog}
+        theme={theme}
+        onToggleTheme={toggleTheme}
+        onOpenSettings={openSettings}
+        onOpenProfile={openProfile}
+        onOpenAkashicRecords={openAkashicRecords}
+        isAnyAppOpen={anyAppOpen}
+      />
       <VersionLabel />
       </div>
     </QuestProvider>

--- a/BottomBar.jsx
+++ b/BottomBar.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import './bottom-bar.css';
+
+export default function BottomBar({
+  focusLabel = 'Tools',
+  quickActions = [],
+  autoLog = false,
+  onToggleAutoLog = () => {},
+  theme = 'dark',
+  onToggleTheme = () => {},
+  onOpenSettings = () => {},
+  onOpenProfile = () => {},
+  onOpenAkashicRecords = () => {},
+  isAnyAppOpen = false,
+}) {
+  const actions = quickActions.filter(Boolean);
+
+  return (
+    <div className="bottom-command-bar" role="contentinfo" aria-label="Command bar">
+      <div className="bottom-command-bar__section bottom-command-bar__section--focus">
+        <div className="bottom-command-bar__label">Current Focus</div>
+        <div className="bottom-command-bar__focus" aria-live="polite">
+          {focusLabel}
+        </div>
+        <div
+          className={`bottom-command-bar__status${
+            isAnyAppOpen ? ' bottom-command-bar__status--active' : ''
+          }`}
+        >
+          {isAnyAppOpen ? 'App Active' : 'Exploring'}
+        </div>
+      </div>
+      <div className="bottom-command-bar__section bottom-command-bar__section--actions">
+        {actions.map((action) => (
+          <button
+            key={action.label}
+            type="button"
+            className={`bottom-command-bar__action${
+              action.active ? ' is-active' : ''
+            }`}
+            onClick={() => action.onClick && action.onClick()}
+            disabled={!action.onClick}
+            aria-pressed={action.active}
+            title={action.label}
+          >
+            <span className="bottom-command-bar__action-icon" aria-hidden="true">
+              {action.icon}
+            </span>
+            <span>{action.label}</span>
+          </button>
+        ))}
+      </div>
+      <div className="bottom-command-bar__section bottom-command-bar__section--toggles">
+        <button
+          type="button"
+          className="bottom-command-bar__pill"
+          onClick={onToggleAutoLog}
+        >
+          <span className="bottom-command-bar__pill-label">Auto Log</span>
+          <span className="bottom-command-bar__pill-value">{autoLog ? 'On' : 'Off'}</span>
+        </button>
+        <button
+          type="button"
+          className="bottom-command-bar__pill"
+          onClick={onToggleTheme}
+        >
+          <span className="bottom-command-bar__pill-label">Theme</span>
+          <span className="bottom-command-bar__pill-value">
+            {theme === 'dark' ? 'Dark' : 'Light'}
+          </span>
+        </button>
+      </div>
+      <div className="bottom-command-bar__section bottom-command-bar__section--secondary">
+        <button type="button" className="bottom-command-bar__ghost" onClick={onOpenSettings}>
+          Settings
+        </button>
+        <button type="button" className="bottom-command-bar__ghost" onClick={onOpenProfile}>
+          Profile
+        </button>
+        <button
+          type="button"
+          className="bottom-command-bar__ghost"
+          onClick={onOpenAkashicRecords}
+        >
+          Akashic Records
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/bottom-bar.css
+++ b/bottom-bar.css
@@ -1,0 +1,217 @@
+.bottom-command-bar {
+  position: fixed;
+  left: 110px;
+  right: 32px;
+  bottom: 28px;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  padding: 16px 24px;
+  border-radius: 22px;
+  background: rgba(17, 18, 22, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.45);
+  color: #e6e7eb;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  z-index: 950;
+  flex-wrap: wrap;
+}
+
+.bottom-command-bar__section {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.bottom-command-bar__section--focus {
+  min-width: 220px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.bottom-command-bar__section--actions {
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.bottom-command-bar__section--toggles {
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.bottom-command-bar__section--secondary {
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.bottom-command-bar__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(230, 231, 235, 0.7);
+}
+
+.bottom-command-bar__focus {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.bottom-command-bar__status {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bottom-command-bar__status--active {
+  background: rgba(46, 204, 113, 0.28);
+  color: #2ecc71;
+}
+
+.bottom-command-bar__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.bottom-command-bar__action:hover,
+.bottom-command-bar__action:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  outline: none;
+}
+
+.bottom-command-bar__action.is-active {
+  background: rgba(0, 180, 255, 0.25);
+  box-shadow: 0 0 0 1px rgba(0, 180, 255, 0.5);
+}
+
+.bottom-command-bar__action-icon {
+  font-size: 1.1rem;
+}
+
+.bottom-command-bar__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.bottom-command-bar__pill:hover,
+.bottom-command-bar__pill:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.bottom-command-bar__pill-value {
+  font-weight: 600;
+}
+
+.bottom-command-bar__ghost {
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.bottom-command-bar__ghost:hover,
+.bottom-command-bar__ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+@media (max-width: 1200px) {
+  .bottom-command-bar {
+    left: 90px;
+    right: 24px;
+  }
+}
+
+@media (max-width: 900px) {
+  .bottom-command-bar {
+    left: 80px;
+    right: 20px;
+    bottom: 20px;
+  }
+}
+
+@media (max-width: 720px) {
+  .bottom-command-bar {
+    position: static;
+    margin: 20px;
+  }
+}
+
+body.light-theme .bottom-command-bar {
+  background: rgba(255, 255, 255, 0.88);
+  border-color: rgba(17, 18, 22, 0.1);
+  color: #111;
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.2);
+}
+
+body.light-theme .bottom-command-bar__label {
+  color: rgba(17, 18, 22, 0.7);
+}
+
+body.light-theme .bottom-command-bar__status,
+body.light-theme .bottom-command-bar__pill {
+  background: rgba(17, 18, 22, 0.08);
+}
+
+body.light-theme .bottom-command-bar__status--active {
+  background: rgba(35, 145, 80, 0.22);
+  color: #239150;
+}
+
+body.light-theme .bottom-command-bar__action {
+  background: rgba(17, 18, 22, 0.08);
+}
+
+body.light-theme .bottom-command-bar__action:hover,
+body.light-theme .bottom-command-bar__action:focus-visible {
+  background: rgba(17, 18, 22, 0.16);
+}
+
+body.light-theme .bottom-command-bar__action.is-active {
+  background: rgba(76, 161, 255, 0.25);
+  box-shadow: 0 0 0 1px rgba(76, 161, 255, 0.5);
+}
+
+body.light-theme .bottom-command-bar__ghost {
+  border-color: rgba(17, 18, 22, 0.2);
+}
+
+body.light-theme .bottom-command-bar__ghost:hover,
+body.light-theme .bottom-command-bar__ghost:focus-visible {
+  background: rgba(17, 18, 22, 0.08);
+  border-color: rgba(17, 18, 22, 0.35);
+}

--- a/styles.css
+++ b/styles.css
@@ -94,6 +94,7 @@ body {
 
 .content {
   padding: 20px;
+  padding-bottom: 180px;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -296,6 +297,12 @@ body.character-page h1 {
 
 .journal-tabs button.active {
   background: #0d0e11;
+}
+
+@media (max-width: 720px) {
+  .content {
+    padding-bottom: 60px;
+  }
 }
 
 body.light-theme {


### PR DESCRIPTION
## Summary
- add a persistent BottomBar component that surfaces current focus, quick launch actions, and profile/settings controls
- wire the command bar into App state with helper actions, focus label tracking, and shared toggles for auto logging and theme
- style the command bar and adjust page padding so content clears the fixed bar across screen sizes

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68fa68b6fb04832283f2cfd789626be7