### PR TITLE
Refine insights toggle visuals

### DIFF
--- a/TimelineBar.jsx
+++ b/TimelineBar.jsx
@@ -28,42 +28,37 @@ export default function TimelineBar({
 
   return (
     <>
-      <button
-        type="button"
-        className={`timeline-bar__panel-toggle${
-          isInsightsOpen ? ' is-open' : ''
-        }`}
-        onClick={toggleInsightsPanel}
-        aria-controls={insightsPanelId}
-        aria-expanded={isInsightsOpen}
-        aria-label={`${isInsightsOpen ? 'Hide' : 'Show'} timeline insights`}
-      >
-        <span aria-hidden="true">{isInsightsOpen ? '×' : '^'}</span>
-      </button>
-      <aside
-        id={insightsPanelId}
-        className={`timeline-insights${isInsightsOpen ? ' is-open' : ''}`}
-        role="complementary"
-        aria-label="Timeline insights"
-      >
-        <div className="timeline-insights__header">
-          <h2 className="timeline-insights__title">Insights Panel</h2>
+      <div className="timeline-bar" role="contentinfo" aria-label="Timeline">
+        <div className="timeline-bar__section timeline-bar__section--panel-toggle">
           <button
             type="button"
-            className="timeline-insights__close"
-            onClick={closeInsightsPanel}
-            aria-label="Close insights panel"
+            className={`timeline-bar__panel-toggle${
+              isInsightsOpen ? ' is-open' : ''
+            }`}
+            onClick={toggleInsightsPanel}
+            aria-controls={insightsPanelId}
+            aria-expanded={isInsightsOpen}
+            aria-label={`${isInsightsOpen ? 'Hide' : 'Show'} timeline insights`}
           >
-            ×
+            <span
+              aria-hidden="true"
+              className="timeline-bar__panel-toggle-icon"
+            >
+              {isInsightsOpen ? (
+                <svg viewBox="0 0 16 16" className="timeline-bar__panel-toggle-icon-close">
+                  <path d="M4.5 4.5l7 7M11.5 4.5l-7 7" />
+                </svg>
+              ) : (
+                <svg
+                  viewBox="0 0 16 16"
+                  className="timeline-bar__panel-toggle-icon-chevron"
+                >
+                  <path d="M6.5 4l4 4-4 4" />
+                </svg>
+              )}
+            </span>
           </button>
         </div>
-        <div className="timeline-insights__body">
-          <p className="timeline-insights__placeholder">
-            Lightweight charts and metrics will appear here.
-          </p>
-        </div>
-      </aside>
-      <div className="timeline-bar" role="contentinfo" aria-label="Timeline">
         <div className="timeline-bar__section timeline-bar__section--focus">
           <div className="timeline-bar__label">Current Focus</div>
           <div className="timeline-bar__focus" aria-live="polite">
@@ -141,6 +136,31 @@ export default function TimelineBar({
           </button>
         </div>
       </div>
+      <aside
+        id={insightsPanelId}
+        className={`timeline-insights${isInsightsOpen ? ' is-open' : ''}`}
+        role="complementary"
+        aria-label="Timeline insights"
+      >
+        <div className="timeline-insights__dialog" role="document">
+          <div className="timeline-insights__header">
+            <h2 className="timeline-insights__title">Insights Panel</h2>
+            <button
+              type="button"
+              className="timeline-insights__close"
+              onClick={closeInsightsPanel}
+              aria-label="Close insights panel"
+            >
+              ×
+            </button>
+          </div>
+          <div className="timeline-insights__body">
+            <p className="timeline-insights__placeholder">
+              Lightweight charts and metrics will appear here.
+            </p>
+          </div>
+        </div>
+      </aside>
     </>
   );
 }

--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -18,70 +18,102 @@
   flex-wrap: wrap;
 }
 
+.timeline-bar__section--panel-toggle {
+  flex: 0 0 auto;
+}
+
 .timeline-bar__panel-toggle {
-  position: fixed;
-  left: 32px;
-  bottom: 44px;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(17, 18, 22, 0.88);
+  width: 58px;
+  height: 38px;
+  border-radius: 27px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
   color: #e6e7eb;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 1.1rem;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease,
     background-color 0.2s ease, border-color 0.2s ease;
-  z-index: 960;
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
 }
 
+.timeline-bar__panel-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+
+.timeline-bar__panel-toggle-icon svg {
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  transition: transform 0.25s ease;
+}
+
+.timeline-bar__panel-toggle-icon-chevron {
+  transform: translateX(1px);
+}
+
+.timeline-bar__panel-toggle.is-open .timeline-bar__panel-toggle-icon svg {
+  transform: scale(0.96);
+}
+
 .timeline-bar__panel-toggle:hover,
 .timeline-bar__panel-toggle:focus-visible {
-  transform: translateY(-2px);
-  background: rgba(255, 255, 255, 0.16);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
   outline: none;
 }
 
 .timeline-bar__panel-toggle.is-open {
-  background: rgba(0, 180, 255, 0.3);
-  border-color: rgba(0, 180, 255, 0.6);
+  background: rgba(0, 180, 255, 0.35);
+  border-color: rgba(0, 180, 255, 0.65);
   color: #e6f7ff;
 }
 
 .timeline-insights {
   position: fixed;
-  left: 32px;
-  bottom: 120px;
-  width: 320px;
-  max-height: 420px;
-  padding: 20px;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(17, 18, 22, 0.92);
+  inset: 20px 28px 32px 118px;
+  padding: 32px;
+  background: rgba(8, 9, 12, 0.75);
   color: #e6e7eb;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  transform: translateY(16px);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+  transform: translateY(12px);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.25s ease, transform 0.25s ease;
-  z-index: 955;
+  z-index: 1200;
   display: flex;
-  flex-direction: column;
-  gap: 16px;
 }
 
 .timeline-insights.is-open {
   transform: translateY(0);
   opacity: 1;
   pointer-events: auto;
+}
+
+.timeline-insights__dialog {
+  width: 100%;
+  height: 100%;
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(17, 18, 22, 0.92);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45);
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .timeline-insights__header {
@@ -121,9 +153,9 @@
 
 .timeline-insights__body {
   flex: 1;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 16px;
-  padding: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 22px;
+  padding: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -134,6 +166,34 @@
   margin: 0;
   font-size: 0.9rem;
   color: rgba(230, 231, 235, 0.75);
+}
+
+@media (max-width: 1200px) {
+  .timeline-insights {
+    inset: 16px 20px 24px 96px;
+  }
+}
+
+@media (max-width: 900px) {
+  .timeline-insights {
+    inset: 14px;
+  }
+
+  .timeline-insights__dialog {
+    border-radius: 22px;
+    padding: 28px;
+  }
+}
+
+@media (max-width: 600px) {
+  .timeline-insights__dialog {
+    padding: 20px;
+  }
+
+  .timeline-insights__body {
+    border-radius: 16px;
+    padding: 18px;
+  }
 }
 
 .timeline-bar__section {
@@ -288,16 +348,12 @@
     margin: 20px;
   }
 
-  .timeline-bar__panel-toggle {
-    left: 20px;
-    bottom: 20px;
+  .timeline-insights {
+    padding: 16px;
   }
 
-  .timeline-insights {
-    left: 20px;
-    right: 20px;
-    width: auto;
-    bottom: 100px;
+  .timeline-insights__dialog {
+    padding: 24px;
   }
 }
 
@@ -347,14 +403,14 @@ body.light-theme .timeline-bar__ghost:focus-visible {
 }
 
 body.light-theme .timeline-bar__panel-toggle {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(17, 18, 22, 0.08);
   color: #111;
   border-color: rgba(17, 18, 22, 0.12);
 }
 
 body.light-theme .timeline-bar__panel-toggle:hover,
 body.light-theme .timeline-bar__panel-toggle:focus-visible {
-  background: rgba(17, 18, 22, 0.08);
+  background: rgba(17, 18, 22, 0.15);
 }
 
 body.light-theme .timeline-bar__panel-toggle.is-open {
@@ -363,10 +419,13 @@ body.light-theme .timeline-bar__panel-toggle.is-open {
 }
 
 body.light-theme .timeline-insights {
-  background: rgba(255, 255, 255, 0.95);
-  border-color: rgba(17, 18, 22, 0.1);
+  background: rgba(255, 255, 255, 0.9);
   color: #111;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
+}
+
+body.light-theme .timeline-insights__dialog {
+  background: rgba(255, 255, 255, 0.96);
+  color: inherit;
 }
 
 body.light-theme .timeline-insights__body {


### PR DESCRIPTION
## Summary
- restyle the insights toggle with a chevron svg for a cleaner look when closed
- inset the insights overlay so the surrounding ui remains visible while the panel is open
- soften the overlay and panel styling with rounded edges, lighter glassmorphism, and responsive spacing adjustments

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb8b4e9c708322b308bf7c3ced06e8