### PR TITLE
Generate thumbnails for video sounds

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -1268,6 +1268,16 @@ export default function Library({ onBack }) {
           metadataNeedsUpdate = true;
         }
         const enrichedBase = { ...base, mimeType: resolvedMime };
+        if (resolvedMime.startsWith('video/') && !enrichedBase.thumbnail) {
+          const promise = generateVideoThumbnail(dataUrl).then((thumb) => {
+            if (!thumb) {
+              return false;
+            }
+            enrichedBase.thumbnail = thumb;
+            return true;
+          });
+          thumbnailPromises.push(promise);
+        }
 
         loaded.push({ base: enrichedBase, dataUrl, stored });
       }


### PR DESCRIPTION
## Summary
- generate thumbnails for stored video entries when no custom thumbnail is saved
- persist generated thumbnails and refresh the sound list when thumbnails become available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139d8e31e4832293ef0ed0917faaab)