### PR TITLE
feat: surface timeline bar across quadrants

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
@@ -27,6 +27,7 @@ import ActivityLogger from './ActivityLogger.jsx';
 import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
+import TimelineBar from './TimelineBar.jsx';
 
 const WindowControls = () => (
   <div className="custom-titlebar">
@@ -88,6 +89,8 @@ const [sidebarIndex, setSidebarIndex] = useState(() =>
   tabs.findIndex((t) => t.label === (initialTab || tabs[0].label))
 );
 
+const toolsTabIndex = tabs.findIndex((t) => t.label === 'Tools');
+
 const anyAppOpen =
   showJournal ||
   showNofap ||
@@ -109,6 +112,54 @@ const anyAppOpen =
   showAkashicRecords ||
   showProfile ||
   showSettings;
+
+const focusLabel = useMemo(() => {
+  const focusEntries = [
+    { condition: showJournal, label: 'Quest Journal' },
+    { condition: showNofap, label: 'NoFap Calendar' },
+    { condition: showRatings, label: 'Version Ratings' },
+    { condition: showWhoAmI, label: 'Who Am I?' },
+    { condition: showMusic, label: 'Music Search' },
+    { condition: showSinging, label: 'Singing Studio' },
+    { condition: showShadowWork, label: 'Shadow Work' },
+    { condition: showCalendarApp, label: 'Calendar' },
+    { condition: showTimeline, label: 'Timeline' },
+    { condition: showTypomancy, label: 'Typomancy' },
+    { condition: showMoodtracker, label: 'Moodtracker' },
+    { condition: showAnima, label: 'Anima' },
+    { condition: showMoodQuadrantGame, label: 'Mood Quadrant' },
+    { condition: showMomentoMori, label: 'Momento Mori' },
+    { condition: showWatchdog, label: 'Watchdog' },
+    { condition: showToolsBlog, label: 'Tools Blog' },
+    { condition: showSemiFormlessWorkbench, label: 'Semi-Formless Canvas' },
+    { condition: showProfile, label: 'Profile' },
+    { condition: showSettings, label: 'Settings' },
+  ];
+
+  const match = focusEntries.find(({ condition }) => condition);
+  return match ? match.label : activeTab;
+}, [
+  activeTab,
+  showAnima,
+  showCalendarApp,
+  showJournal,
+  showMoodQuadrantGame,
+  showMoodtracker,
+  showMomentoMori,
+  showMusic,
+  showNofap,
+  showProfile,
+  showRatings,
+  showSemiFormlessWorkbench,
+  showSettings,
+  showShadowWork,
+  showSinging,
+  showTimeline,
+  showToolsBlog,
+  showTypomancy,
+  showWatchdog,
+  showWhoAmI,
+]);
 
 const closeOpenApp = () => {
   setShowJournal(false);
@@ -132,6 +183,76 @@ const closeOpenApp = () => {
   setShowProfile(false);
   setShowSettings(false);
 };
+
+const toggleAutoLog = (nextValue) => {
+  if (typeof nextValue === 'boolean') {
+    setAutoLog(nextValue);
+  } else {
+    setAutoLog((prev) => !prev);
+  }
+};
+
+const toggleTheme = () => {
+  setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+};
+
+const focusToolsTab = () => {
+  if (activeTab !== 'Tools') {
+    setActiveTab('Tools');
+  }
+  if (toolsTabIndex !== -1) {
+    setSidebarIndex(toolsTabIndex);
+  }
+};
+
+const launchTool = (setter) => {
+  focusToolsTab();
+  closeOpenApp();
+  setSelectedAppIndex(-1);
+  setter(true);
+};
+
+const openQuestJournal = () => launchTool(setShowJournal);
+const openTimeline = () => launchTool(setShowTimeline);
+const openMoodtracker = () => launchTool(setShowMoodtracker);
+
+const openSettings = () => {
+  closeOpenApp();
+  setShowSettings(true);
+  setSidebarIndex(tabs.length);
+};
+
+const openProfile = () => {
+  closeOpenApp();
+  setShowProfile(true);
+  setSidebarIndex(tabs.length + 1);
+};
+
+const openAkashicRecords = () => {
+  closeOpenApp();
+  setShowAkashicRecords(true);
+};
+
+const timelineQuickActions = [
+  {
+    label: 'Quest Journal',
+    icon: '📓',
+    onClick: openQuestJournal,
+    active: showJournal,
+  },
+  {
+    label: 'Timeline',
+    icon: '🕒',
+    onClick: openTimeline,
+    active: showTimeline,
+  },
+  {
+    label: 'Moodtracker',
+    icon: '😊',
+    onClick: openMoodtracker,
+    active: showMoodtracker,
+  },
+];
 
   useEffect(() => {
     localStorage.setItem('autoLog', autoLog ? 'true' : 'false');
@@ -482,14 +603,24 @@ useEffect(() => {
         <SettingsModal
           onClose={() => setShowSettings(false)}
           autoLog={autoLog}
-          onToggleAutoLog={setAutoLog}
+          onToggleAutoLog={toggleAutoLog}
           theme={theme}
-          onToggleTheme={() =>
-            setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
-          }
-          onOpenAkashicRecords={() => setShowAkashicRecords(true)}
+          onToggleTheme={toggleTheme}
+          onOpenAkashicRecords={openAkashicRecords}
         />
       )}
+      <TimelineBar
+        focusLabel={focusLabel}
+        quickActions={timelineQuickActions}
+        autoLog={autoLog}
+        onToggleAutoLog={toggleAutoLog}
+        theme={theme}
+        onToggleTheme={toggleTheme}
+        onOpenSettings={openSettings}
+        onOpenProfile={openProfile}
+        onOpenAkashicRecords={openAkashicRecords}
+        isAnyAppOpen={anyAppOpen}
+      />
       <VersionLabel />
       </div>
     </QuestProvider>

--- a/TimelineBar.jsx
+++ b/TimelineBar.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import './timeline-bar.css';
+
+export default function TimelineBar({
+  focusLabel = 'Tools',
+  quickActions = [],
+  autoLog = false,
+  onToggleAutoLog = () => {},
+  theme = 'dark',
+  onToggleTheme = () => {},
+  onOpenSettings = () => {},
+  onOpenProfile = () => {},
+  onOpenAkashicRecords = () => {},
+  isAnyAppOpen = false,
+}) {
+  const actions = quickActions.filter(Boolean);
+
+  return (
+    <div className="timeline-bar" role="contentinfo" aria-label="Timeline">
+      <div className="timeline-bar__section timeline-bar__section--focus">
+        <div className="timeline-bar__label">Current Focus</div>
+        <div className="timeline-bar__focus" aria-live="polite">
+          {focusLabel}
+        </div>
+        <div
+          className={`timeline-bar__status${
+            isAnyAppOpen ? ' timeline-bar__status--active' : ''
+          }`}
+        >
+          {isAnyAppOpen ? 'App Active' : 'Exploring'}
+        </div>
+      </div>
+      <div className="timeline-bar__section timeline-bar__section--actions">
+        {actions.map((action) => (
+          <button
+            key={action.label}
+            type="button"
+            className={`timeline-bar__action${
+              action.active ? ' is-active' : ''
+            }`}
+            onClick={() => action.onClick && action.onClick()}
+            disabled={!action.onClick}
+            aria-pressed={action.active}
+            title={action.label}
+          >
+            <span className="timeline-bar__action-icon" aria-hidden="true">
+              {action.icon}
+            </span>
+            <span>{action.label}</span>
+          </button>
+        ))}
+      </div>
+      <div className="timeline-bar__section timeline-bar__section--toggles">
+        <button
+          type="button"
+          className="timeline-bar__pill"
+          onClick={onToggleAutoLog}
+        >
+          <span className="timeline-bar__pill-label">Auto Log</span>
+          <span className="timeline-bar__pill-value">{autoLog ? 'On' : 'Off'}</span>
+        </button>
+        <button
+          type="button"
+          className="timeline-bar__pill"
+          onClick={onToggleTheme}
+        >
+          <span className="timeline-bar__pill-label">Theme</span>
+          <span className="timeline-bar__pill-value">
+            {theme === 'dark' ? 'Dark' : 'Light'}
+          </span>
+        </button>
+      </div>
+      <div className="timeline-bar__section timeline-bar__section--secondary">
+        <button type="button" className="timeline-bar__ghost" onClick={onOpenSettings}>
+          Settings
+        </button>
+        <button type="button" className="timeline-bar__ghost" onClick={onOpenProfile}>
+          Profile
+        </button>
+        <button
+          type="button"
+          className="timeline-bar__ghost"
+          onClick={onOpenAkashicRecords}
+        >
+          Akashic Records
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import './styles.css';
 import StatsQuadrant from './StatsQuadrant.jsx';
 import NofapCalendar from './NofapCalendar.jsx';
@@ -40,6 +40,7 @@ import { supabaseClient } from './supabaseClient';
 import VersionLabel from './VersionLabel.jsx';
 import { QuestProvider } from './QuestContext.jsx';
 import ActivityLogger from './ActivityLogger.jsx';
+import TimelineBar from '../TimelineBar.jsx';
 
 const placeholderImg =
   "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'50'%20height%3D'50'%3E%3Crect%20width%3D'50'%20height%3D'50'%20rx%3D'25'%20fill%3D'%23444'%2F%3E%3Ctext%20x%3D'25'%20y%3D'33'%20font-size%3D'26'%20text-anchor%3D'middle'%20fill%3D'%23aaa'%3E%3F%3C%2Ftext%3E%3C%2Fsvg%3E";
@@ -169,6 +170,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     () => localStorage.getItem('theme') || 'dark'
   );
 
+  const toggleAutoLog = (nextValue) => {
+    if (typeof nextValue === 'boolean') {
+      setAutoLog(nextValue);
+    } else {
+      setAutoLog((prev) => !prev);
+    }
+  };
+
+  const toggleTheme = () => {
+    setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  };
+
   const [selectedAppIndex, setSelectedAppIndex] = useState(-1);
   const [sidebarIndex, setSidebarIndex] = useState(() =>
     tabs.findIndex((t) => t.label === (initialTab || tabs[0].label))
@@ -215,6 +228,81 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     showAkashicRecords ||
     showProfile ||
     showSettings;
+
+  const focusLabel = useMemo(() => {
+    const focusEntries = [
+      { condition: showJournal, label: 'Quest Journal' },
+      { condition: showNofap, label: 'NoFap Calendar' },
+      { condition: showRatings, label: 'Version Ratings' },
+      { condition: showWhoAmI, label: 'Who Am I?' },
+      { condition: showMusic, label: 'Music Search' },
+      { condition: showSinging, label: 'Singing Studio' },
+      { condition: showShadowWork, label: 'Shadow Work' },
+      { condition: showCalendarApp, label: 'Calendar' },
+      { condition: showTimeline, label: 'Timeline' },
+      { condition: showTypomancy, label: 'Typomancy' },
+      { condition: showMoodtracker, label: 'Moodtracker' },
+      { condition: showMomentoMori, label: 'Momento Mori' },
+      { condition: showQuadrantComb, label: 'Quadrant Combinaisons' },
+      { condition: showTrinities, label: 'Trinities' },
+      { condition: showAnima, label: 'Anima' },
+      { condition: showBlog || showToolsBlog, label: 'Tools Blog' },
+      { condition: showLibrary, label: 'Library' },
+      { condition: showTodoGoals, label: 'Todo & Goals' },
+      { condition: showActivity, label: 'Activity' },
+      { condition: showActivityLog, label: 'Activity Log' },
+      { condition: showCharacterEvolve, label: 'Character Evolve' },
+      { condition: showWeakness, label: 'Weakness' },
+      { condition: showAccessLog, label: 'Access State Log' },
+      { condition: showSemiCharacter, label: 'Semi Character' },
+      { condition: showIdeaBoard, label: 'Idea Board' },
+      { condition: showImplementationIdeas, label: 'Implementation Ideas' },
+      { condition: showTips, label: 'Tips' },
+      { condition: showOrb, label: 'Orb' },
+      { condition: showWatchdog, label: 'Watchdog' },
+      { condition: showAkashicRecords, label: 'Akashic Records' },
+      { condition: showProfile, label: 'Profile' },
+      { condition: showSettings, label: 'Settings' },
+    ];
+
+    const match = focusEntries.find(({ condition }) => condition);
+    return match ? match.label : activeTab;
+  }, [
+    activeTab,
+    showAccessLog,
+    showActivity,
+    showActivityLog,
+    showAkashicRecords,
+    showAnima,
+    showBlog,
+    showCalendarApp,
+    showCharacterEvolve,
+    showIdeaBoard,
+    showImplementationIdeas,
+    showJournal,
+    showLibrary,
+    showMoodtracker,
+    showMomentoMori,
+    showMusic,
+    showNofap,
+    showProfile,
+    showQuadrantComb,
+    showRatings,
+    showSemiCharacter,
+    showSettings,
+    showShadowWork,
+    showSinging,
+    showTips,
+    showTimeline,
+    showTodoGoals,
+    showToolsBlog,
+    showTrinities,
+    showTypomancy,
+    showWatchdog,
+    showWeakness,
+    showWhoAmI,
+    showOrb,
+  ]);
 
   const closeOpenApp = () => {
     setShowJournal(false);
@@ -263,18 +351,24 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
     return willChange;
   };
 
+  const focusToolsTab = (layer = 'Form') => {
+    if (activeTab !== 'Tools') {
+      setActiveTab('Tools');
+    }
+    if (toolsTabIndex !== -1) {
+      setSidebarIndex(toolsTabIndex);
+    }
+    triggerElevatorToLayer(layer);
+  };
+
   const openToolsHome = () => {
-    setActiveTab('Tools');
-    setSidebarIndex(toolsTabIndex);
-    triggerElevatorToLayer('Form');
+    focusToolsTab('Form');
     closeOpenApp();
     setSelectedAppIndex(-1);
   };
 
   const openToolsBlog = () => {
-    setActiveTab('Tools');
-    setSidebarIndex(toolsTabIndex);
-    triggerElevatorToLayer('Semi-Formless');
+    focusToolsTab('Semi-Formless');
     closeOpenApp();
     setSelectedAppIndex(-1);
     window.postMessage(
@@ -284,9 +378,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
   };
 
   const openCollectiveLayer = () => {
-    setActiveTab('Tools');
-    setSidebarIndex(toolsTabIndex);
-    triggerElevatorToLayer('Formless');
+    focusToolsTab('Formless');
     closeOpenApp();
     setSelectedAppIndex(-1);
     window.postMessage(
@@ -294,6 +386,55 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
       '*'
     );
   };
+
+  const launchTool = (setter, layer = 'Form') => {
+    focusToolsTab(layer);
+    closeOpenApp();
+    setSelectedAppIndex(-1);
+    setter(true);
+  };
+
+  const openQuestJournal = () => launchTool(setShowJournal);
+  const openTimeline = () => launchTool(setShowTimeline);
+  const openMoodtracker = () => launchTool(setShowMoodtracker);
+
+  const openSettings = () => {
+    closeOpenApp();
+    setShowSettings(true);
+    setSidebarIndex(tabs.length);
+  };
+
+  const openProfile = () => {
+    closeOpenApp();
+    setShowProfile(true);
+    setSidebarIndex(tabs.length + 1);
+  };
+
+  const openAkashicRecords = () => {
+    closeOpenApp();
+    setShowAkashicRecords(true);
+  };
+
+  const timelineQuickActions = [
+    {
+      label: 'Quest Journal',
+      icon: '📓',
+      onClick: openQuestJournal,
+      active: showJournal,
+    },
+    {
+      label: 'Timeline',
+      icon: '🕒',
+      onClick: openTimeline,
+      active: showTimeline,
+    },
+    {
+      label: 'Moodtracker',
+      icon: '😊',
+      onClick: openMoodtracker,
+      active: showMoodtracker,
+    },
+  ];
 
   useEffect(() => {
     document.body.classList.toggle('light-theme', theme === 'light');
@@ -425,9 +566,9 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
           } else {
             const actionIdx = sidebarIndex - tabs.length;
             if (actionIdx === 0) {
-              setShowSettings(true);
+              openSettings();
             } else if (actionIdx === 1) {
-              setShowProfile(true);
+              openProfile();
             } else if (actionIdx === 2) {
               window.location.reload();
             }
@@ -635,10 +776,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
           <div className="bottom-buttons">
           <div
             className={`settings-button ${sidebarIndex === tabs.length ? 'selected' : ''}`}
-            onClick={() => {
-              setShowSettings(true);
-              setSidebarIndex(tabs.length);
-            }}
+            onClick={openSettings}
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M13.6006 21.0761L19.0608 17.9236C19.6437 17.5871 19.9346 17.4188 20.1465 17.1834C20.3341 16.9751 20.4759 16.7297 20.5625 16.4632C20.6602 16.1626 20.6602 15.8267 20.6602 15.1568V8.84268C20.6602 8.17277 20.6602 7.83694 20.5625 7.53638C20.4759 7.26982 20.3341 7.02428 20.1465 6.816C19.9355 6.58161 19.6453 6.41405 19.0674 6.08043L13.5996 2.92359C13.0167 2.58706 12.7259 2.41913 12.416 2.35328C12.1419 2.295 11.8584 2.295 11.5843 2.35328C11.2744 2.41914 10.9826 2.58706 10.3997 2.92359L4.93843 6.07666C4.35623 6.41279 4.06535 6.58073 3.85352 6.816C3.66597 7.02428 3.52434 7.26982 3.43773 7.53638C3.33984 7.83765 3.33984 8.17436 3.33984 8.84742V15.1524C3.33984 15.8254 3.33984 16.1619 3.43773 16.4632C3.52434 16.7297 3.66597 16.9751 3.85352 17.1834C4.06548 17.4188 4.35657 17.5871 4.93945 17.9236L10.3997 21.0761C10.9826 21.4126 11.2744 21.5806 11.5843 21.6465C11.8584 21.7047 12.1419 21.7047 12.416 21.6465C12.7259 21.5806 13.0177 21.4126 13.6006 21.0761Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
@@ -647,10 +785,7 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
           </div>
           <div
             className={`profile-button ${sidebarIndex === tabs.length + 1 ? 'selected' : ''}`}
-            onClick={() => {
-              setShowProfile(true);
-              setSidebarIndex(tabs.length + 1);
-            }}
+            onClick={openProfile}
           >
             <img className="sidebar-avatar" src={avatarUrl} alt="Profile" />
           </div>
@@ -1125,12 +1260,10 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
         <SettingsModal
           onClose={() => setShowSettings(false)}
           autoLog={autoLog}
-          onToggleAutoLog={setAutoLog}
+          onToggleAutoLog={toggleAutoLog}
           theme={theme}
-          onToggleTheme={() =>
-            setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
-          }
-          onOpenAkashicRecords={() => setShowAkashicRecords(true)}
+          onToggleTheme={toggleTheme}
+          onOpenAkashicRecords={openAkashicRecords}
           mainBg={mainBg}
           onChangeMainBg={setMainBg}
           charBg={charBg}
@@ -1156,6 +1289,18 @@ export default function QuadrantPage({ initialTab, menuBg, onChangeMenuBg }) {
           ))}
         </ul>
       )}
+      <TimelineBar
+        focusLabel={focusLabel}
+        quickActions={timelineQuickActions}
+        autoLog={autoLog}
+        onToggleAutoLog={toggleAutoLog}
+        theme={theme}
+        onToggleTheme={toggleTheme}
+        onOpenSettings={openSettings}
+        onOpenProfile={openProfile}
+        onOpenAkashicRecords={openAkashicRecords}
+        isAnyAppOpen={anyAppOpen}
+      />
       <VersionLabel />
       </div>
     </QuestProvider>

--- a/src/styles.css
+++ b/src/styles.css
@@ -239,10 +239,11 @@ body.character-page {
 
 .bottom-nav {
   position: fixed;
-  bottom: 20px;
+  bottom: 120px;
   left: 95px;
   display: flex;
   gap: 15px;
+  z-index: 960;
 }
 
 .layer-tabs {

--- a/styles.css
+++ b/styles.css
@@ -86,14 +86,16 @@ body {
 
 .bottom-nav {
   position: fixed;
-  bottom: 20px;
+  bottom: 120px;
   left: 95px;
   display: flex;
   gap: 15px;
+  z-index: 960;
 }
 
 .content {
   padding: 20px;
+  padding-bottom: 180px;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -296,6 +298,12 @@ body.character-page h1 {
 
 .journal-tabs button.active {
   background: #0d0e11;
+}
+
+@media (max-width: 720px) {
+  .content {
+    padding-bottom: 60px;
+  }
 }
 
 body.light-theme {

--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -1,0 +1,217 @@
+.timeline-bar {
+  position: fixed;
+  left: 110px;
+  right: 32px;
+  bottom: 28px;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  padding: 16px 24px;
+  border-radius: 22px;
+  background: rgba(17, 18, 22, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.45);
+  color: #e6e7eb;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  z-index: 950;
+  flex-wrap: wrap;
+}
+
+.timeline-bar__section {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.timeline-bar__section--focus {
+  min-width: 220px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.timeline-bar__section--actions {
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.timeline-bar__section--toggles {
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.timeline-bar__section--secondary {
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.timeline-bar__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(230, 231, 235, 0.7);
+}
+
+.timeline-bar__focus {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.timeline-bar__status {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.timeline-bar__status--active {
+  background: rgba(46, 204, 113, 0.28);
+  color: #2ecc71;
+}
+
+.timeline-bar__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.timeline-bar__action:hover,
+.timeline-bar__action:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  outline: none;
+}
+
+.timeline-bar__action.is-active {
+  background: rgba(0, 180, 255, 0.25);
+  box-shadow: 0 0 0 1px rgba(0, 180, 255, 0.5);
+}
+
+.timeline-bar__action-icon {
+  font-size: 1.1rem;
+}
+
+.timeline-bar__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.timeline-bar__pill:hover,
+.timeline-bar__pill:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.timeline-bar__pill-value {
+  font-weight: 600;
+}
+
+.timeline-bar__ghost {
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.timeline-bar__ghost:hover,
+.timeline-bar__ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+@media (max-width: 1200px) {
+  .timeline-bar {
+    left: 90px;
+    right: 24px;
+  }
+}
+
+@media (max-width: 900px) {
+  .timeline-bar {
+    left: 80px;
+    right: 20px;
+    bottom: 20px;
+  }
+}
+
+@media (max-width: 720px) {
+  .timeline-bar {
+    position: static;
+    margin: 20px;
+  }
+}
+
+body.light-theme .timeline-bar {
+  background: rgba(255, 255, 255, 0.88);
+  border-color: rgba(17, 18, 22, 0.1);
+  color: #111;
+  box-shadow: 0 20px 48px rgba(0, 0, 0, 0.2);
+}
+
+body.light-theme .timeline-bar__label {
+  color: rgba(17, 18, 22, 0.7);
+}
+
+body.light-theme .timeline-bar__status,
+body.light-theme .timeline-bar__pill {
+  background: rgba(17, 18, 22, 0.08);
+}
+
+body.light-theme .timeline-bar__status--active {
+  background: rgba(35, 145, 80, 0.22);
+  color: #239150;
+}
+
+body.light-theme .timeline-bar__action {
+  background: rgba(17, 18, 22, 0.08);
+}
+
+body.light-theme .timeline-bar__action:hover,
+body.light-theme .timeline-bar__action:focus-visible {
+  background: rgba(17, 18, 22, 0.16);
+}
+
+body.light-theme .timeline-bar__action.is-active {
+  background: rgba(76, 161, 255, 0.25);
+  box-shadow: 0 0 0 1px rgba(76, 161, 255, 0.5);
+}
+
+body.light-theme .timeline-bar__ghost {
+  border-color: rgba(17, 18, 22, 0.2);
+}
+
+body.light-theme .timeline-bar__ghost:hover,
+body.light-theme .timeline-bar__ghost:focus-visible {
+  background: rgba(17, 18, 22, 0.08);
+  border-color: rgba(17, 18, 22, 0.35);
+}


### PR DESCRIPTION
## Summary
- rename the bottom command component to a TimelineBar and integrate it into both QuadrantPage implementations with focus tracking and quick actions
- add dedicated timeline bar styling and reposition the existing bottom tab nav so the bar is visible across layouts
- centralize settings/profile/Akashic handlers and toggles so the new timeline control reflects app state consistently

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68fa68b6fb04832283f2cfd789626be7