### PR TITLE
Add editable side bonus stat to character quadrant

### DIFF
--- a/src/StatsQuadrant.jsx
+++ b/src/StatsQuadrant.jsx
@@ -8,11 +8,18 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
     const stored = localStorage.getItem('characterStats');
     return stored ? JSON.parse(stored) : initialStats;
   });
+  const [bonus, setBonus] = useState(() => {
+    const stored = localStorage.getItem('characterBonus');
+    if (!stored) return 0;
+    const parsed = Number(JSON.parse(stored));
+    return Number.isFinite(parsed) ? parsed : 0;
+  });
   const [userId, setUserId] = useState(null);
   const [profile, setProfile] = useState({});
   const [editing, setEditing] = useState(null);
 
-  const total = stats.reduce((sum, val) => sum + Number(val), 0);
+  const total =
+    stats.reduce((sum, val) => sum + Number(val), 0) + Number(bonus || 0);
   const starsUnlocked = Math.min(5, Math.floor(total / 100));
 
   useEffect(() => {
@@ -21,6 +28,10 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
       supabaseClient.from('profiles').update({ stats }).eq('id', userId);
     }
   }, [stats, userId]);
+
+  useEffect(() => {
+    localStorage.setItem('characterBonus', JSON.stringify(bonus));
+  }, [bonus]);
 
   useEffect(() => {
     document.body.classList.add('character-page');
@@ -55,32 +66,67 @@ export default function StatsQuadrant({ initialStats = [5, 5, 5, 5] }) {
     setStats(updated);
   };
 
+  const handleBonusChange = (value) => {
+    if (Number.isNaN(value)) {
+      setBonus(0);
+      return;
+    }
+    setBonus(value);
+  };
+
   return (
     <div className="character-scroll">
       <section className="header-section">
         <h2 className="character-title">Character</h2>
       </section>
       <section className="stats-section">
-        <div className="stats-quadrant">
-        {stats.map((stat, i) => (
+        <div className="stats-quadrant-wrapper">
           <div
-            key={i}
-            className={`quadrant ${['top-left', 'top-right', 'bottom-left', 'bottom-right'][i]}`}
-            onClick={() => setEditing(i)}
+            className="side-value"
+            onClick={() => setEditing('bonus')}
           >
-            {editing === i ? (
+            {editing === 'bonus' ? (
               <input
                 type="number"
                 autoFocus
-                value={stat}
-                onChange={(e) => handleChange(i, parseInt(e.target.value, 10))}
+                value={bonus}
+                onChange={(e) =>
+                  handleBonusChange(parseInt(e.target.value, 10))
+                }
                 onBlur={() => setEditing(null)}
               />
             ) : (
-              <span>{stat}</span>
+              <span>{bonus}</span>
             )}
           </div>
-        ))}
+          <div className="stats-quadrant">
+            {stats.map((stat, i) => (
+              <div
+                key={i}
+                className={`quadrant ${[
+                  'top-left',
+                  'top-right',
+                  'bottom-left',
+                  'bottom-right',
+                ][i]}`}
+                onClick={() => setEditing(i)}
+              >
+                {editing === i ? (
+                  <input
+                    type="number"
+                    autoFocus
+                    value={stat}
+                    onChange={(e) =>
+                      handleChange(i, parseInt(e.target.value, 10))
+                    }
+                    onBlur={() => setEditing(null)}
+                  />
+                ) : (
+                  <span>{stat}</span>
+                )}
+              </div>
+            ))}
+          </div>
         </div>
         <div className="total-display">
         <div className="power-label">POWER LEVEL</div>

--- a/src/stats-quadrant.css
+++ b/src/stats-quadrant.css
@@ -7,11 +7,16 @@
 
 
 
+.stats-quadrant-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+
 .stats-quadrant {
   position: relative;
   width: 300px;
   height: 300px;
-  margin-left: 60px;
 }
 
 .stats-quadrant::before,
@@ -63,6 +68,33 @@
 }
 
 .quadrant input:focus {
+  outline: 1px solid #fff;
+}
+
+.side-value {
+  color: #fff;
+  font-size: 3.2em;
+  font-family: 'ExodusD-Regular', sans-serif;
+  cursor: pointer;
+  text-shadow: 2px 2px 4px #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 80px;
+}
+
+.side-value input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: center;
+  font-size: inherit;
+  font-family: inherit;
+  text-shadow: 2px 2px 4px #000;
+}
+
+.side-value input:focus {
   outline: 1px solid #fff;
 }
 

--- a/stats-quadrant.css
+++ b/stats-quadrant.css
@@ -11,11 +11,16 @@ body.character-page {
   background-position: center;
 }
 
+.stats-quadrant-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+
 .stats-quadrant {
   position: relative;
   width: 300px;
   height: 300px;
-  margin-left: 60px;
 }
 
 .stats-quadrant::before,
@@ -67,6 +72,33 @@ body.character-page {
 }
 
 .quadrant input:focus {
+  outline: 1px solid #fff;
+}
+
+.side-value {
+  color: #fff;
+  font-size: 3.2em;
+  font-family: 'ExodusD-Regular', sans-serif;
+  cursor: pointer;
+  text-shadow: 2px 2px 4px #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 80px;
+}
+
+.side-value input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: center;
+  font-size: inherit;
+  font-family: inherit;
+  text-shadow: 2px 2px 4px #000;
+}
+
+.side-value input:focus {
   outline: 1px solid #fff;
 }
 


### PR DESCRIPTION
## Summary
- add a persistent bonus stat input to the character form so it can be adjusted alongside the quadrant values
- update the StatsQuadrant layout and styles to position the new control on the left of the grid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffaa00469c832298a79492da68ee2d