### PR TITLE
Ensure video thumbnails render without hover

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -665,6 +665,10 @@ function VideoPreview({ src, poster, title }) {
 
   useEffect(() => () => pause(), [pause]);
 
+  useEffect(() => {
+    pause(true);
+  }, [src, poster, pause]);
+
   const ensurePlaying = useCallback(
     (event) => {
       event.stopPropagation();
@@ -724,6 +728,7 @@ function VideoPreview({ src, poster, title }) {
       aria-label={label}
     >
       <video
+        key={poster || src}
         ref={videoRef}
         src={src}
         poster={poster || undefined}
@@ -1268,6 +1273,16 @@ export default function Library({ onBack }) {
           metadataNeedsUpdate = true;
         }
         const enrichedBase = { ...base, mimeType: resolvedMime };
+        if (resolvedMime.startsWith('video/') && !enrichedBase.thumbnail) {
+          const promise = generateVideoThumbnail(dataUrl).then((thumb) => {
+            if (!thumb) {
+              return false;
+            }
+            enrichedBase.thumbnail = thumb;
+            return true;
+          });
+          thumbnailPromises.push(promise);
+        }
 
         loaded.push({ base: enrichedBase, dataUrl, stored });
       }
@@ -2410,7 +2425,9 @@ export default function Library({ onBack }) {
           }
         }}
       >
-        {snd.thumbnail ? (
+        {isVideo ? (
+          <VideoPreview src={snd.dataUrl} poster={snd.thumbnail} title={snd.title} />
+        ) : snd.thumbnail ? (
           <img src={snd.thumbnail} alt={snd.title} draggable={false} />
         ) : (
           <div className="sound-placeholder">{placeholderIcon}</div>
@@ -2425,13 +2442,7 @@ export default function Library({ onBack }) {
             )}
             {snd.title}
           </h3>
-          {isVideo ? (
-            <VideoPreview
-              src={snd.dataUrl}
-              poster={snd.thumbnail}
-              title={snd.title}
-            />
-          ) : (
+          {isVideo ? null : (
             <audio
               controls
               src={snd.dataUrl}

--- a/src/library.css
+++ b/src/library.css
@@ -883,6 +883,15 @@
   width: 100%;
 }
 
+.sound-card .video-preview {
+  height: 100%;
+}
+
+.sound-card .video-preview video {
+  height: 100%;
+  object-fit: cover;
+}
+
 .video-preview {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- pause previews when their source or poster changes so remounts reset playback state
- force video elements to remount when generated posters appear so thumbnails are visible immediately

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69139d8e31e4832293ef0ed0917faaab)