### PR TITLE
Stop showing lightweight chart loading overlay after initialization

### DIFF
--- a/TimelineBar.jsx
+++ b/TimelineBar.jsx
@@ -675,7 +675,7 @@ export default function TimelineBar({
                   chartMode === 'lightweight' && isChartReady ? 'false' : 'true'
                 }
               />
-              {(!isChartReady || chartStatusMessage) && (
+              {!isChartReady && (
                 <div className="timeline-insights__chart-status" role="status">
                   {chartStatusMessage || 'Preparing chart…'}
                 </div>


### PR DESCRIPTION
## Summary
- stop rendering the insights panel loading overlay once the lightweight chart is marked ready, preventing the perpetual "Loading lightweight chart" message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ff6a146af08322bb78f8c9386aaeca