### PR TITLE
Generate thumbnails for video sounds

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -1268,6 +1268,16 @@ export default function Library({ onBack }) {
           metadataNeedsUpdate = true;
         }
         const enrichedBase = { ...base, mimeType: resolvedMime };
+        if (resolvedMime.startsWith('video/') && !enrichedBase.thumbnail) {
+          const promise = generateVideoThumbnail(dataUrl).then((thumb) => {
+            if (!thumb) {
+              return false;
+            }
+            enrichedBase.thumbnail = thumb;
+            return true;
+          });
+          thumbnailPromises.push(promise);
+        }
 
         loaded.push({ base: enrichedBase, dataUrl, stored });
       }
@@ -2410,7 +2420,9 @@ export default function Library({ onBack }) {
           }
         }}
       >
-        {snd.thumbnail ? (
+        {isVideo ? (
+          <VideoPreview src={snd.dataUrl} poster={snd.thumbnail} title={snd.title} />
+        ) : snd.thumbnail ? (
           <img src={snd.thumbnail} alt={snd.title} draggable={false} />
         ) : (
           <div className="sound-placeholder">{placeholderIcon}</div>
@@ -2425,13 +2437,7 @@ export default function Library({ onBack }) {
             )}
             {snd.title}
           </h3>
-          {isVideo ? (
-            <VideoPreview
-              src={snd.dataUrl}
-              poster={snd.thumbnail}
-              title={snd.title}
-            />
-          ) : (
+          {isVideo ? null : (
             <audio
               controls
               src={snd.dataUrl}

--- a/src/library.css
+++ b/src/library.css
@@ -883,6 +883,15 @@
   width: 100%;
 }
 
+.sound-card .video-preview {
+  height: 100%;
+}
+
+.sound-card .video-preview video {
+  height: 100%;
+  object-fit: cover;
+}
+
 .video-preview {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- generate thumbnails for stored video entries when no custom thumbnail is saved
- persist generated thumbnails and refresh the sound list when thumbnails become available
- render generated video thumbnails as the default preview so they are visible without hovering

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139d8e31e4832293ef0ed0917faaab)