### PR TITLE
Embed TradingView widget in timeline insights

### DIFF
--- a/TimelineBar.jsx
+++ b/TimelineBar.jsx
@@ -51,6 +51,40 @@ const getLightweightChartsModule = async () => {
   return lightweightChartsPromise;
 };
 
+let tradingViewScriptPromise;
+const loadTradingViewScript = async () => {
+  if (typeof window === 'undefined') {
+    throw new Error('TradingView widget requires a browser environment.');
+  }
+
+  if (window.TradingView && typeof window.TradingView.widget === 'function') {
+    return window.TradingView;
+  }
+
+  if (!tradingViewScriptPromise) {
+    tradingViewScriptPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = 'https://s3.tradingview.com/tv.js';
+      script.async = true;
+      script.onload = () => {
+        if (window.TradingView && typeof window.TradingView.widget === 'function') {
+          resolve(window.TradingView);
+        } else {
+          tradingViewScriptPromise = null;
+          reject(new Error('TradingView widget unavailable after script load.'));
+        }
+      };
+      script.onerror = () => {
+        tradingViewScriptPromise = null;
+        reject(new Error('Failed to load TradingView widget script.'));
+      };
+      document.head.appendChild(script);
+    });
+  }
+
+  return tradingViewScriptPromise;
+};
+
 export default function TimelineBar({
   focusLabel = 'Tools',
   quickActions = [],
@@ -66,7 +100,22 @@ export default function TimelineBar({
   const actions = quickActions.filter(Boolean);
   const [isInsightsOpen, setIsInsightsOpen] = React.useState(false);
   const chartContainerRef = React.useRef(null);
+  const tradingViewContainerRef = React.useRef(null);
   const [isChartReady, setIsChartReady] = React.useState(false);
+  const animationFrameRef = React.useRef(null);
+  const [chartData, setChartData] = React.useState(null);
+  const [chartStatusMessage, setChartStatusMessage] = React.useState(
+    'Loading lightweight chart…'
+  );
+  const [chartFootnote, setChartFootnote] = React.useState(
+    'Data shown is simulated for demonstration purposes.'
+  );
+  const tradingViewWidgetRef = React.useRef(null);
+  const [chartMode, setChartMode] = React.useState('tradingview');
+  const tradingViewContainerId = React.useMemo(
+    () => `tradingview-container-${Math.random().toString(36).slice(2, 10)}`,
+    []
+  );
   const chartResourcesRef = React.useRef({
     chart: null,
     candleSeries: null,
@@ -113,6 +162,95 @@ export default function TimelineBar({
   const insightsPanelId = 'timeline-insights-panel';
 
   React.useEffect(() => {
+    if (!isInsightsOpen) {
+      setIsChartReady(false);
+      setChartStatusMessage('Loading lightweight chart…');
+      setChartFootnote('Data shown is simulated for demonstration purposes.');
+      setChartData(null);
+      setChartMode('tradingview');
+      return;
+    }
+
+    if (chartMode === 'tradingview') {
+      setChartStatusMessage('Loading TradingView widget…');
+      setChartFootnote('Live BTC/USDT market data provided by TradingView.');
+    }
+  }, [chartMode, isInsightsOpen]);
+
+  React.useEffect(() => {
+    if (!isInsightsOpen || chartMode !== 'tradingview') {
+      return undefined;
+    }
+
+    let cancelled = false;
+    const container = tradingViewContainerRef.current;
+
+    if (!container) {
+      return undefined;
+    }
+
+    setIsChartReady(false);
+    setChartStatusMessage('Loading TradingView widget…');
+    setChartFootnote('Live BTC/USDT market data provided by TradingView.');
+
+    const initializeTradingView = async () => {
+      try {
+        const TradingView = await loadTradingViewScript();
+        if (cancelled || !container) {
+          return;
+        }
+
+        container.innerHTML = '';
+        const widget = new TradingView.widget({
+          autosize: true,
+          symbol: 'BINANCE:BTCUSDT',
+          interval: '60',
+          timezone: 'Etc/UTC',
+          theme: theme === 'dark' ? 'dark' : 'light',
+          style: '1',
+          locale: 'en',
+          backgroundColor: 'rgba(0, 0, 0, 0)',
+          hide_top_toolbar: false,
+          hide_side_toolbar: false,
+          allow_symbol_change: false,
+          container_id: tradingViewContainerId,
+        });
+
+        tradingViewWidgetRef.current = widget;
+        widget.onChartReady(() => {
+          if (!cancelled) {
+            setChartStatusMessage('');
+            setIsChartReady(true);
+          }
+        });
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Failed to load TradingView widget', error);
+          setChartStatusMessage(
+            'TradingView widget unavailable. Loading fallback preview…'
+          );
+          setChartFootnote('Data shown is simulated for demonstration purposes.');
+          setChartMode('lightweight');
+        }
+      }
+    };
+
+    initializeTradingView();
+
+    return () => {
+      cancelled = true;
+      if (tradingViewWidgetRef.current && tradingViewWidgetRef.current.remove) {
+        tradingViewWidgetRef.current.remove();
+      }
+      tradingViewWidgetRef.current = null;
+    };
+  }, [chartMode, isInsightsOpen, theme, tradingViewContainerId]);
+
+  React.useEffect(() => {
+    if (!isInsightsOpen || chartMode === 'tradingview') {
+      return undefined;
+    }
+
     let cancelled = false;
     const abortControllers = [];
 
@@ -190,6 +328,10 @@ export default function TimelineBar({
         return;
       }
 
+      setIsChartReady(false);
+      setChartStatusMessage('Loading lightweight chart…');
+      setChartFootnote('Data shown is simulated for demonstration purposes.');
+
       const container = chartContainerRef.current;
       if (!container) {
         return;
@@ -215,108 +357,141 @@ export default function TimelineBar({
         return;
       }
 
-      const ensureDimensionsAndCreate = () => {
-        const target = chartContainerRef.current;
-        if (!target || cancelled) {
-          return;
-        }
+      const ensureDimensionsAndCreate = () =>
+        new Promise((resolve) => {
+          const attemptInitialization = () => {
+            const target = chartContainerRef.current;
+            if (!target || cancelled) {
+              if (animationFrameRef.current) {
+                cancelAnimationFrame(animationFrameRef.current);
+                animationFrameRef.current = null;
+              }
+              resolve(false);
+              return;
+            }
 
-        const { width, height } = target.getBoundingClientRect();
-        if (!width || !height) {
-          animationFrameRef.current = requestAnimationFrame(ensureDimensionsAndCreate);
-          return;
-        }
+            const { width, height } = target.getBoundingClientRect();
+            if (!width || !height) {
+              animationFrameRef.current = requestAnimationFrame(attemptInitialization);
+              return;
+            }
 
-        if (!chartResourcesRef.current.chart) {
-          const chart = createChart(target, {
-            width,
-            height,
-            layout: {
-              background: { color: 'transparent' },
-              textColor: '#11141c',
-            },
-            grid: {
-              vertLines: { color: 'rgba(17, 20, 28, 0.08)' },
-              horzLines: { color: 'rgba(17, 20, 28, 0.08)' },
-            },
-            crosshair: {
-              mode: CrosshairMode.Normal,
-              vertLine: { color: 'rgba(17, 102, 229, 0.35)', width: 1, style: 0 },
-              horzLine: { color: 'rgba(17, 102, 229, 0.35)', width: 1, style: 0 },
-            },
-            rightPriceScale: {
+            const chart = chartResourcesRef.current.chart ??
+              createChart(target, {
+                width,
+                height,
+                layout: {
+                  background: { color: 'transparent' },
+                  textColor: '#11141c',
+                },
+                grid: {
+                  vertLines: { color: 'rgba(17, 20, 28, 0.08)' },
+                  horzLines: { color: 'rgba(17, 20, 28, 0.08)' },
+                },
+                crosshair: {
+                  mode: CrosshairMode.Normal,
+                  vertLine: { color: 'rgba(17, 102, 229, 0.35)', width: 1, style: 0 },
+                  horzLine: { color: 'rgba(17, 102, 229, 0.35)', width: 1, style: 0 },
+                },
+                rightPriceScale: {
+                  borderColor: 'rgba(17, 20, 28, 0.12)',
+                },
+                timeScale: {
+                  borderColor: 'rgba(17, 20, 28, 0.12)',
+                  rightOffset: 8,
+                  barSpacing: 9,
+                },
+                localization: {
+                  dateFormat: 'MMM dd',
+                },
+              });
+
+            chart.resize(width, height);
+
+            const candleSeries =
+              chartResourcesRef.current.candleSeries ??
+              chart.addCandlestickSeries({
+                upColor: '#16a085',
+                borderUpColor: '#16a085',
+                wickUpColor: '#16a085',
+                downColor: '#e74c3c',
+                borderDownColor: '#e74c3c',
+                wickDownColor: '#e74c3c',
+                priceScaleId: 'right',
+              });
+
+            const volumeSeries =
+              chartResourcesRef.current.volumeSeries ??
+              chart.addHistogramSeries({
+                priceFormat: { type: 'volume' },
+                priceScaleId: '',
+                scaleMargins: { top: 0.8, bottom: 0 },
+              });
+
+            chart.priceScale('right').applyOptions({
               borderColor: 'rgba(17, 20, 28, 0.12)',
-            },
-            timeScale: {
-              borderColor: 'rgba(17, 20, 28, 0.12)',
-              rightOffset: 8,
-              barSpacing: 9,
-            },
-            localization: {
-              dateFormat: 'MMM dd',
-            },
-          });
+              scaleMargins: { top: 0.08, bottom: 0.28 },
+            });
+            chart.priceScale('').applyOptions({
+              scaleMargins: { top: 0.75, bottom: 0 },
+            });
 
-          const candleSeries = chart.addCandlestickSeries({
-            upColor: '#16a085',
-            borderUpColor: '#16a085',
-            wickUpColor: '#16a085',
-            downColor: '#e74c3c',
-            borderDownColor: '#e74c3c',
-            wickDownColor: '#e74c3c',
-            priceScaleId: 'right',
-          });
+            let { resizeObserver } = chartResourcesRef.current;
+            if (!resizeObserver && typeof ResizeObserver !== 'undefined') {
+              resizeObserver = new ResizeObserver((entries) => {
+                const entry = entries[0];
+                if (!entry) return;
+                const { width: nextWidth, height: nextHeight } = entry.contentRect;
+                chart.resize(nextWidth, nextHeight);
+              });
+            }
 
-          const volumeSeries = chart.addHistogramSeries({
-            priceFormat: { type: 'volume' },
-            priceScaleId: '',
-            scaleMargins: { top: 0.8, bottom: 0 },
-          });
+            if (resizeObserver) {
+              resizeObserver.disconnect();
+              resizeObserver.observe(target);
+            }
 
-          chart.priceScale('right').applyOptions({
-            borderColor: 'rgba(17, 20, 28, 0.12)',
-            scaleMargins: { top: 0.08, bottom: 0.28 },
-          });
-          chart.priceScale('').applyOptions({
-            scaleMargins: { top: 0.75, bottom: 0 },
-          });
+            chartResourcesRef.current = {
+              chart,
+              candleSeries,
+              volumeSeries,
+              resizeObserver: resizeObserver ?? null,
+            };
 
-          const resizeObserver =
-            typeof ResizeObserver !== 'undefined'
-              ? new ResizeObserver((entries) => {
-                  const entry = entries[0];
-                  if (!entry) return;
-                  const { width: nextWidth, height: nextHeight } = entry.contentRect;
-                  chart.resize(nextWidth, nextHeight);
-                })
-              : null;
-
-          if (resizeObserver) {
-            resizeObserver.observe(target);
-          }
-
-          chartResourcesRef.current = {
-            chart,
-            candleSeries,
-            volumeSeries,
-            resizeObserver,
+            animationFrameRef.current = null;
+            resolve(true);
           };
-        }
 
-        chartResourcesRef.current = {
-          chart,
-          candleSeries,
-          volumeSeries,
-          resizeObserver,
-        };
-
-        if (!cancelled) {
-          setIsChartReady(true);
-        }
-      };
+          attemptInitialization();
+        });
 
       setChartStatusMessage('Preparing chart surface…');
-      ensureDimensionsAndCreate();
+      const chartReady = await ensureDimensionsAndCreate();
+      if (!chartReady || cancelled) {
+        return;
+      }
+
+      setChartStatusMessage('Loading BTC market data…');
+      const result = await fetchCandleData();
+      if (!result || cancelled) {
+        return;
+      }
+
+      if (!cancelled) {
+        setChartData(result.dataset);
+        applyDatasetToSeries(result.dataset, theme === 'dark');
+        setChartFootnote(
+          result.isFallback
+            ? 'Using fallback BTC dataset (offline mode).'
+            : `Data sourced from ${result.label}.`
+        );
+        setChartStatusMessage('');
+        setIsChartReady(true);
+
+        if (chartResourcesRef.current.chart) {
+          chartResourcesRef.current.chart.timeScale().fitContent();
+        }
+      }
     };
 
     initializeChart();
@@ -331,7 +506,7 @@ export default function TimelineBar({
         controller.abort();
       });
     };
-  }, [applyDatasetToSeries, chartData, isInsightsOpen, theme]);
+  }, [applyDatasetToSeries, chartMode, isInsightsOpen]);
 
   React.useEffect(() => {
     return () => {
@@ -357,7 +532,7 @@ export default function TimelineBar({
   }, []);
 
   React.useEffect(() => {
-    if (!chartResourcesRef.current.chart) {
+    if (chartMode !== 'lightweight' || !chartResourcesRef.current.chart) {
       return;
     }
 
@@ -396,21 +571,29 @@ export default function TimelineBar({
       borderDownColor: '#e74c3c',
       wickDownColor: '#e74c3c',
     });
-  }, [theme]);
+  }, [chartMode, theme]);
 
   React.useEffect(() => {
-    if (!chartResourcesRef.current.chart || !chartData) {
+    if (
+      chartMode !== 'lightweight' ||
+      !chartResourcesRef.current.chart ||
+      !chartData
+    ) {
       return;
     }
 
     applyDatasetToSeries(chartData, theme === 'dark');
-  }, [applyDatasetToSeries, chartData, theme]);
+  }, [applyDatasetToSeries, chartData, chartMode, theme]);
 
   React.useEffect(() => {
-    if (isInsightsOpen && chartResourcesRef.current.chart) {
+    if (
+      chartMode === 'lightweight' &&
+      isInsightsOpen &&
+      chartResourcesRef.current.chart
+    ) {
       chartResourcesRef.current.chart.timeScale().fitContent();
     }
-  }, [isInsightsOpen]);
+  }, [chartMode, isInsightsOpen]);
 
   return (
     <>
@@ -527,19 +710,33 @@ export default function TimelineBar({
           <div className="timeline-insights__body">
             <div className="timeline-insights__chart" role="img" aria-label="Candle and volume chart preview">
               <div
-                ref={chartContainerRef}
-                className="timeline-insights__chart-surface"
-                aria-hidden={isChartReady ? 'false' : 'true'}
+                ref={tradingViewContainerRef}
+                id={tradingViewContainerId}
+                className={`timeline-insights__chart-surface${
+                  chartMode === 'tradingview' ? '' : ' is-hidden'
+                }`}
+                aria-hidden={
+                  chartMode === 'tradingview' && isChartReady ? 'false' : 'true'
+                }
               />
-              {!isChartReady && (
+              <div
+                ref={chartContainerRef}
+                className={`timeline-insights__chart-surface${
+                  chartMode === 'lightweight' ? '' : ' is-hidden'
+                }`}
+                aria-hidden={
+                  chartMode === 'lightweight' && isChartReady ? 'false' : 'true'
+                }
+              />
+              {(!isChartReady || chartStatusMessage) && (
                 <div className="timeline-insights__chart-status" role="status">
-                  Loading lightweight chart…
+                  {chartStatusMessage || 'Preparing chart…'}
                 </div>
               )}
             </div>
           </div>
           <p className="timeline-insights__footnote">
-            Data shown is simulated for demonstration purposes.
+            {chartFootnote}
           </p>
         </div>
       </aside>

--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -172,14 +172,27 @@
   position: relative;
   flex: 1;
   min-height: 360px;
+  height: clamp(360px, 52vh, 520px);
   max-width: 100%;
   border-radius: 16px;
   overflow: hidden;
 }
 
 .timeline-insights__chart-surface {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
+}
+
+.timeline-insights__chart-surface.is-hidden {
+  display: none;
+}
+
+.timeline-insights__chart-surface iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
 }
 
 .timeline-insights__chart canvas {


### PR DESCRIPTION
## Summary
- load the TradingView widget in the timeline insights panel and fall back to lightweight-charts when unavailable
- manage chart lifecycles for both trading view and lightweight previews, including theme reinitialization
- update chart container styling to support stacked widgets and responsive heights

## Testing
- npm test -- --runTestsByPath Timeline.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ff4b8048f08322a2592c4517f30555