### PR TITLE
Unify note attachments with content

### DIFF
--- a/NoteModal.jsx
+++ b/NoteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import './note-modal.css';
 
 const TAGS = ['II', 'IE', 'EI', 'EE', 'form', 'semi-formless', 'formless'];
@@ -43,6 +43,8 @@ export default function NoteModal({ onClose }) {
   const [imageError, setImageError] = useState(null);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const dragCounterRef = useRef(0);
+  const imageInputRef = useRef(null);
+  const imageInputId = useId();
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -143,6 +145,9 @@ export default function NoteModal({ onClose }) {
     setImageData(null);
     setImageName('');
     setImageError(null);
+    if (imageInputRef.current) {
+      imageInputRef.current.value = '';
+    }
   };
 
   const handleDragEnter = (event) => {
@@ -225,33 +230,50 @@ export default function NoteModal({ onClose }) {
               value={content}
               onChange={(event) => setContent(event.target.value)}
             />
-          </div>
 
-          <label className="form-field note-image-field">
-            <span>Image (optional)</span>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handleImageChange}
-              className="note-image-input"
-            />
-            {imageError ? <p className="note-image-error">{imageError}</p> : null}
-            {imageData ? (
-              <div className="note-image-preview">
-                <img src={imageData} alt="Selected attachment" loading="lazy" />
-                <div className="note-image-preview__meta">
-                  <span>{imageName || 'Attached image'}</span>
-                  <button type="button" className="ghost-button" onClick={handleRemoveImage}>
-                    Remove image
-                  </button>
-                </div>
+            <div className="note-composer__attachment">
+              <div className={`note-attachment ${imageData ? 'has-image' : ''}`}>
+                <input
+                  id={imageInputId}
+                  ref={imageInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageChange}
+                  className="note-attachment__input"
+                />
+                {imageData ? (
+                  <div className="note-attachment__preview">
+                    <img src={imageData} alt="Selected attachment" loading="lazy" />
+                    <div className="note-attachment__meta">
+                      <p className="note-attachment__filename">{imageName || 'Attached image'}</p>
+                      <div className="note-attachment__buttons">
+                        <button
+                          type="button"
+                          className="ghost-button ghost-button--compact"
+                          onClick={() => imageInputRef.current?.click()}
+                        >
+                          Replace
+                        </button>
+                        <button
+                          type="button"
+                          className="ghost-button ghost-button--compact"
+                          onClick={handleRemoveImage}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <label className="note-attachment__placeholder" htmlFor={imageInputId}>
+                    <span className="note-attachment__label">Drop or upload an image</span>
+                    <span className="note-attachment__subtext">PNG, JPG, GIF or WEBP</span>
+                  </label>
+                )}
               </div>
-            ) : (
-              <p className="note-image-hint">
-                Add a reference photo or sketch to bring the note to life.
-              </p>
-            )}
-          </label>
+              {imageError ? <p className="note-attachment__error">{imageError}</p> : null}
+            </div>
+          </div>
         </div>
 
         <div className="note-editor__footer">

--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import './note-modal.css';
 
 const VIEWPORT_FALLBACK = { width: 1440, height: 900 };
@@ -575,6 +575,8 @@ export default function NotesListModal({ onClose }) {
   const [editImageError, setEditImageError] = useState(null);
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [editError, setEditError] = useState(null);
+  const editImageInputId = useId();
+  const editImageInputRef = useRef(null);
   const modalDimensions = useMemo(() => computeModalDimensions(viewportSize), [viewportSize]);
   const modalStyle = useMemo(() => {
     if (!modalDimensions) {
@@ -806,6 +808,9 @@ export default function NotesListModal({ onClose }) {
 
     setEditImage(null);
     setEditImageError(null);
+    if (editImageInputRef.current) {
+      editImageInputRef.current.value = '';
+    }
   };
 
   const handleCancelEdit = () => {
@@ -1060,50 +1065,65 @@ export default function NotesListModal({ onClose }) {
                       />
                     </label>
 
-                    <label className="form-field">
-                      <span>Notes</span>
-                      <textarea
-                        className="note-content"
-                        value={editContent}
-                        onChange={(event) => setEditContent(event.target.value)}
-                        placeholder="Revise the insight, context, or next steps..."
-                        disabled={isSavingEdit}
-                      />
-                    </label>
-
-                    <label className="form-field note-image-field">
-                      <span>Image (optional)</span>
-                      <input
-                        type="file"
-                        accept="image/*"
-                        onChange={handleEditImageChange}
-                        className="note-image-input"
-                        disabled={isSavingEdit}
-                      />
-                      {editImageError ? (
-                        <p className="note-image-error">{editImageError}</p>
-                      ) : null}
-                      {editImage ? (
-                        <div className="note-image-preview">
-                          <img src={editImage} alt="Attached to this note" loading="lazy" />
-                          <div className="note-image-preview__meta">
-                            <span>Image attached</span>
-                            <button
-                              type="button"
-                              className="ghost-button"
-                              onClick={handleRemoveEditImage}
+                    <div className="form-field form-field--stacked">
+                      <span>Notes & image</span>
+                      <div className="notes-edit-form__composer">
+                        <textarea
+                          className="note-content note-composer__content"
+                          value={editContent}
+                          onChange={(event) => setEditContent(event.target.value)}
+                          placeholder="Revise the insight, context, or next steps..."
+                          disabled={isSavingEdit}
+                        />
+                        <div className="note-composer__attachment">
+                          <div className={`note-attachment ${editImage ? 'has-image' : ''}`}>
+                            <input
+                              id={editImageInputId}
+                              ref={editImageInputRef}
+                              type="file"
+                              accept="image/*"
+                              onChange={handleEditImageChange}
+                              className="note-attachment__input"
                               disabled={isSavingEdit}
-                            >
-                              Remove image
-                            </button>
+                            />
+                            {editImage ? (
+                              <div className="note-attachment__preview">
+                                <img src={editImage} alt="Attached to this note" loading="lazy" />
+                                <div className="note-attachment__meta">
+                                  <p className="note-attachment__filename">Image attached</p>
+                                  <div className="note-attachment__buttons">
+                                    <button
+                                      type="button"
+                                      className="ghost-button ghost-button--compact"
+                                      onClick={() => editImageInputRef.current?.click()}
+                                      disabled={isSavingEdit}
+                                    >
+                                      Replace
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="ghost-button ghost-button--compact"
+                                      onClick={handleRemoveEditImage}
+                                      disabled={isSavingEdit}
+                                    >
+                                      Remove
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            ) : (
+                              <label className="note-attachment__placeholder" htmlFor={editImageInputId}>
+                                <span className="note-attachment__label">Add a supporting image</span>
+                                <span className="note-attachment__subtext">
+                                  Drop a diagram, screenshot, or sketch to make the note memorable.
+                                </span>
+                              </label>
+                            )}
                           </div>
+                          {editImageError ? <p className="note-attachment__error">{editImageError}</p> : null}
                         </div>
-                      ) : (
-                        <p className="note-image-hint">
-                          Drop in a diagram, screenshot, or sketch to make the note memorable.
-                        </p>
-                      )}
-                    </label>
+                      </div>
+                    </div>
 
                     <div className="notes-edit-form__footer">
                       <div className="form-field form-field--inline">
@@ -1130,18 +1150,20 @@ export default function NotesListModal({ onClose }) {
                 ) : (
                   <>
                     <h4 className="notes-detail__title">{selectedNote.title}</h4>
-                    <div className="note-view-content">
-                      {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
-                    </div>
-                    {selectedNote.image ? (
-                      <div className="note-image-preview note-image-preview--detail">
-                        <img
-                          src={selectedNote.image}
-                          alt={`Attachment for ${selectedNote.title}`}
-                          loading="lazy"
-                        />
+                    <div className={`note-view-content ${selectedNote.image ? 'has-image' : ''}`}>
+                      <div className="note-view-content__text">
+                        {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
                       </div>
-                    ) : null}
+                      {selectedNote.image ? (
+                        <div className="note-view-content__media">
+                          <img
+                            src={selectedNote.image}
+                            alt={`Attachment for ${selectedNote.title}`}
+                            loading="lazy"
+                          />
+                        </div>
+                      ) : null}
+                    </div>
                   </>
                 )}
               </>

--- a/note-modal.css
+++ b/note-modal.css
@@ -115,66 +115,34 @@
 }
 
 .note-view-content {
-  white-space: pre-wrap;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
   margin: 0;
 }
 
-.note-image-field {
-  gap: 8px;
+.note-view-content__text {
+  white-space: pre-wrap;
+  line-height: 1.75;
+  color: #cbd5f5;
 }
 
-.note-image-input {
-  color: #e2e8f0;
+.note-view-content__media {
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(2, 6, 23, 0.55);
+  padding: 12px;
+  box-shadow: 0 20px 40px -32px rgba(15, 23, 42, 0.85);
 }
 
-.note-image-hint {
-  font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.9);
-  margin: 4px 0 0;
-}
-
-.note-image-error {
-  color: #f87171;
-  margin: 4px 0;
-  font-size: 0.9rem;
-}
-
-.note-image-preview {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 12px;
-  padding: 8px;
-  background: rgba(15, 23, 42, 0.35);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.note-image-preview img {
+.note-view-content__media img {
   width: 100%;
-  border-radius: 8px;
-  object-fit: contain;
-  max-height: 260px;
+  border-radius: 16px;
+  object-fit: cover;
+  max-height: 420px;
+  display: block;
 }
 
-.note-image-preview__meta {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 8px;
-}
-
-.note-image-preview__meta span {
-  color: rgba(226, 232, 240, 0.86);
-  font-size: 0.9rem;
-}
-
-.note-image-preview--detail img {
-  max-height: 360px;
-}
-
-.note-image-preview--detail {
-  margin-top: 16px;
-}
 
 .notes-card__header-meta {
   display: flex;
@@ -345,6 +313,12 @@
   line-height: 1.75;
   resize: vertical;
   color: rgba(248, 250, 252, 0.9);
+}
+
+.note-composer__attachment {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .note-attachment {
@@ -850,6 +824,30 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
+}
+
+.notes-edit-form__composer {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.7) 0%, rgba(2, 6, 23, 0.88) 100%);
+  padding: clamp(18px, 3vw, 28px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 35px 65px -45px rgba(15, 23, 42, 0.85);
+}
+
+.notes-edit-form__composer textarea {
+  border: none;
+  background: transparent;
+  color: rgba(248, 250, 252, 0.9);
+  resize: vertical;
+}
+
+.notes-edit-form__composer textarea:focus {
+  outline: none;
 }
 
 .notes-edit-form__footer {

--- a/src/NoteModal.jsx
+++ b/src/NoteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import './note-modal.css';
 
 const TAGS = ['II', 'IE', 'EI', 'EE', 'form', 'semi-formless', 'formless'];
@@ -43,6 +43,8 @@ export default function NoteModal({ onClose }) {
   const [imageError, setImageError] = useState(null);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const dragCounterRef = useRef(0);
+  const imageInputRef = useRef(null);
+  const imageInputId = useId();
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -143,6 +145,9 @@ export default function NoteModal({ onClose }) {
     setImageData(null);
     setImageName('');
     setImageError(null);
+    if (imageInputRef.current) {
+      imageInputRef.current.value = '';
+    }
   };
 
   const handleDragEnter = (event) => {
@@ -225,33 +230,50 @@ export default function NoteModal({ onClose }) {
               value={content}
               onChange={(event) => setContent(event.target.value)}
             />
-          </div>
 
-          <label className="form-field note-image-field">
-            <span>Image (optional)</span>
-            <input
-              type="file"
-              accept="image/*"
-              onChange={handleImageChange}
-              className="note-image-input"
-            />
-            {imageError ? <p className="note-image-error">{imageError}</p> : null}
-            {imageData ? (
-              <div className="note-image-preview">
-                <img src={imageData} alt="Selected attachment" loading="lazy" />
-                <div className="note-image-preview__meta">
-                  <span>{imageName || 'Attached image'}</span>
-                  <button type="button" className="ghost-button" onClick={handleRemoveImage}>
-                    Remove image
-                  </button>
-                </div>
+            <div className="note-composer__attachment">
+              <div className={`note-attachment ${imageData ? 'has-image' : ''}`}>
+                <input
+                  id={imageInputId}
+                  ref={imageInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageChange}
+                  className="note-attachment__input"
+                />
+                {imageData ? (
+                  <div className="note-attachment__preview">
+                    <img src={imageData} alt="Selected attachment" loading="lazy" />
+                    <div className="note-attachment__meta">
+                      <p className="note-attachment__filename">{imageName || 'Attached image'}</p>
+                      <div className="note-attachment__buttons">
+                        <button
+                          type="button"
+                          className="ghost-button ghost-button--compact"
+                          onClick={() => imageInputRef.current?.click()}
+                        >
+                          Replace
+                        </button>
+                        <button
+                          type="button"
+                          className="ghost-button ghost-button--compact"
+                          onClick={handleRemoveImage}
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <label className="note-attachment__placeholder" htmlFor={imageInputId}>
+                    <span className="note-attachment__label">Drop or upload an image</span>
+                    <span className="note-attachment__subtext">PNG, JPG, GIF or WEBP</span>
+                  </label>
+                )}
               </div>
-            ) : (
-              <p className="note-image-hint">
-                Add a reference photo or sketch to bring the note to life.
-              </p>
-            )}
-          </label>
+              {imageError ? <p className="note-attachment__error">{imageError}</p> : null}
+            </div>
+          </div>
         </div>
 
         <div className="note-editor__footer">

--- a/src/NotesListModal.jsx
+++ b/src/NotesListModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import './note-modal.css';
 
 const VIEWPORT_FALLBACK = { width: 1440, height: 900 };
@@ -575,6 +575,8 @@ export default function NotesListModal({ onClose }) {
   const [editImageError, setEditImageError] = useState(null);
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [editError, setEditError] = useState(null);
+  const editImageInputId = useId();
+  const editImageInputRef = useRef(null);
   const modalDimensions = useMemo(() => computeModalDimensions(viewportSize), [viewportSize]);
   const modalStyle = useMemo(() => {
     if (!modalDimensions) {
@@ -806,6 +808,9 @@ export default function NotesListModal({ onClose }) {
 
     setEditImage(null);
     setEditImageError(null);
+    if (editImageInputRef.current) {
+      editImageInputRef.current.value = '';
+    }
   };
 
   const handleCancelEdit = () => {
@@ -1060,50 +1065,65 @@ export default function NotesListModal({ onClose }) {
                       />
                     </label>
 
-                    <label className="form-field">
-                      <span>Notes</span>
-                      <textarea
-                        className="note-content"
-                        value={editContent}
-                        onChange={(event) => setEditContent(event.target.value)}
-                        placeholder="Revise the insight, context, or next steps..."
-                        disabled={isSavingEdit}
-                      />
-                    </label>
-
-                    <label className="form-field note-image-field">
-                      <span>Image (optional)</span>
-                      <input
-                        type="file"
-                        accept="image/*"
-                        onChange={handleEditImageChange}
-                        className="note-image-input"
-                        disabled={isSavingEdit}
-                      />
-                      {editImageError ? (
-                        <p className="note-image-error">{editImageError}</p>
-                      ) : null}
-                      {editImage ? (
-                        <div className="note-image-preview">
-                          <img src={editImage} alt="Attached to this note" loading="lazy" />
-                          <div className="note-image-preview__meta">
-                            <span>Image attached</span>
-                            <button
-                              type="button"
-                              className="ghost-button"
-                              onClick={handleRemoveEditImage}
+                    <div className="form-field form-field--stacked">
+                      <span>Notes & image</span>
+                      <div className="notes-edit-form__composer">
+                        <textarea
+                          className="note-content note-composer__content"
+                          value={editContent}
+                          onChange={(event) => setEditContent(event.target.value)}
+                          placeholder="Revise the insight, context, or next steps..."
+                          disabled={isSavingEdit}
+                        />
+                        <div className="note-composer__attachment">
+                          <div className={`note-attachment ${editImage ? 'has-image' : ''}`}>
+                            <input
+                              id={editImageInputId}
+                              ref={editImageInputRef}
+                              type="file"
+                              accept="image/*"
+                              onChange={handleEditImageChange}
+                              className="note-attachment__input"
                               disabled={isSavingEdit}
-                            >
-                              Remove image
-                            </button>
+                            />
+                            {editImage ? (
+                              <div className="note-attachment__preview">
+                                <img src={editImage} alt="Attached to this note" loading="lazy" />
+                                <div className="note-attachment__meta">
+                                  <p className="note-attachment__filename">Image attached</p>
+                                  <div className="note-attachment__buttons">
+                                    <button
+                                      type="button"
+                                      className="ghost-button ghost-button--compact"
+                                      onClick={() => editImageInputRef.current?.click()}
+                                      disabled={isSavingEdit}
+                                    >
+                                      Replace
+                                    </button>
+                                    <button
+                                      type="button"
+                                      className="ghost-button ghost-button--compact"
+                                      onClick={handleRemoveEditImage}
+                                      disabled={isSavingEdit}
+                                    >
+                                      Remove
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            ) : (
+                              <label className="note-attachment__placeholder" htmlFor={editImageInputId}>
+                                <span className="note-attachment__label">Add a supporting image</span>
+                                <span className="note-attachment__subtext">
+                                  Drop a diagram, screenshot, or sketch to make the note memorable.
+                                </span>
+                              </label>
+                            )}
                           </div>
+                          {editImageError ? <p className="note-attachment__error">{editImageError}</p> : null}
                         </div>
-                      ) : (
-                        <p className="note-image-hint">
-                          Drop in a diagram, screenshot, or sketch to make the note memorable.
-                        </p>
-                      )}
-                    </label>
+                      </div>
+                    </div>
 
                     <div className="notes-edit-form__footer">
                       <div className="form-field form-field--inline">
@@ -1130,18 +1150,20 @@ export default function NotesListModal({ onClose }) {
                 ) : (
                   <>
                     <h4 className="notes-detail__title">{selectedNote.title}</h4>
-                    <div className="note-view-content">
-                      {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
-                    </div>
-                    {selectedNote.image ? (
-                      <div className="note-image-preview note-image-preview--detail">
-                        <img
-                          src={selectedNote.image}
-                          alt={`Attachment for ${selectedNote.title}`}
-                          loading="lazy"
-                        />
+                    <div className={`note-view-content ${selectedNote.image ? 'has-image' : ''}`}>
+                      <div className="note-view-content__text">
+                        {selectedNote.content ? selectedNote.content : 'No additional context yet.'}
                       </div>
-                    ) : null}
+                      {selectedNote.image ? (
+                        <div className="note-view-content__media">
+                          <img
+                            src={selectedNote.image}
+                            alt={`Attachment for ${selectedNote.title}`}
+                            loading="lazy"
+                          />
+                        </div>
+                      ) : null}
+                    </div>
                   </>
                 )}
               </>

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -115,66 +115,34 @@
 }
 
 .note-view-content {
-  white-space: pre-wrap;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
   margin: 0;
 }
 
-.note-image-field {
-  gap: 8px;
+.note-view-content__text {
+  white-space: pre-wrap;
+  line-height: 1.75;
+  color: #cbd5f5;
 }
 
-.note-image-input {
-  color: #e2e8f0;
+.note-view-content__media {
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(2, 6, 23, 0.55);
+  padding: 12px;
+  box-shadow: 0 20px 40px -32px rgba(15, 23, 42, 0.85);
 }
 
-.note-image-hint {
-  font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.9);
-  margin: 4px 0 0;
-}
-
-.note-image-error {
-  color: #f87171;
-  margin: 4px 0;
-  font-size: 0.9rem;
-}
-
-.note-image-preview {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 12px;
-  padding: 8px;
-  background: rgba(15, 23, 42, 0.35);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.note-image-preview img {
+.note-view-content__media img {
   width: 100%;
-  border-radius: 8px;
-  object-fit: contain;
-  max-height: 260px;
+  border-radius: 16px;
+  object-fit: cover;
+  max-height: 420px;
+  display: block;
 }
 
-.note-image-preview__meta {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 8px;
-}
-
-.note-image-preview__meta span {
-  color: rgba(226, 232, 240, 0.86);
-  font-size: 0.9rem;
-}
-
-.note-image-preview--detail img {
-  max-height: 360px;
-}
-
-.note-image-preview--detail {
-  margin-top: 16px;
-}
 
 .notes-card__header-meta {
   display: flex;
@@ -329,7 +297,7 @@
 }
 
 .note-editor__composer input:focus,
-.note-editor__composer textarea:focus { 
+.note-editor__composer textarea:focus {
   outline: none;
 }
 
@@ -345,6 +313,12 @@
   line-height: 1.75;
   resize: vertical;
   color: rgba(248, 250, 252, 0.9);
+}
+
+.note-composer__attachment {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .note-attachment {
@@ -850,6 +824,30 @@
   display: flex;
   flex-direction: column;
   gap: 18px;
+}
+
+.notes-edit-form__composer {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.7) 0%, rgba(2, 6, 23, 0.88) 100%);
+  padding: clamp(18px, 3vw, 28px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 35px 65px -45px rgba(15, 23, 42, 0.85);
+}
+
+.notes-edit-form__composer textarea {
+  border: none;
+  background: transparent;
+  color: rgba(248, 250, 252, 0.9);
+  resize: vertical;
+}
+
+.notes-edit-form__composer textarea:focus {
+  outline: none;
 }
 
 .notes-edit-form__footer {


### PR DESCRIPTION
## Summary
- embed the image picker directly into the note composer so text, title, and media live inside a single quadrant
- refresh the notes library editor/detail view so editing and reading share the same unified canvas for text plus media and update the supporting styles

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: electron requires libatk-1.0.so.0 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b244c70508322b14ced23c739780c)