### PR TITLE
Make timeline mood tracker horizontal

### DIFF
--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -321,18 +321,38 @@
 .timeline-bar__mood-grid {
   --cell-size: 16px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(var(--cell-size), 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: var(--cell-size);
+  grid-auto-rows: var(--cell-size);
   gap: 6px;
   padding: 8px 10px;
   border-radius: 14px;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 8px 16px rgba(0, 0, 0, 0.18);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+  -webkit-overflow-scrolling: touch;
+}
+
+.timeline-bar__mood-grid::-webkit-scrollbar {
+  height: 6px;
+}
+
+.timeline-bar__mood-grid::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.timeline-bar__mood-grid::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.3);
+  border-radius: 999px;
 }
 
 .timeline-bar__mood-cell {
   position: relative;
-  width: 100%;
+  width: var(--cell-size);
   height: var(--cell-size);
   border-radius: 6px;
   background: var(--mood-color, #7f8c8d);


### PR DESCRIPTION
## Summary
- ensure the timeline mood tracker uses horizontal layout for its segments
- add overflow handling and subtle scrollbar styling for the horizontal track

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912317bbedc8322a6093eece7d9a27a)