### PR TITLE
Add lightweight chart to timeline insights panel

### DIFF
--- a/TimelineBar.jsx
+++ b/TimelineBar.jsx
@@ -52,6 +52,7 @@ export default function TimelineBar({
   const actions = quickActions.filter(Boolean);
   const [isInsightsOpen, setIsInsightsOpen] = React.useState(false);
   const chartContainerRef = React.useRef(null);
+  const [isChartReady, setIsChartReady] = React.useState(false);
   const chartResourcesRef = React.useRef({
     chart: null,
     candleSeries: null,
@@ -188,6 +189,10 @@ export default function TimelineBar({
           volumeSeries,
           resizeObserver,
         };
+
+        if (!cancelled) {
+          setIsChartReady(true);
+        }
       };
 
       ensureDimensionsAndCreate();
@@ -394,10 +399,22 @@ export default function TimelineBar({
             </button>
           </div>
           <div className="timeline-insights__body">
-            <p className="timeline-insights__placeholder">
-              Lightweight charts and metrics will appear here.
-            </p>
+            <div className="timeline-insights__chart" role="img" aria-label="Candle and volume chart preview">
+              <div
+                ref={chartContainerRef}
+                className="timeline-insights__chart-surface"
+                aria-hidden={isChartReady ? 'false' : 'true'}
+              />
+              {!isChartReady && (
+                <div className="timeline-insights__chart-status" role="status">
+                  Loading lightweight chart…
+                </div>
+              )}
+            </div>
           </div>
+          <p className="timeline-insights__footnote">
+            Data shown is simulated for demonstration purposes.
+          </p>
         </div>
       </aside>
     </>

--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -164,8 +164,22 @@
   border-radius: 20px;
   padding: 24px;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
+}
+
+.timeline-insights__chart {
+  position: relative;
+  flex: 1;
+  min-height: 360px;
+  max-width: 100%;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.timeline-insights__chart-surface {
+  width: 100%;
+  height: 100%;
 }
 
 .timeline-insights__chart canvas {
@@ -181,10 +195,9 @@
   padding: 0 24px;
   text-align: center;
   color: rgba(17, 20, 28, 0.78);
-}
-
-.timeline-insights__chart canvas {
-  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.72);
+  font-weight: 500;
+  letter-spacing: 0.01em;
 }
 
 .timeline-insights__footnote {
@@ -490,6 +503,7 @@ body.light-theme .timeline-insights__body {
     rgba(17, 18, 22, 0.02);
 }
 
-body.light-theme .timeline-insights__placeholder {
-  color: rgba(17, 18, 22, 0.55);
+body.light-theme .timeline-insights__chart-status {
+  background: rgba(17, 18, 22, 0.08);
+  color: rgba(17, 18, 22, 0.78);
 }


### PR DESCRIPTION
## Summary
- replace the insights panel placeholder with a live lightweight-charts candlestick/volume preview
- initialize the chart when the panel mounts and surface a loading status while waiting for rendering
- refresh the panel styling to host the chart surface across themes and maintain responsive sizing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff386cb53c8322a966b3a9d10cfa52