### PR TITLE
Ensure library video thumbnails display before hover

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -740,6 +740,14 @@ function VideoPreview({ src, poster, title }) {
       tabIndex={0}
       aria-label={label}
     >
+      {poster && (
+        <img
+          className={`video-poster${isPlaying ? ' hidden' : ''}`}
+          src={poster}
+          alt={title ? `Poster for ${title}` : 'Video preview poster'}
+          draggable={false}
+        />
+      )}
       <video
         key={poster || src}
         ref={videoRef}

--- a/src/library.css
+++ b/src/library.css
@@ -902,6 +902,20 @@
   outline: none;
 }
 
+.video-preview .video-poster {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.video-preview .video-poster.hidden {
+  opacity: 0;
+}
+
 .video-preview video {
   width: 100%;
   display: block;


### PR DESCRIPTION
## Summary
- overlay the video preview with the stored poster image so thumbnails show immediately
- add styling to layer the poster above the video until playback begins

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691498abff04832280563981627f830a)