### PR TITLE
Ensure library video thumbnails appear immediately

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -666,6 +666,14 @@ function VideoPreview({ src, poster, title }) {
   useEffect(() => () => pause(), [pause]);
 
   useEffect(() => {
+    const video = videoRef.current;
+    if (video) {
+      try {
+        video.load();
+      } catch {
+        // Ignore load errors so we can still show the poster once available
+      }
+    }
     pause(true);
   }, [src, poster, pause]);
 


### PR DESCRIPTION
## Summary
- force library video previews to reload their media when the source or poster changes
- keep the preview paused after reloading so thumbnails render without waiting for hover

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a6806a2883228ca6ea4a98030ade)