### PR TITLE
Shrink timeline bar vertical footprint

### DIFF
--- a/timeline-bar.css
+++ b/timeline-bar.css
@@ -2,12 +2,12 @@
   position: fixed;
   left: 110px;
   right: 32px;
-  bottom: 28px;
+  bottom: 13px;
   display: flex;
   align-items: center;
-  gap: 28px;
-  padding: 16px 24px;
-  border-radius: 22px;
+  gap: 16px;
+  padding: 9px 18px;
+  border-radius: 16px;
   background: rgba(17, 18, 22, 0.88);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 20px 48px rgba(0, 0, 0, 0.45);
@@ -23,9 +23,9 @@
 }
 
 .timeline-bar__panel-toggle {
-  width: 58px;
-  height: 38px;
-  border-radius: 27px;
+  width: 48px;
+  height: 28px;
+  border-radius: 22px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.1);
   color: #e6e7eb;
@@ -44,8 +44,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  width: 14px;
+  height: 14px;
 }
 
 .timeline-bar__panel-toggle-icon svg {
@@ -278,7 +278,7 @@
 .timeline-bar__section {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 10px;
 }
 
 .timeline-bar__section--focus {
@@ -290,7 +290,7 @@
 .timeline-bar__section--actions {
   flex: 1;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 8px;
 }
 
 .timeline-bar__section--mood {
@@ -298,7 +298,7 @@
   min-width: 220px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 6px;
 }
 
 .timeline-bar__mood-header {
@@ -309,24 +309,24 @@
 }
 
 .timeline-bar__mood-caption {
-  font-size: 0.7rem;
+  font-size: 0.64rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(230, 231, 235, 0.72);
   background: rgba(255, 255, 255, 0.08);
-  padding: 4px 8px;
+  padding: 2px 6px;
   border-radius: 999px;
 }
 
 .timeline-bar__mood-grid {
-  --cell-size: 16px;
+  --cell-size: 13px;
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: var(--cell-size);
   grid-auto-rows: var(--cell-size);
-  gap: 6px;
-  padding: 8px 10px;
-  border-radius: 14px;
+  gap: 4px;
+  padding: 5px 9px;
+  border-radius: 11px;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: inset 0 8px 16px rgba(0, 0, 0, 0.18);
@@ -378,17 +378,17 @@
 }
 
 .timeline-bar__section--toggles {
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
 .timeline-bar__section--secondary {
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
 .timeline-bar__label {
-  font-size: 0.75rem;
+  font-size: 0.68rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(230, 231, 235, 0.7);
@@ -396,14 +396,14 @@
 
 .timeline-bar__focus {
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 0.9rem;
 }
 
 .timeline-bar__status {
-  font-size: 0.7rem;
+  font-size: 0.64rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  padding: 4px 10px;
+  padding: 2px 7px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
 }
@@ -416,9 +416,9 @@
 .timeline-bar__action {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  border-radius: 14px;
+  gap: 7px;
+  padding: 6px 11px;
+  border-radius: 11px;
   background: rgba(255, 255, 255, 0.08);
   color: inherit;
   border: none;
@@ -442,14 +442,14 @@
 }
 
 .timeline-bar__action-icon {
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 .timeline-bar__pill {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+  gap: 5px;
+  padding: 5px 12px;
   border-radius: 999px;
   border: none;
   background: rgba(255, 255, 255, 0.12);
@@ -471,8 +471,8 @@
 }
 
 .timeline-bar__ghost {
-  padding: 8px 14px;
-  border-radius: 12px;
+  padding: 5px 10px;
+  border-radius: 11px;
   border: 1px solid rgba(255, 255, 255, 0.2);
   background: transparent;
   color: inherit;


### PR DESCRIPTION
## Summary
- tighten the timeline bar padding, gaps, and corner radius to reduce its vertical footprint
- scale down toggle, action, and pill controls plus typography for a more compact layout that clears the bottom-left icons

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914985cf8b083228ea2426873d1ac98)