### PR TITLE
Expand lightweight chart to fill insights panel

### DIFF
--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -162,17 +162,17 @@
   flex: 1;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 20px;
-  padding: 24px;
+  padding: 0;
   display: flex;
   align-items: stretch;
-  justify-content: center;
+  min-height: 0;
 }
 
 .timeline-insights__chart {
   position: relative;
   flex: 1;
-  min-height: 360px;
-  height: clamp(360px, 52vh, 520px);
+  min-height: 0;
+  height: 100%;
   max-width: 100%;
   border-radius: 16px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- remove padding from the insights panel body so the lightweight chart can occupy the full container
- allow the chart wrapper to stretch to 100% height without enforcing a clamp so it fills the available space
- ensure the flex container and chart surface can grow with the dialog by clearing minimum height constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff677bc71c832285cc30b0527675d2