### PR TITLE
Add image attachments to notes

### DIFF
--- a/NoteModal.jsx
+++ b/NoteModal.jsx
@@ -38,6 +38,9 @@ export default function NoteModal({ onClose }) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [tag, setTag] = useState(TAGS[0]);
+  const [imageData, setImageData] = useState(null);
+  const [imageName, setImageName] = useState('');
+  const [imageError, setImageError] = useState(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -70,6 +73,7 @@ export default function NoteModal({ onClose }) {
       tag,
       createdAt: timestamp,
       updatedAt: timestamp,
+      image: imageData,
     };
 
     const updatedNotes = [...notes, newNote];
@@ -78,6 +82,9 @@ export default function NoteModal({ onClose }) {
     setTitle('');
     setContent('');
     setTag(TAGS[0]);
+    setImageData(null);
+    setImageName('');
+    setImageError(null);
     onClose();
   };
 
@@ -95,6 +102,45 @@ export default function NoteModal({ onClose }) {
     if (event.target === event.currentTarget) {
       onClose();
     }
+  };
+
+  const handleImageChange = (event) => {
+    const input = event.target;
+    const file = input.files && input.files[0];
+    if (!file) {
+      setImageError(null);
+      return;
+    }
+
+    if (file.type && !file.type.startsWith('image/')) {
+      setImageError('Please choose an image file (JPG, PNG, GIF, or WEBP).');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : null;
+      setImageData(result);
+      setImageName(file.name);
+      setImageError(null);
+      if (input) {
+        input.value = '';
+      }
+    };
+    reader.onerror = () => {
+      setImageError('Failed to read the selected image. Please try again.');
+      if (input) {
+        input.value = '';
+      }
+    };
+
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveImage = () => {
+    setImageData(null);
+    setImageName('');
+    setImageError(null);
   };
 
   return (
@@ -141,6 +187,32 @@ export default function NoteModal({ onClose }) {
               value={content}
               onChange={(event) => setContent(event.target.value)}
             />
+          </label>
+
+          <label className="form-field note-image-field">
+            <span>Image (optional)</span>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleImageChange}
+              className="note-image-input"
+            />
+            {imageError ? <p className="note-image-error">{imageError}</p> : null}
+            {imageData ? (
+              <div className="note-image-preview">
+                <img src={imageData} alt="Selected attachment" loading="lazy" />
+                <div className="note-image-preview__meta">
+                  <span>{imageName || 'Attached image'}</span>
+                  <button type="button" className="ghost-button" onClick={handleRemoveImage}>
+                    Remove image
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <p className="note-image-hint">
+                Add a reference photo or sketch to bring the note to life.
+              </p>
+            )}
           </label>
         </div>
 

--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -96,6 +96,7 @@ const NOTE_TITLE_KEYS = ['title', 'name', 'heading'];
 const NOTE_CONTENT_KEYS = ['content', 'body', 'note', 'text'];
 const NOTE_TAG_KEYS = ['tag', 'quadrant', 'category'];
 const NOTE_UPDATED_AT_KEYS = ['updatedAt', 'updated_at', 'modifiedAt', 'editedAt', 'lastUpdated'];
+const NOTE_IMAGE_KEYS = ['image', 'imageUrl', 'imageURL', 'image_url', 'photo', 'attachment'];
 
 const getLocalStorage = () => {
   if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
@@ -292,6 +293,7 @@ const normaliseNote = (entry, index) => {
       characterCount: text.length,
       storageIndex: index,
       fieldMapping: null,
+      image: null,
       sourceType: 'primitive',
     };
   }
@@ -317,6 +319,7 @@ const normaliseNote = (entry, index) => {
   const contentField = pickFirstAvailableField(entry, NOTE_CONTENT_KEYS, 'content');
   const tagField = pickFirstAvailableField(entry, NOTE_TAG_KEYS, 'tag');
   const updatedField = pickFirstAvailableField(entry, NOTE_UPDATED_AT_KEYS, 'updatedAt');
+  const imageField = pickFirstAvailableField(entry, NOTE_IMAGE_KEYS, 'image');
 
   const rawTitle = toText(titleField.value ?? '');
   const rawContent = toText(contentField.value ?? '');
@@ -343,6 +346,8 @@ const normaliseNote = (entry, index) => {
   const updatedAt = parseDate(updatedField.value);
 
   const preview = createPreview(content);
+  const rawImage = imageField.value;
+  const image = typeof rawImage === 'string' && rawImage.trim() ? rawImage.trim() : null;
   const searchable = `${title} ${content} ${tag}`.toLowerCase();
   const wordCount = content.trim() ? content.trim().split(/\s+/).length : 0;
 
@@ -356,6 +361,7 @@ const normaliseNote = (entry, index) => {
     createdAtLabel: formatDateTime(createdAt),
     updatedAtLabel: updatedAt ? formatDateTime(updatedAt) : null,
     preview,
+    image,
     searchable,
     sortKey,
     wordCount,
@@ -366,6 +372,7 @@ const normaliseNote = (entry, index) => {
       content: contentField.key,
       tag: tagField.key,
       updatedAt: updatedField.key,
+      image: imageField.key,
     },
     sourceType: 'object',
   };
@@ -420,11 +427,12 @@ const loadStoredNotes = () => {
   }
 };
 
-const buildUpdatedEntry = (originalEntry, note, { title, content, tag }) => {
+const buildUpdatedEntry = (originalEntry, note, { title, content, tag, image }) => {
   const timestamp = new Date().toISOString();
   const safeTitle = title && title.trim() ? title.trim() : 'Untitled note';
   const safeContent = typeof content === 'string' ? content : '';
   const normalisedTag = QUADRANT_TAGS.includes(tag) ? tag : 'II';
+  const safeImage = typeof image === 'string' && image.trim() ? image.trim() : null;
 
   if (!isPlainObject(originalEntry)) {
     const createdAt =
@@ -440,6 +448,10 @@ const buildUpdatedEntry = (originalEntry, note, { title, content, tag }) => {
       createdAt,
       updatedAt: timestamp,
     };
+
+    if (safeImage !== null) {
+      payload.image = safeImage;
+    }
 
     if (note?.referenceId) {
       payload.id = note.referenceId;
@@ -459,6 +471,13 @@ const buildUpdatedEntry = (originalEntry, note, { title, content, tag }) => {
 
   const tagKey = mapping.tag ?? 'tag';
   updatedEntry[tagKey] = normalisedTag;
+
+  const imageKey = mapping.image ?? 'image';
+  if (safeImage) {
+    updatedEntry[imageKey] = safeImage;
+  } else if (Object.prototype.hasOwnProperty.call(updatedEntry, imageKey)) {
+    updatedEntry[imageKey] = null;
+  }
 
   const updatedAtKey =
     mapping.updatedAt ??
@@ -552,6 +571,8 @@ export default function NotesListModal({ onClose }) {
   const [editTitle, setEditTitle] = useState('');
   const [editContent, setEditContent] = useState('');
   const [editTag, setEditTag] = useState(QUADRANT_TAGS[0]);
+  const [editImage, setEditImage] = useState(null);
+  const [editImageError, setEditImageError] = useState(null);
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [editError, setEditError] = useState(null);
   const modalDimensions = useMemo(() => computeModalDimensions(viewportSize), [viewportSize]);
@@ -672,6 +693,8 @@ export default function NotesListModal({ onClose }) {
       setEditContent('');
       setEditTag(QUADRANT_TAGS[0]);
       setEditError(null);
+      setEditImage(null);
+      setEditImageError(null);
       return;
     }
 
@@ -680,6 +703,8 @@ export default function NotesListModal({ onClose }) {
       setEditContent(selectedNote.content);
       setEditTag(selectedNote.tag);
       setEditError(null);
+      setEditImage(selectedNote.image ?? null);
+      setEditImageError(null);
     }
   }, [selectedNote, isEditing]);
 
@@ -734,6 +759,53 @@ export default function NotesListModal({ onClose }) {
     setEditContent(selectedNote.content);
     setEditTag(selectedNote.tag);
     setEditError(null);
+    setEditImage(selectedNote.image ?? null);
+    setEditImageError(null);
+  };
+
+  const handleEditImageChange = (event) => {
+    if (isSavingEdit) {
+      return;
+    }
+
+    const input = event.target;
+    const file = input?.files?.[0];
+    if (!file) {
+      setEditImageError(null);
+      return;
+    }
+
+    if (file.type && !file.type.startsWith('image/')) {
+      setEditImageError('Please choose an image file (JPG, PNG, GIF, or WEBP).');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : null;
+      setEditImage(result);
+      setEditImageError(null);
+      if (input) {
+        input.value = '';
+      }
+    };
+    reader.onerror = () => {
+      setEditImageError('Unable to load the selected image. Please try again.');
+      if (input) {
+        input.value = '';
+      }
+    };
+
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveEditImage = () => {
+    if (isSavingEdit) {
+      return;
+    }
+
+    setEditImage(null);
+    setEditImageError(null);
   };
 
   const handleCancelEdit = () => {
@@ -747,11 +819,14 @@ export default function NotesListModal({ onClose }) {
       setEditTitle(selectedNote.title);
       setEditContent(selectedNote.content);
       setEditTag(selectedNote.tag);
+      setEditImage(selectedNote.image ?? null);
     } else {
       setEditTitle('');
       setEditContent('');
       setEditTag(QUADRANT_TAGS[0]);
+      setEditImage(null);
     }
+    setEditImageError(null);
   };
 
   const handleSaveEdit = () => {
@@ -766,11 +841,13 @@ export default function NotesListModal({ onClose }) {
     const cleanedContent = editContent.replace(/\r\n/g, '\n');
     const safeTitle = trimmedTitle || 'Untitled note';
     const safeTag = QUADRANT_TAGS.includes(editTag) ? editTag : 'II';
+    const safeImage = editImage ?? null;
 
     const result = updateNoteInStorage(selectedNote, {
       title: safeTitle,
       content: cleanedContent,
       tag: safeTag,
+      image: safeImage,
     });
 
     if (!result.success) {
@@ -808,9 +885,13 @@ export default function NotesListModal({ onClose }) {
       setSelectedId(null);
     }
 
+    const nextSelectedImage = nextSelected ? nextSelected.image ?? null : safeImage;
+
     setEditTitle(safeTitle);
     setEditContent(cleanedContent);
     setEditTag(safeTag);
+    setEditImage(nextSelectedImage);
+    setEditImageError(null);
     setEditError(null);
     setIsEditing(false);
     setIsSavingEdit(false);
@@ -897,7 +978,14 @@ export default function NotesListModal({ onClose }) {
                     <span className="note-card__tag" data-tag={note.tag}>
                       {note.tag}
                     </span>
-                    <span className="notes-card__date">{note.createdAtLabel}</span>
+                    <div className="notes-card__header-meta">
+                      <span className="notes-card__date">{note.createdAtLabel}</span>
+                      {note.image ? (
+                        <span className="notes-card__attachment" title="Contains an image" aria-label="Contains an image">
+                          📷
+                        </span>
+                      ) : null}
+                    </div>
                   </div>
                   <h4 className="notes-card__title">{note.title}</h4>
                   <p className="notes-card__preview">{note.preview}</p>
@@ -983,6 +1071,40 @@ export default function NotesListModal({ onClose }) {
                       />
                     </label>
 
+                    <label className="form-field note-image-field">
+                      <span>Image (optional)</span>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        onChange={handleEditImageChange}
+                        className="note-image-input"
+                        disabled={isSavingEdit}
+                      />
+                      {editImageError ? (
+                        <p className="note-image-error">{editImageError}</p>
+                      ) : null}
+                      {editImage ? (
+                        <div className="note-image-preview">
+                          <img src={editImage} alt="Attached to this note" loading="lazy" />
+                          <div className="note-image-preview__meta">
+                            <span>Image attached</span>
+                            <button
+                              type="button"
+                              className="ghost-button"
+                              onClick={handleRemoveEditImage}
+                              disabled={isSavingEdit}
+                            >
+                              Remove image
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="note-image-hint">
+                          Drop in a diagram, screenshot, or sketch to make the note memorable.
+                        </p>
+                      )}
+                    </label>
+
                     <div className="notes-edit-form__footer">
                       <div className="form-field form-field--inline">
                         <span>Quadrant</span>
@@ -1011,6 +1133,15 @@ export default function NotesListModal({ onClose }) {
                     <div className="note-view-content">
                       {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
                     </div>
+                    {selectedNote.image ? (
+                      <div className="note-image-preview note-image-preview--detail">
+                        <img
+                          src={selectedNote.image}
+                          alt={`Attachment for ${selectedNote.title}`}
+                          loading="lazy"
+                        />
+                      </div>
+                    ) : null}
                   </>
                 )}
               </>

--- a/note-modal.css
+++ b/note-modal.css
@@ -119,6 +119,75 @@
   margin: 0;
 }
 
+.note-image-field {
+  gap: 8px;
+}
+
+.note-image-input {
+  color: #e2e8f0;
+}
+
+.note-image-hint {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.9);
+  margin: 4px 0 0;
+}
+
+.note-image-error {
+  color: #f87171;
+  margin: 4px 0;
+  font-size: 0.9rem;
+}
+
+.note-image-preview {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 8px;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.note-image-preview img {
+  width: 100%;
+  border-radius: 8px;
+  object-fit: contain;
+  max-height: 260px;
+}
+
+.note-image-preview__meta {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+}
+
+.note-image-preview__meta span {
+  color: rgba(226, 232, 240, 0.86);
+  font-size: 0.9rem;
+}
+
+.note-image-preview--detail img {
+  max-height: 360px;
+}
+
+.note-image-preview--detail {
+  margin-top: 16px;
+}
+
+.notes-card__header-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.notes-card__attachment {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .akashic-button {
   background: none;
   border: none;

--- a/src/NoteModal.jsx
+++ b/src/NoteModal.jsx
@@ -38,6 +38,9 @@ export default function NoteModal({ onClose }) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [tag, setTag] = useState(TAGS[0]);
+  const [imageData, setImageData] = useState(null);
+  const [imageName, setImageName] = useState('');
+  const [imageError, setImageError] = useState(null);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -70,6 +73,7 @@ export default function NoteModal({ onClose }) {
       tag,
       createdAt: timestamp,
       updatedAt: timestamp,
+      image: imageData,
     };
 
     const updatedNotes = [...notes, newNote];
@@ -78,6 +82,9 @@ export default function NoteModal({ onClose }) {
     setTitle('');
     setContent('');
     setTag(TAGS[0]);
+    setImageData(null);
+    setImageName('');
+    setImageError(null);
     onClose();
   };
 
@@ -95,6 +102,45 @@ export default function NoteModal({ onClose }) {
     if (event.target === event.currentTarget) {
       onClose();
     }
+  };
+
+  const handleImageChange = (event) => {
+    const input = event.target;
+    const file = input.files && input.files[0];
+    if (!file) {
+      setImageError(null);
+      return;
+    }
+
+    if (file.type && !file.type.startsWith('image/')) {
+      setImageError('Please choose an image file (JPG, PNG, GIF, or WEBP).');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : null;
+      setImageData(result);
+      setImageName(file.name);
+      setImageError(null);
+      if (input) {
+        input.value = '';
+      }
+    };
+    reader.onerror = () => {
+      setImageError('Failed to read the selected image. Please try again.');
+      if (input) {
+        input.value = '';
+      }
+    };
+
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveImage = () => {
+    setImageData(null);
+    setImageName('');
+    setImageError(null);
   };
 
   return (
@@ -141,6 +187,32 @@ export default function NoteModal({ onClose }) {
               value={content}
               onChange={(event) => setContent(event.target.value)}
             />
+          </label>
+
+          <label className="form-field note-image-field">
+            <span>Image (optional)</span>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleImageChange}
+              className="note-image-input"
+            />
+            {imageError ? <p className="note-image-error">{imageError}</p> : null}
+            {imageData ? (
+              <div className="note-image-preview">
+                <img src={imageData} alt="Selected attachment" loading="lazy" />
+                <div className="note-image-preview__meta">
+                  <span>{imageName || 'Attached image'}</span>
+                  <button type="button" className="ghost-button" onClick={handleRemoveImage}>
+                    Remove image
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <p className="note-image-hint">
+                Add a reference photo or sketch to bring the note to life.
+              </p>
+            )}
           </label>
         </div>
 

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -96,6 +96,7 @@ const NOTE_TITLE_KEYS = ['title', 'name', 'heading'];
 const NOTE_CONTENT_KEYS = ['content', 'body', 'note', 'text'];
 const NOTE_TAG_KEYS = ['tag', 'quadrant', 'category'];
 const NOTE_UPDATED_AT_KEYS = ['updatedAt', 'updated_at', 'modifiedAt', 'editedAt', 'lastUpdated'];
+const NOTE_IMAGE_KEYS = ['image', 'imageUrl', 'imageURL', 'image_url', 'photo', 'attachment'];
 
 const getLocalStorage = () => {
   if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
@@ -292,6 +293,7 @@ const normaliseNote = (entry, index) => {
       characterCount: text.length,
       storageIndex: index,
       fieldMapping: null,
+      image: null,
       sourceType: 'primitive',
     };
   }
@@ -317,6 +319,7 @@ const normaliseNote = (entry, index) => {
   const contentField = pickFirstAvailableField(entry, NOTE_CONTENT_KEYS, 'content');
   const tagField = pickFirstAvailableField(entry, NOTE_TAG_KEYS, 'tag');
   const updatedField = pickFirstAvailableField(entry, NOTE_UPDATED_AT_KEYS, 'updatedAt');
+  const imageField = pickFirstAvailableField(entry, NOTE_IMAGE_KEYS, 'image');
 
   const rawTitle = toText(titleField.value ?? '');
   const rawContent = toText(contentField.value ?? '');
@@ -343,6 +346,8 @@ const normaliseNote = (entry, index) => {
   const updatedAt = parseDate(updatedField.value);
 
   const preview = createPreview(content);
+  const rawImage = imageField.value;
+  const image = typeof rawImage === 'string' && rawImage.trim() ? rawImage.trim() : null;
   const searchable = `${title} ${content} ${tag}`.toLowerCase();
   const wordCount = content.trim() ? content.trim().split(/\s+/).length : 0;
 
@@ -356,6 +361,7 @@ const normaliseNote = (entry, index) => {
     createdAtLabel: formatDateTime(createdAt),
     updatedAtLabel: updatedAt ? formatDateTime(updatedAt) : null,
     preview,
+    image,
     searchable,
     sortKey,
     wordCount,
@@ -366,6 +372,7 @@ const normaliseNote = (entry, index) => {
       content: contentField.key,
       tag: tagField.key,
       updatedAt: updatedField.key,
+      image: imageField.key,
     },
     sourceType: 'object',
   };
@@ -420,11 +427,12 @@ const loadStoredNotes = () => {
   }
 };
 
-const buildUpdatedEntry = (originalEntry, note, { title, content, tag }) => {
+const buildUpdatedEntry = (originalEntry, note, { title, content, tag, image }) => {
   const timestamp = new Date().toISOString();
   const safeTitle = title && title.trim() ? title.trim() : 'Untitled note';
   const safeContent = typeof content === 'string' ? content : '';
   const normalisedTag = QUADRANT_TAGS.includes(tag) ? tag : 'II';
+  const safeImage = typeof image === 'string' && image.trim() ? image.trim() : null;
 
   if (!isPlainObject(originalEntry)) {
     const createdAt =
@@ -440,6 +448,10 @@ const buildUpdatedEntry = (originalEntry, note, { title, content, tag }) => {
       createdAt,
       updatedAt: timestamp,
     };
+
+    if (safeImage !== null) {
+      payload.image = safeImage;
+    }
 
     if (note?.referenceId) {
       payload.id = note.referenceId;
@@ -459,6 +471,13 @@ const buildUpdatedEntry = (originalEntry, note, { title, content, tag }) => {
 
   const tagKey = mapping.tag ?? 'tag';
   updatedEntry[tagKey] = normalisedTag;
+
+  const imageKey = mapping.image ?? 'image';
+  if (safeImage) {
+    updatedEntry[imageKey] = safeImage;
+  } else if (Object.prototype.hasOwnProperty.call(updatedEntry, imageKey)) {
+    updatedEntry[imageKey] = null;
+  }
 
   const updatedAtKey =
     mapping.updatedAt ??
@@ -552,6 +571,8 @@ export default function NotesListModal({ onClose }) {
   const [editTitle, setEditTitle] = useState('');
   const [editContent, setEditContent] = useState('');
   const [editTag, setEditTag] = useState(QUADRANT_TAGS[0]);
+  const [editImage, setEditImage] = useState(null);
+  const [editImageError, setEditImageError] = useState(null);
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [editError, setEditError] = useState(null);
   const modalDimensions = useMemo(() => computeModalDimensions(viewportSize), [viewportSize]);
@@ -672,6 +693,8 @@ export default function NotesListModal({ onClose }) {
       setEditContent('');
       setEditTag(QUADRANT_TAGS[0]);
       setEditError(null);
+      setEditImage(null);
+      setEditImageError(null);
       return;
     }
 
@@ -680,6 +703,8 @@ export default function NotesListModal({ onClose }) {
       setEditContent(selectedNote.content);
       setEditTag(selectedNote.tag);
       setEditError(null);
+      setEditImage(selectedNote.image ?? null);
+      setEditImageError(null);
     }
   }, [selectedNote, isEditing]);
 
@@ -734,6 +759,53 @@ export default function NotesListModal({ onClose }) {
     setEditContent(selectedNote.content);
     setEditTag(selectedNote.tag);
     setEditError(null);
+    setEditImage(selectedNote.image ?? null);
+    setEditImageError(null);
+  };
+
+  const handleEditImageChange = (event) => {
+    if (isSavingEdit) {
+      return;
+    }
+
+    const input = event.target;
+    const file = input?.files?.[0];
+    if (!file) {
+      setEditImageError(null);
+      return;
+    }
+
+    if (file.type && !file.type.startsWith('image/')) {
+      setEditImageError('Please choose an image file (JPG, PNG, GIF, or WEBP).');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : null;
+      setEditImage(result);
+      setEditImageError(null);
+      if (input) {
+        input.value = '';
+      }
+    };
+    reader.onerror = () => {
+      setEditImageError('Unable to load the selected image. Please try again.');
+      if (input) {
+        input.value = '';
+      }
+    };
+
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveEditImage = () => {
+    if (isSavingEdit) {
+      return;
+    }
+
+    setEditImage(null);
+    setEditImageError(null);
   };
 
   const handleCancelEdit = () => {
@@ -747,11 +819,14 @@ export default function NotesListModal({ onClose }) {
       setEditTitle(selectedNote.title);
       setEditContent(selectedNote.content);
       setEditTag(selectedNote.tag);
+      setEditImage(selectedNote.image ?? null);
     } else {
       setEditTitle('');
       setEditContent('');
       setEditTag(QUADRANT_TAGS[0]);
+      setEditImage(null);
     }
+    setEditImageError(null);
   };
 
   const handleSaveEdit = () => {
@@ -766,11 +841,13 @@ export default function NotesListModal({ onClose }) {
     const cleanedContent = editContent.replace(/\r\n/g, '\n');
     const safeTitle = trimmedTitle || 'Untitled note';
     const safeTag = QUADRANT_TAGS.includes(editTag) ? editTag : 'II';
+    const safeImage = editImage ?? null;
 
     const result = updateNoteInStorage(selectedNote, {
       title: safeTitle,
       content: cleanedContent,
       tag: safeTag,
+      image: safeImage,
     });
 
     if (!result.success) {
@@ -808,9 +885,13 @@ export default function NotesListModal({ onClose }) {
       setSelectedId(null);
     }
 
+    const nextSelectedImage = nextSelected ? nextSelected.image ?? null : safeImage;
+
     setEditTitle(safeTitle);
     setEditContent(cleanedContent);
     setEditTag(safeTag);
+    setEditImage(nextSelectedImage);
+    setEditImageError(null);
     setEditError(null);
     setIsEditing(false);
     setIsSavingEdit(false);
@@ -897,7 +978,14 @@ export default function NotesListModal({ onClose }) {
                     <span className="note-card__tag" data-tag={note.tag}>
                       {note.tag}
                     </span>
-                    <span className="notes-card__date">{note.createdAtLabel}</span>
+                    <div className="notes-card__header-meta">
+                      <span className="notes-card__date">{note.createdAtLabel}</span>
+                      {note.image ? (
+                        <span className="notes-card__attachment" title="Contains an image" aria-label="Contains an image">
+                          📷
+                        </span>
+                      ) : null}
+                    </div>
                   </div>
                   <h4 className="notes-card__title">{note.title}</h4>
                   <p className="notes-card__preview">{note.preview}</p>
@@ -983,6 +1071,40 @@ export default function NotesListModal({ onClose }) {
                       />
                     </label>
 
+                    <label className="form-field note-image-field">
+                      <span>Image (optional)</span>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        onChange={handleEditImageChange}
+                        className="note-image-input"
+                        disabled={isSavingEdit}
+                      />
+                      {editImageError ? (
+                        <p className="note-image-error">{editImageError}</p>
+                      ) : null}
+                      {editImage ? (
+                        <div className="note-image-preview">
+                          <img src={editImage} alt="Attached to this note" loading="lazy" />
+                          <div className="note-image-preview__meta">
+                            <span>Image attached</span>
+                            <button
+                              type="button"
+                              className="ghost-button"
+                              onClick={handleRemoveEditImage}
+                              disabled={isSavingEdit}
+                            >
+                              Remove image
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="note-image-hint">
+                          Drop in a diagram, screenshot, or sketch to make the note memorable.
+                        </p>
+                      )}
+                    </label>
+
                     <div className="notes-edit-form__footer">
                       <div className="form-field form-field--inline">
                         <span>Quadrant</span>
@@ -1011,6 +1133,15 @@ export default function NotesListModal({ onClose }) {
                     <div className="note-view-content">
                       {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
                     </div>
+                    {selectedNote.image ? (
+                      <div className="note-image-preview note-image-preview--detail">
+                        <img
+                          src={selectedNote.image}
+                          alt={`Attachment for ${selectedNote.title}`}
+                          loading="lazy"
+                        />
+                      </div>
+                    ) : null}
                   </>
                 )}
               </>

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -119,6 +119,75 @@
   margin: 0;
 }
 
+.note-image-field {
+  gap: 8px;
+}
+
+.note-image-input {
+  color: #e2e8f0;
+}
+
+.note-image-hint {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.9);
+  margin: 4px 0 0;
+}
+
+.note-image-error {
+  color: #f87171;
+  margin: 4px 0;
+  font-size: 0.9rem;
+}
+
+.note-image-preview {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 8px;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.note-image-preview img {
+  width: 100%;
+  border-radius: 8px;
+  object-fit: contain;
+  max-height: 260px;
+}
+
+.note-image-preview__meta {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+}
+
+.note-image-preview__meta span {
+  color: rgba(226, 232, 240, 0.86);
+  font-size: 0.9rem;
+}
+
+.note-image-preview--detail img {
+  max-height: 360px;
+}
+
+.note-image-preview--detail {
+  margin-top: 16px;
+}
+
+.notes-card__header-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.notes-card__attachment {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .akashic-button {
   background: none;
   border: none;
@@ -588,8 +657,9 @@
 .notes-detail__header {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  align-items: center;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
 }
 
 .notes-detail__title {
@@ -597,6 +667,49 @@
   font-size: 1.35rem;
   font-weight: 700;
   color: #f8fafc;
+}
+
+.notes-detail__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.notes-detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.notes-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.notes-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.notes-edit-form__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.notes-edit-form__error {
+  margin: 0;
+  color: #f87171;
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 .notes-modal .note-view-content {


### PR DESCRIPTION
## Summary
- allow new notes to include optional image attachments with inline preview and removal controls
- extend the notes library to normalise, display, and edit stored image data along with an attachment indicator
- update the shared modal styles (and mirrored src components) to support the new uploader and detail preview UI

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: electron requires libatk-1.0.so.0 in this container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af8500a3483229df335b252011f69)