### PR TITLE
Enable dragging library words into Typomancy writing area

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -1232,6 +1233,16 @@ export default function Library({ onBack }) {
     setWords(w);
     localStorage.setItem('mazedWords', JSON.stringify(w));
   };
+
+  const handleWordDragStart = useCallback((event, wordText) => {
+    if (!event?.dataTransfer) {
+      return;
+    }
+
+    const textPayload = typeof wordText === 'string' ? wordText : '';
+    event.dataTransfer.setData('text/plain', textPayload);
+    event.dataTransfer.effectAllowed = 'copy';
+  }, []);
 
   const saveSounds = async (list) => {
     const metadataOnly = list.map(getSoundMetadata);
@@ -3466,6 +3477,8 @@ export default function Library({ onBack }) {
                       className="word-card"
                       data-item-type="word"
                       data-pretty-symbol={typeInfo.symbol}
+                      draggable
+                      onDragStart={(event) => handleWordDragStart(event, w.text)}
                       onClick={() => openWordInspector(w)}
                     >
                       <span className="word-card-text">{w.text || 'Untitled'}</span>

--- a/src/Typomancy.jsx
+++ b/src/Typomancy.jsx
@@ -67,6 +67,7 @@ export default function Typomancy({ onBack }) {
   const shellRef = useRef(null);
   const sidebarWidthRef = useRef(DEFAULT_SIDEBAR_WIDTH);
   const analysisWidthRef = useRef(DEFAULT_ANALYSIS_WIDTH);
+  const textareaRef = useRef(null);
 
   useEffect(() => {
     sidebarWidthRef.current = sidebarWidth;
@@ -179,6 +180,64 @@ export default function Typomancy({ onBack }) {
       }
     },
     [autoAnalyze]
+  );
+
+  const handleTextDragOver = useCallback((event) => {
+    if (!event?.dataTransfer) {
+      return;
+    }
+
+    const types = event.dataTransfer.types;
+    const hasPlainText =
+      !!types &&
+      ((typeof types.includes === 'function' && types.includes('text/plain')) ||
+        (typeof types.contains === 'function' && types.contains('text/plain')) ||
+        Array.from(types).includes('text/plain'));
+
+    if (hasPlainText) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'copy';
+    }
+  }, []);
+
+  const handleTextDrop = useCallback(
+    (event) => {
+      const target = textareaRef.current;
+      if (!target || !event?.dataTransfer) {
+        return;
+      }
+
+      const droppedText = event.dataTransfer.getData('text/plain');
+      if (typeof droppedText !== 'string' || droppedText.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const selectionStart = target.selectionStart ?? target.value.length;
+      const selectionEnd = target.selectionEnd ?? selectionStart;
+      const currentValue = target.value;
+
+      const nextValue =
+        currentValue.slice(0, selectionStart) +
+        droppedText +
+        currentValue.slice(selectionEnd);
+
+      applyTextUpdate(nextValue);
+
+      const nextCursor = selectionStart + droppedText.length;
+      requestAnimationFrame(() => {
+        if (!textareaRef.current) {
+          return;
+        }
+
+        textareaRef.current.focus();
+        textareaRef.current.selectionStart = nextCursor;
+        textareaRef.current.selectionEnd = nextCursor;
+      });
+    },
+    [applyTextUpdate]
   );
 
   useEffect(() => {
@@ -994,8 +1053,11 @@ export default function Typomancy({ onBack }) {
           </header>
           <textarea
             className="text-input"
+            ref={textareaRef}
             value={text}
             onChange={(event) => applyTextUpdate(event.target.value)}
+            onDragOver={handleTextDragOver}
+            onDrop={handleTextDrop}
             placeholder="Summon your prose here..."
           />
           <div className="quick-actions">


### PR DESCRIPTION
## Summary
- mark library word cards as draggable and seed their text payload
- allow the Typomancy editor to accept dropped text and insert it at the caret position

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902287c2af08322b17d6fd19d0997e7