### PR TITLE
Add Allignement journaling tool

### DIFF
--- a/Allignement.jsx
+++ b/Allignement.jsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import './allignement.css';
+
+const STORAGE_KEY = 'allignementEntries';
+
+const generateId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const createEntry = (overrides = {}) => ({
+  id: generateId(),
+  title: '',
+  under: '',
+  aligned: '',
+  over: '',
+  ...overrides,
+});
+
+const sanitizeEntries = (raw) => {
+  if (!Array.isArray(raw)) return [createEntry()];
+  return raw
+    .map((entry) => ({
+      ...createEntry(),
+      ...entry,
+    }))
+    .filter((entry, index, arr) =>
+      typeof entry.id === 'string' && arr.findIndex((e) => e.id === entry.id) === index
+    );
+};
+
+export default function Allignement({ onBack }) {
+  const [entries, setEntries] = useState(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (!saved) return [createEntry()];
+      return sanitizeEntries(JSON.parse(saved));
+    } catch (error) {
+      console.warn('Failed to load allignement entries:', error);
+      return [createEntry()];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    } catch (error) {
+      console.warn('Failed to persist allignement entries:', error);
+    }
+  }, [entries]);
+
+  const hasContent = useMemo(
+    () =>
+      entries.some(
+        ({ title, under, aligned, over }) =>
+          [title, under, aligned, over].some((value) => value && value.trim() !== '')
+      ),
+    [entries]
+  );
+
+  const updateEntry = (id, field, value) => {
+    setEntries((prev) =>
+      prev.map((entry) => (entry.id === id ? { ...entry, [field]: value } : entry))
+    );
+  };
+
+  const addEntry = () => {
+    setEntries((prev) => [...prev, createEntry()]);
+  };
+
+  const removeEntry = (id) => {
+    setEntries((prev) => (prev.length === 1 ? prev : prev.filter((entry) => entry.id !== id)));
+  };
+
+  const clearEntries = () => {
+    setEntries([createEntry()]);
+  };
+
+  return (
+    <div className="allignement-app">
+      <div className="allignement-header">
+        <button className="allignement-back" type="button" onClick={onBack}>
+          ← Back
+        </button>
+        <div className="allignement-title">
+          <h2>Allignement</h2>
+          <p className="allignement-subtitle">
+            Map each energy, habit, or idea across under, aligned, and over expressions.
+          </p>
+        </div>
+        <div className="allignement-controls">
+          <button type="button" onClick={addEntry} className="allignement-button">
+            + Add entry
+          </button>
+          <button
+            type="button"
+            onClick={clearEntries}
+            className="allignement-button"
+            disabled={!hasContent && entries.length === 1}
+          >
+            Clear all
+          </button>
+        </div>
+      </div>
+
+      <div className="allignement-table">
+        <div className="allignement-columns-header">
+          <span className="allignement-label">Focus</span>
+          <span className="allignement-label">Under</span>
+          <span className="allignement-label">Aligned</span>
+          <span className="allignement-label">Over</span>
+        </div>
+        {entries.map((entry) => (
+          <div key={entry.id} className="allignement-row">
+            <div className="allignement-focus">
+              <input
+                type="text"
+                value={entry.title}
+                placeholder="e.g. Sacral"
+                onChange={(event) => updateEntry(entry.id, 'title', event.target.value)}
+              />
+              <button
+                type="button"
+                className="allignement-remove"
+                onClick={() => removeEntry(entry.id)}
+                title="Remove entry"
+                disabled={entries.length === 1}
+              >
+                ✕
+              </button>
+            </div>
+            <textarea
+              value={entry.under}
+              placeholder="How it looks when it's running low"
+              onChange={(event) => updateEntry(entry.id, 'under', event.target.value)}
+            />
+            <textarea
+              value={entry.aligned}
+              placeholder="Your balanced, aligned state"
+              onChange={(event) => updateEntry(entry.id, 'aligned', event.target.value)}
+            />
+            <textarea
+              value={entry.over}
+              placeholder="What it feels like when there's too much"
+              onChange={(event) => updateEntry(entry.id, 'over', event.target.value)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/App.jsx
+++ b/App.jsx
@@ -18,6 +18,7 @@ import ToolsBlog from './src/ToolsBlog.jsx';
 import SemiFormlessWorkbench from './src/SemiFormlessWorkbench.jsx';
 import MomentoMori from './MomentoMori.jsx';
 import Watchdog from './Watchdog.jsx';
+import Allignement from './Allignement.jsx';
 import World from './World.jsx';
 import FriendsList from './FriendsList.jsx';
 import ProfileModal from './ProfileModal.jsx';
@@ -70,6 +71,7 @@ export default function QuadrantPage({ initialTab }) {
   const [showAnima, setShowAnima] = useState(false);
   const [showMoodQuadrantGame, setShowMoodQuadrantGame] = useState(false);
   const [showMomentoMori, setShowMomentoMori] = useState(false);
+  const [showAllignement, setShowAllignement] = useState(false);
   // Avoid naming clash with src/App.jsx by giving the blog state a unique name
   const [showToolsBlog, setShowToolsBlog] = useState(false);
   const [showSemiFormlessWorkbench, setShowSemiFormlessWorkbench] = useState(false);
@@ -106,6 +108,7 @@ const anyAppOpen =
   showAnima ||
   showMoodQuadrantGame ||
   showMomentoMori ||
+  showAllignement ||
   showWatchdog ||
   showToolsBlog ||
   showSemiFormlessWorkbench ||
@@ -129,6 +132,7 @@ const focusLabel = useMemo(() => {
     { condition: showAnima, label: 'Anima' },
     { condition: showMoodQuadrantGame, label: 'Mood Quadrant' },
     { condition: showMomentoMori, label: 'Momento Mori' },
+    { condition: showAllignement, label: 'Allignement' },
     { condition: showWatchdog, label: 'Watchdog' },
     { condition: showToolsBlog, label: 'Tools Blog' },
     { condition: showSemiFormlessWorkbench, label: 'Semi-Formless Canvas' },
@@ -147,6 +151,7 @@ const focusLabel = useMemo(() => {
   showMoodtracker,
   showMomentoMori,
   showMusic,
+  showAllignement,
   showNofap,
   showProfile,
   showRatings,
@@ -176,6 +181,7 @@ const closeOpenApp = () => {
   setShowAnima(false);
   setShowMoodQuadrantGame(false);
   setShowMomentoMori(false);
+  setShowAllignement(false);
   setShowWatchdog(false);
   setShowToolsBlog(false);
   setShowSemiFormlessWorkbench(false);
@@ -508,6 +514,8 @@ useEffect(() => {
               <SemiFormlessWorkbench
                 onBack={() => setShowSemiFormlessWorkbench(false)}
               />
+            ) : showAllignement ? (
+              <Allignement onBack={() => setShowAllignement(false)} />
             ) : showAnima ? (
               <Anima onBack={() => setShowAnima(false)} />
             ) : (
@@ -574,6 +582,10 @@ useEffect(() => {
                 <div className="app-card" onClick={() => setShowToolsBlog(true)}>
                   <div className="star-icon">📝</div>
                   <span>Blog</span>
+                </div>
+                <div className="app-card" onClick={() => setShowAllignement(true)}>
+                  <div className="star-icon">⚖️</div>
+                  <span>Allignement</span>
                 </div>
                 <div
                   className="app-card"

--- a/allignement.css
+++ b/allignement.css
@@ -1,0 +1,183 @@
+.allignement-app {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+  padding: 1.5rem;
+  color: var(--text-primary, #f0f0f0);
+}
+
+.allignement-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.allignement-back {
+  background: transparent;
+  border: 1px solid var(--accent, #7f7fff);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.allignement-back:hover {
+  background: var(--accent, #7f7fff);
+  color: #111;
+}
+
+.allignement-title {
+  flex: 1;
+  min-width: 200px;
+}
+
+.allignement-title h2 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.allignement-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--text-muted, rgba(240, 240, 240, 0.7));
+}
+
+.allignement-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.allignement-button {
+  background: var(--card-bg, rgba(255, 255, 255, 0.08));
+  border: 1px solid var(--accent, #7f7fff);
+  border-radius: 0.75rem;
+  padding: 0.5rem 1rem;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.allignement-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.allignement-button:not(:disabled):hover {
+  background: var(--accent, #7f7fff);
+  color: #111;
+  transform: translateY(-1px);
+}
+
+.allignement-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+}
+
+.allignement-columns-header {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) repeat(3, minmax(180px, 1fr));
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, rgba(240, 240, 240, 0.7));
+}
+
+.allignement-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) repeat(3, minmax(180px, 1fr));
+  gap: 0.75rem;
+  align-items: stretch;
+  background: var(--card-bg, rgba(255, 255, 255, 0.04));
+  border-radius: 1rem;
+  padding: 0.75rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+}
+
+.allignement-label {
+  padding: 0.25rem 0.5rem;
+}
+
+.allignement-focus {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.allignement-focus input {
+  flex: 1;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  color: inherit;
+}
+
+.allignement-focus input:focus {
+  outline: none;
+  border-color: var(--accent, #7f7fff);
+  box-shadow: 0 0 0 2px rgba(127, 127, 255, 0.2);
+}
+
+.allignement-remove {
+  background: transparent;
+  border: none;
+  color: var(--text-muted, rgba(240, 240, 240, 0.7));
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.5rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.allignement-remove:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.allignement-remove:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ff6b6b;
+}
+
+.allignement-row textarea {
+  min-height: 120px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  color: inherit;
+  resize: vertical;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.allignement-row textarea:focus {
+  outline: none;
+  border-color: var(--accent, #7f7fff);
+  box-shadow: 0 0 0 2px rgba(127, 127, 255, 0.2);
+}
+
+@media (max-width: 1100px) {
+  .allignement-columns-header {
+    display: none;
+  }
+
+  .allignement-row {
+    grid-template-columns: 1fr;
+  }
+
+  .allignement-row textarea {
+    min-height: 100px;
+  }
+
+  .allignement-focus {
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Summary
- add an Allignement tool for capturing under, aligned, and over expressions with persistent entries
- style the Allignement view with responsive layout and quick entry management controls
- hook the new tool into the Tools hub with navigation, focus tracking, and launch card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb5f924c4883228ff96e79be880313