### PR TITLE
Prototype lightweight chart in insights panel

### DIFF
--- a/TimelineBar.jsx
+++ b/TimelineBar.jsx
@@ -1,6 +1,42 @@
 import React from 'react';
 import './timeline-bar.css';
 
+const SAMPLE_CANDLE_DATA = [
+  { time: '2024-02-01', open: 102.3, high: 104.2, low: 100.8, close: 103.6, volume: 284120 },
+  { time: '2024-02-02', open: 103.6, high: 106.4, low: 102.2, close: 105.1, volume: 321884 },
+  { time: '2024-02-05', open: 105.2, high: 108.1, low: 104.7, close: 107.4, volume: 352210 },
+  { time: '2024-02-06', open: 107.1, high: 109.2, low: 105.4, close: 106.3, volume: 298761 },
+  { time: '2024-02-07', open: 106.2, high: 108.8, low: 105.3, close: 108.4, volume: 310024 },
+  { time: '2024-02-08', open: 108.6, high: 110.2, low: 107.3, close: 109.6, volume: 287410 },
+  { time: '2024-02-09', open: 109.4, high: 112.1, low: 108.9, close: 111.3, volume: 365892 },
+  { time: '2024-02-12', open: 111.5, high: 113.8, low: 110.8, close: 113.1, volume: 342107 },
+  { time: '2024-02-13', open: 113.2, high: 114.9, low: 111.6, close: 112.4, volume: 329844 },
+  { time: '2024-02-14', open: 112.6, high: 115.2, low: 111.8, close: 114.7, volume: 347012 },
+  { time: '2024-02-15', open: 114.9, high: 117.4, low: 113.2, close: 116.8, volume: 382601 },
+  { time: '2024-02-16', open: 116.5, high: 118.2, low: 115.4, close: 117.1, volume: 295884 },
+  { time: '2024-02-20', open: 117.2, high: 119.8, low: 116.3, close: 118.9, volume: 301420 },
+  { time: '2024-02-21', open: 118.8, high: 121.6, low: 118.1, close: 120.7, volume: 344105 },
+  { time: '2024-02-22', open: 120.6, high: 123.2, low: 119.5, close: 121.4, volume: 356994 },
+  { time: '2024-02-23', open: 121.6, high: 124.8, low: 120.7, close: 123.9, volume: 402285 },
+  { time: '2024-02-26', open: 123.8, high: 126.4, low: 123.1, close: 125.2, volume: 389772 },
+  { time: '2024-02-27', open: 125.4, high: 126.8, low: 123.7, close: 124.1, volume: 310225 },
+  { time: '2024-02-28', open: 124.2, high: 125.6, low: 121.9, close: 122.3, volume: 298004 },
+  { time: '2024-02-29', open: 122.1, high: 124.7, low: 121.4, close: 124.1, volume: 276593 },
+  { time: '2024-03-01', open: 124.2, high: 127.8, low: 123.6, close: 127.1, volume: 418205 },
+  { time: '2024-03-04', open: 127.3, high: 129.2, low: 126.5, close: 128.4, volume: 352900 },
+  { time: '2024-03-05', open: 128.2, high: 130.6, low: 127.7, close: 129.5, volume: 361122 },
+  { time: '2024-03-06', open: 129.4, high: 131.8, low: 128.6, close: 130.9, volume: 339870 },
+  { time: '2024-03-07', open: 130.8, high: 133.4, low: 129.9, close: 132.6, volume: 372114 },
+  { time: '2024-03-08', open: 132.4, high: 134.9, low: 131.2, close: 134.4, volume: 398621 },
+  { time: '2024-03-11', open: 134.3, high: 136.5, low: 133.4, close: 135.2, volume: 312410 },
+  { time: '2024-03-12', open: 135.3, high: 137.8, low: 134.6, close: 137.1, volume: 328504 },
+  { time: '2024-03-13', open: 137.2, high: 139.4, low: 136.1, close: 138.6, volume: 347881 },
+  { time: '2024-03-14', open: 138.4, high: 140.2, low: 137.3, close: 139.1, volume: 318702 },
+  { time: '2024-03-15', open: 139.2, high: 141.6, low: 138.4, close: 140.8, volume: 356214 },
+];
+
+let lightweightChartsPromise;
+
 export default function TimelineBar({
   focusLabel = 'Tools',
   quickActions = [],
@@ -15,6 +51,13 @@ export default function TimelineBar({
 }) {
   const actions = quickActions.filter(Boolean);
   const [isInsightsOpen, setIsInsightsOpen] = React.useState(false);
+  const chartContainerRef = React.useRef(null);
+  const chartResourcesRef = React.useRef({
+    chart: null,
+    candleSeries: null,
+    volumeSeries: null,
+    resizeObserver: null,
+  });
 
   const toggleInsightsPanel = () => {
     setIsInsightsOpen((prev) => !prev);
@@ -26,44 +69,251 @@ export default function TimelineBar({
 
   const insightsPanelId = 'timeline-insights-panel';
 
+  React.useEffect(() => {
+    let cancelled = false;
+    let animationFrame;
+
+    const initializeChart = async () => {
+      const container = chartContainerRef.current;
+      if (!container || chartResourcesRef.current.chart) {
+        return;
+      }
+
+      if (!lightweightChartsPromise) {
+        lightweightChartsPromise = import('lightweight-charts');
+      }
+
+      const { createChart, CrosshairMode } = await lightweightChartsPromise;
+      if (cancelled) {
+        return;
+      }
+
+      const ensureDimensionsAndCreate = () => {
+        const target = chartContainerRef.current;
+        if (!target || chartResourcesRef.current.chart || cancelled) {
+          return;
+        }
+
+        const { width, height } = target.getBoundingClientRect();
+        if (!width || !height) {
+          animationFrame = requestAnimationFrame(ensureDimensionsAndCreate);
+          return;
+        }
+
+        const chart = createChart(target, {
+          width,
+          height,
+          layout: {
+            background: { color: 'transparent' },
+            textColor: '#11141c',
+          },
+          grid: {
+            vertLines: { color: 'rgba(17, 20, 28, 0.08)' },
+            horzLines: { color: 'rgba(17, 20, 28, 0.08)' },
+          },
+          crosshair: {
+            mode: CrosshairMode.Normal,
+            vertLine: { color: 'rgba(17, 102, 229, 0.35)', width: 1, style: 0 },
+            horzLine: { color: 'rgba(17, 102, 229, 0.35)', width: 1, style: 0 },
+          },
+          rightPriceScale: {
+            borderColor: 'rgba(17, 20, 28, 0.12)',
+          },
+          timeScale: {
+            borderColor: 'rgba(17, 20, 28, 0.12)',
+            rightOffset: 8,
+            barSpacing: 9,
+          },
+          localization: {
+            dateFormat: 'MMM dd',
+          },
+        });
+
+        const candleSeries = chart.addCandlestickSeries({
+          upColor: '#16a085',
+          borderUpColor: '#16a085',
+          wickUpColor: '#16a085',
+          downColor: '#e74c3c',
+          borderDownColor: '#e74c3c',
+          wickDownColor: '#e74c3c',
+          priceScaleId: 'right',
+        });
+        candleSeries.setData(
+          SAMPLE_CANDLE_DATA.map(({ volume, ...candlestick }) => candlestick)
+        );
+
+        const volumeSeries = chart.addHistogramSeries({
+          priceFormat: { type: 'volume' },
+          priceScaleId: '',
+          scaleMargins: { top: 0.8, bottom: 0 },
+        });
+        volumeSeries.setData(
+          SAMPLE_CANDLE_DATA.map((point) => ({
+            time: point.time,
+            value: point.volume,
+            color:
+              point.close >= point.open
+                ? 'rgba(39, 174, 96, 0.5)'
+                : 'rgba(192, 57, 43, 0.5)',
+          }))
+        );
+
+        chart.priceScale('right').applyOptions({
+          borderColor: 'rgba(17, 20, 28, 0.12)',
+          scaleMargins: { top: 0.08, bottom: 0.28 },
+        });
+        chart.priceScale('').applyOptions({
+          scaleMargins: { top: 0.75, bottom: 0 },
+        });
+
+        chart.timeScale().fitContent();
+
+        const resizeObserver =
+          typeof ResizeObserver !== 'undefined'
+            ? new ResizeObserver((entries) => {
+                const entry = entries[0];
+                if (!entry) return;
+                const { width: nextWidth, height: nextHeight } = entry.contentRect;
+                chart.resize(nextWidth, nextHeight);
+              })
+            : null;
+
+        if (resizeObserver) {
+          resizeObserver.observe(target);
+        }
+
+        chartResourcesRef.current = {
+          chart,
+          candleSeries,
+          volumeSeries,
+          resizeObserver,
+        };
+      };
+
+      ensureDimensionsAndCreate();
+    };
+
+    initializeChart();
+
+    return () => {
+      cancelled = true;
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+      }
+
+      const { chart, resizeObserver } = chartResourcesRef.current;
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+      if (chart) {
+        chart.remove();
+      }
+
+      chartResourcesRef.current = {
+        chart: null,
+        candleSeries: null,
+        volumeSeries: null,
+        resizeObserver: null,
+      };
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!chartResourcesRef.current.chart) {
+      return;
+    }
+
+    const isDark = theme === 'dark';
+
+    chartResourcesRef.current.chart.applyOptions({
+      layout: {
+        background: { color: 'transparent' },
+        textColor: isDark ? '#f1f3fb' : '#11141c',
+      },
+      grid: {
+        vertLines: {
+          color: isDark ? 'rgba(241, 243, 251, 0.08)' : 'rgba(17, 20, 28, 0.08)',
+        },
+        horzLines: {
+          color: isDark ? 'rgba(241, 243, 251, 0.08)' : 'rgba(17, 20, 28, 0.08)',
+        },
+      },
+      rightPriceScale: {
+        borderColor: isDark
+          ? 'rgba(241, 243, 251, 0.12)'
+          : 'rgba(17, 20, 28, 0.12)',
+      },
+      timeScale: {
+        borderColor: isDark
+          ? 'rgba(241, 243, 251, 0.12)'
+          : 'rgba(17, 20, 28, 0.12)',
+      },
+    });
+
+    chartResourcesRef.current.candleSeries.applyOptions({
+      upColor: isDark ? '#2ecc71' : '#16a085',
+      borderUpColor: isDark ? '#2ecc71' : '#16a085',
+      wickUpColor: isDark ? '#2ecc71' : '#16a085',
+      downColor: '#e74c3c',
+      borderDownColor: '#e74c3c',
+      wickDownColor: '#e74c3c',
+    });
+
+    chartResourcesRef.current.volumeSeries.setData(
+      SAMPLE_CANDLE_DATA.map((point) => ({
+        time: point.time,
+        value: point.volume,
+        color:
+          point.close >= point.open
+            ? isDark
+              ? 'rgba(46, 204, 113, 0.55)'
+              : 'rgba(39, 174, 96, 0.45)'
+            : isDark
+            ? 'rgba(231, 76, 60, 0.55)'
+            : 'rgba(192, 57, 43, 0.45)',
+      }))
+    );
+  }, [theme]);
+
+  React.useEffect(() => {
+    if (isInsightsOpen && chartResourcesRef.current.chart) {
+      chartResourcesRef.current.chart.timeScale().fitContent();
+    }
+  }, [isInsightsOpen]);
+
   return (
     <>
-      <button
-        type="button"
-        className={`timeline-bar__panel-toggle${
-          isInsightsOpen ? ' is-open' : ''
-        }`}
-        onClick={toggleInsightsPanel}
-        aria-controls={insightsPanelId}
-        aria-expanded={isInsightsOpen}
-        aria-label={`${isInsightsOpen ? 'Hide' : 'Show'} timeline insights`}
-      >
-        <span aria-hidden="true">{isInsightsOpen ? '×' : '^'}</span>
-      </button>
-      <aside
-        id={insightsPanelId}
-        className={`timeline-insights${isInsightsOpen ? ' is-open' : ''}`}
-        role="complementary"
-        aria-label="Timeline insights"
-      >
-        <div className="timeline-insights__header">
-          <h2 className="timeline-insights__title">Insights Panel</h2>
+      <div className="timeline-bar" role="contentinfo" aria-label="Timeline">
+        <div className="timeline-bar__section timeline-bar__section--panel-toggle">
           <button
             type="button"
-            className="timeline-insights__close"
-            onClick={closeInsightsPanel}
-            aria-label="Close insights panel"
+            className={`timeline-bar__panel-toggle${
+              isInsightsOpen ? ' is-open' : ''
+            }`}
+            onClick={toggleInsightsPanel}
+            aria-controls={insightsPanelId}
+            aria-expanded={isInsightsOpen}
+            aria-label={`${isInsightsOpen ? 'Hide' : 'Show'} timeline insights`}
           >
-            ×
+            <span
+              aria-hidden="true"
+              className="timeline-bar__panel-toggle-icon"
+            >
+              {isInsightsOpen ? (
+                <svg viewBox="0 0 16 16" className="timeline-bar__panel-toggle-icon-close">
+                  <path d="M4.5 4.5l7 7M11.5 4.5l-7 7" />
+                </svg>
+              ) : (
+                <svg
+                  viewBox="0 0 16 16"
+                  className="timeline-bar__panel-toggle-icon-chevron"
+                >
+                  <path d="M6.5 4l4 4-4 4" />
+                </svg>
+              )}
+            </span>
           </button>
         </div>
-        <div className="timeline-insights__body">
-          <p className="timeline-insights__placeholder">
-            Lightweight charts and metrics will appear here.
-          </p>
-        </div>
-      </aside>
-      <div className="timeline-bar" role="contentinfo" aria-label="Timeline">
         <div className="timeline-bar__section timeline-bar__section--focus">
           <div className="timeline-bar__label">Current Focus</div>
           <div className="timeline-bar__focus" aria-live="polite">
@@ -141,6 +391,43 @@ export default function TimelineBar({
           </button>
         </div>
       </div>
+      <aside
+        id={insightsPanelId}
+        className={`timeline-insights${isInsightsOpen ? ' is-open' : ''}`}
+        role="complementary"
+        aria-label="Timeline insights"
+      >
+        <div className="timeline-insights__dialog" role="document">
+          <div className="timeline-insights__header">
+            <h2 className="timeline-insights__title">Insights Panel</h2>
+            <button
+              type="button"
+              className="timeline-insights__close"
+              onClick={closeInsightsPanel}
+              aria-label="Close insights panel"
+            >
+              ×
+            </button>
+          </div>
+          <div className="timeline-insights__body">
+            <div className="timeline-insights__chart-shell">
+              <div className="timeline-insights__chart-toolbar">
+                <div className="timeline-insights__chart-symbol">BTC · USDT</div>
+                <div className="timeline-insights__chart-meta">1H · Simulated feed</div>
+              </div>
+              <div
+                className="timeline-insights__chart"
+                ref={chartContainerRef}
+                aria-hidden="true"
+              />
+            </div>
+            <p className="timeline-insights__footnote">
+              Prototype data powered by TradingView’s lightweight-charts. Live
+              account hooks will stream here next.
+            </p>
+          </div>
+        </div>
+      </aside>
     </>
   );
 }

--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -18,70 +18,135 @@
   flex-wrap: wrap;
 }
 
+.timeline-bar__section--panel-toggle {
+  flex: 0 0 auto;
+}
+
 .timeline-bar__panel-toggle {
-  position: fixed;
-  left: 32px;
-  bottom: 44px;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(17, 18, 22, 0.88);
+  width: 58px;
+  height: 38px;
+  border-radius: 27px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
   color: #e6e7eb;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 1.1rem;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease,
     background-color 0.2s ease, border-color 0.2s ease;
-  z-index: 960;
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
 }
 
+.timeline-bar__panel-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+}
+
+.timeline-bar__panel-toggle-icon svg {
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+  transition: transform 0.25s ease;
+}
+
+.timeline-bar__panel-toggle-icon-chevron {
+  transform: translateX(1px);
+}
+
+.timeline-bar__panel-toggle.is-open .timeline-bar__panel-toggle-icon svg {
+  transform: scale(0.96);
+}
+
 .timeline-bar__panel-toggle:hover,
 .timeline-bar__panel-toggle:focus-visible {
-  transform: translateY(-2px);
-  background: rgba(255, 255, 255, 0.16);
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
   outline: none;
 }
 
 .timeline-bar__panel-toggle.is-open {
-  background: rgba(0, 180, 255, 0.3);
-  border-color: rgba(0, 180, 255, 0.6);
+  background: rgba(0, 180, 255, 0.35);
+  border-color: rgba(0, 180, 255, 0.65);
   color: #e6f7ff;
 }
 
 .timeline-insights {
   position: fixed;
-  left: 32px;
-  bottom: 120px;
-  width: 320px;
-  max-height: 420px;
-  padding: 20px;
-  border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(17, 18, 22, 0.92);
-  color: #e6e7eb;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  transform: translateY(16px);
+  inset: 20px 28px 32px 118px;
+  padding: 32px;
+  background: linear-gradient(
+      120deg,
+      rgba(255, 255, 255, 0.16) 0%,
+      rgba(255, 255, 255, 0.06) 46%,
+      rgba(17, 18, 22, 0.08) 100%
+    ),
+    radial-gradient(
+      120% 120% at 0% 50%,
+      rgba(255, 255, 255, 0.24) 0%,
+      rgba(255, 255, 255, 0.08) 34%,
+      rgba(255, 255, 255, 0.02) 68%
+    ),
+    radial-gradient(
+      120% 120% at 100% 50%,
+      rgba(255, 255, 255, 0.24) 0%,
+      rgba(255, 255, 255, 0.08) 34%,
+      rgba(255, 255, 255, 0.02) 68%
+    );
+  color: #11141c;
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 18px 60px rgba(7, 10, 18, 0.18);
+  transform: translate3d(0, 18px, 0) scale(0.995);
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.25s ease, transform 0.25s ease;
-  z-index: 955;
+  transition: opacity 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+  z-index: 1200;
   display: flex;
-  flex-direction: column;
-  gap: 16px;
+  will-change: transform, opacity;
 }
 
 .timeline-insights.is-open {
-  transform: translateY(0);
+  transform: translate3d(0, 0, 0) scale(1);
   opacity: 1;
   pointer-events: auto;
+}
+
+.timeline-insights__dialog {
+  width: 100%;
+  height: 100%;
+  border-radius: 28px;
+  border: 1px solid rgba(17, 18, 22, 0.08);
+  background: linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.82),
+      rgba(255, 255, 255, 0.5)
+    ),
+    rgba(255, 255, 255, 0.38);
+  box-shadow: 0 26px 70px rgba(10, 13, 22, 0.18);
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: #11141c;
+  transform: translate3d(0, 22px, 0) scale(0.985);
+  opacity: 0;
+  transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.5s ease;
+  will-change: transform, opacity;
 }
 
 .timeline-insights__header {
@@ -91,15 +156,22 @@
   gap: 12px;
 }
 
+.timeline-insights.is-open .timeline-insights__dialog {
+  transform: translate3d(0, 0, 0) scale(1);
+  opacity: 1;
+  box-shadow: 0 36px 80px rgba(10, 13, 22, 0.24);
+}
+
 .timeline-insights__title {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
+  color: rgba(17, 20, 28, 0.78);
 }
 
 .timeline-insights__close {
   border: none;
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(17, 20, 28, 0.08);
   color: inherit;
   width: 32px;
   height: 32px;
@@ -114,26 +186,136 @@
 
 .timeline-insights__close:hover,
 .timeline-insights__close:focus-visible {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(17, 20, 28, 0.16);
   transform: translateY(-1px);
   outline: none;
 }
 
 .timeline-insights__body {
   flex: 1;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 16px;
-  padding: 16px;
+  background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.72),
+      rgba(255, 255, 255, 0.32)
+    ),
+    rgba(17, 20, 28, 0.03);
+  border-radius: 22px;
+  padding: 24px;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
+  flex-direction: column;
+  gap: 20px;
+  color: rgba(17, 20, 28, 0.7);
+  transition: background 0.6s ease;
 }
 
-.timeline-insights__placeholder {
+.timeline-insights__chart-shell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 22px 24px 20px;
+  background: linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.82),
+      rgba(255, 255, 255, 0.5)
+    ),
+    rgba(255, 255, 255, 0.38);
+  border-radius: 20px;
+  border: 1px solid rgba(17, 20, 28, 0.08);
+  box-shadow: 0 22px 45px rgba(17, 20, 28, 0.12);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  overflow: hidden;
+}
+
+.timeline-insights__chart-toolbar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: rgba(17, 20, 28, 0.55);
+}
+
+.timeline-insights__chart-symbol {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(17, 20, 28, 0.8);
+  letter-spacing: 0.02em;
+}
+
+.timeline-insights__chart-meta {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  color: rgba(17, 20, 28, 0.45);
+}
+
+.timeline-insights__chart {
+  position: relative;
+  flex: 1;
+  width: 100%;
+  min-height: 320px;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.timeline-insights__chart canvas {
+  border-radius: 16px;
+}
+
+.timeline-insights__footnote {
   margin: 0;
-  font-size: 0.9rem;
-  color: rgba(230, 231, 235, 0.75);
+  font-size: 0.75rem;
+  color: rgba(17, 20, 28, 0.5);
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 1200px) {
+  .timeline-insights {
+    inset: 16px 20px 24px 96px;
+  }
+}
+
+@media (max-width: 900px) {
+  .timeline-insights {
+    inset: 14px;
+  }
+
+  .timeline-insights__dialog {
+    border-radius: 22px;
+    padding: 28px;
+  }
+}
+
+@media (max-width: 600px) {
+  .timeline-insights__dialog {
+    padding: 20px;
+  }
+
+  .timeline-insights__body {
+    border-radius: 16px;
+    padding: 18px;
+    gap: 16px;
+  }
+
+  .timeline-insights__chart-shell {
+    padding: 16px;
+    border-radius: 16px;
+  }
+
+  .timeline-insights__chart {
+    min-height: 240px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline-insights,
+  .timeline-insights__dialog {
+    transition-duration: 0.01ms !important;
+    transition-timing-function: linear !important;
+    transform: none !important;
+  }
 }
 
 .timeline-bar__section {
@@ -288,16 +470,12 @@
     margin: 20px;
   }
 
-  .timeline-bar__panel-toggle {
-    left: 20px;
-    bottom: 20px;
+  .timeline-insights {
+    padding: 16px;
   }
 
-  .timeline-insights {
-    left: 20px;
-    right: 20px;
-    width: auto;
-    bottom: 100px;
+  .timeline-insights__dialog {
+    padding: 24px;
   }
 }
 
@@ -347,14 +525,14 @@ body.light-theme .timeline-bar__ghost:focus-visible {
 }
 
 body.light-theme .timeline-bar__panel-toggle {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(17, 18, 22, 0.08);
   color: #111;
   border-color: rgba(17, 18, 22, 0.12);
 }
 
 body.light-theme .timeline-bar__panel-toggle:hover,
 body.light-theme .timeline-bar__panel-toggle:focus-visible {
-  background: rgba(17, 18, 22, 0.08);
+  background: rgba(17, 18, 22, 0.15);
 }
 
 body.light-theme .timeline-bar__panel-toggle.is-open {
@@ -363,16 +541,46 @@ body.light-theme .timeline-bar__panel-toggle.is-open {
 }
 
 body.light-theme .timeline-insights {
-  background: rgba(255, 255, 255, 0.95);
-  border-color: rgba(17, 18, 22, 0.1);
+  background: linear-gradient(
+      120deg,
+      rgba(255, 255, 255, 0.82) 0%,
+      rgba(255, 255, 255, 0.46) 50%,
+      rgba(229, 236, 247, 0.32) 100%
+    ),
+    radial-gradient(
+      120% 120% at 0% 50%,
+      rgba(255, 255, 255, 0.68) 0%,
+      rgba(255, 255, 255, 0.24) 38%,
+      rgba(255, 255, 255, 0.08) 70%
+    ),
+    radial-gradient(
+      120% 120% at 100% 50%,
+      rgba(255, 255, 255, 0.68) 0%,
+      rgba(255, 255, 255, 0.24) 38%,
+      rgba(255, 255, 255, 0.08) 70%
+    );
   color: #111;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
+}
+
+body.light-theme .timeline-insights__dialog {
+  background: linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.97),
+      rgba(255, 255, 255, 0.76)
+    ),
+    rgba(255, 255, 255, 0.64);
+  color: inherit;
 }
 
 body.light-theme .timeline-insights__body {
-  background: rgba(17, 18, 22, 0.05);
+  background: linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.94),
+      rgba(241, 245, 253, 0.52)
+    ),
+    rgba(17, 18, 22, 0.015);
 }
 
 body.light-theme .timeline-insights__placeholder {
-  color: rgba(17, 18, 22, 0.65);
+  color: rgba(17, 18, 22, 0.55);
 }


### PR DESCRIPTION
## Summary
- embed a lightweight-charts candlestick + volume view in the insights panel and load the library lazily for smoother bundling
- restyle the insights body so the trading viewport fills the glass panel with toolbar and footnote context

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fb8b4e9c708322b308bf7c3ced06e8