### PR TITLE
Add reusable floating action button for capturing notes

### DIFF
--- a/FifthMain.jsx
+++ b/FifthMain.jsx
@@ -16,6 +16,11 @@ export default function FifthMain({ onSelectQuadrant }) {
   const [menuIndex, setMenuIndex] = useState(0);
   const [showPlanner, setShowPlanner] = useState(false);
 
+  const openNoteComposer = () => {
+    setShowList(false);
+    setShowModal(true);
+  };
+
   const startLeftDrag = (e) => {
     e.preventDefault();
     const startX = e.clientX;
@@ -119,7 +124,7 @@ export default function FifthMain({ onSelectQuadrant }) {
         if (menuIndex === 0) {
           setShowList(true);
         } else if (menuIndex === 1) {
-          setShowModal(true);
+          openNoteComposer();
         } else if (menuIndex === 2) {
           onSelectQuadrant('dock');
         } else {
@@ -152,7 +157,7 @@ export default function FifthMain({ onSelectQuadrant }) {
         </button>
         <button
           className={`side-button ${menuIndex === 1 ? 'selected' : ''}`}
-          onClick={() => setShowModal(true)}
+          onClick={openNoteComposer}
         >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M6.5 19H17.5C17.9647 19 18.197 18.9999 18.3902 18.9614C19.1836 18.8036 19.8036 18.1836 19.9614 17.3902C19.9999 17.197 19.9999 16.9647 19.9999 16.5C19.9999 16.0353 19.9999 15.8031 19.9614 15.6099C19.8036 14.8165 19.1836 14.1962 18.3902 14.0384C18.197 14 17.9647 14 17.5 14H6.5C6.03534 14 5.80306 14 5.60986 14.0384C4.81648 14.1962 4.19624 14.8165 4.03843 15.6099C4 15.8031 4 16.0354 4 16.5C4 16.9647 4 17.1969 4.03843 17.3901C4.19624 18.1835 4.81648 18.8036 5.60986 18.9614C5.80306 18.9999 6.03535 19 6.5 19Z" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
@@ -181,7 +186,12 @@ export default function FifthMain({ onSelectQuadrant }) {
         <QuadrantMenu onSelect={onSelectQuadrant} selected={menuIndex - 3} />
       </div>
       {showModal && <NoteModal onClose={() => setShowModal(false)} />}
-      {showList && <NotesListModal onClose={() => setShowList(false)} />}
+      {showList && (
+        <NotesListModal
+          onClose={() => setShowList(false)}
+          onCreateNote={openNoteComposer}
+        />
+      )}
       {showPlanner && <DayPlanner onComplete={handlePlannerComplete} />}
     </div>
   );

--- a/FloatingActionButton.jsx
+++ b/FloatingActionButton.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import './floating-action-button.css';
+
+const sizeClassMap = {
+  small: 'floating-action-button--small',
+  medium: 'floating-action-button--medium',
+  large: 'floating-action-button--large',
+};
+
+const variantClassMap = {
+  primary: 'floating-action-button--primary',
+  neutral: 'floating-action-button--neutral',
+};
+
+export default function FloatingActionButton({
+  icon = '+',
+  children,
+  ariaLabel = 'Trigger action',
+  size = 'medium',
+  variant = 'primary',
+  className = '',
+  ...props
+}) {
+  const resolvedSizeClass = sizeClassMap[size] ?? sizeClassMap.medium;
+  const resolvedVariantClass = variantClassMap[variant] ?? variantClassMap.primary;
+  const content = children ?? icon;
+
+  return (
+    <button
+      type="button"
+      className={[
+        'floating-action-button',
+        resolvedSizeClass,
+        resolvedVariantClass,
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      <span aria-hidden="true" className="floating-action-button__icon">
+        {content}
+      </span>
+    </button>
+  );
+}

--- a/NotesListModal.jsx
+++ b/NotesListModal.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
+import FloatingActionButton from './FloatingActionButton.jsx';
 import './note-modal.css';
 
 const VIEWPORT_FALLBACK = { width: 1440, height: 900 };
@@ -561,7 +562,7 @@ const updateNoteInStorage = (note, fields) => {
 
 const pluralise = (count, singular, plural) => (count === 1 ? singular : plural);
 
-export default function NotesListModal({ onClose }) {
+export default function NotesListModal({ onClose, onCreateNote }) {
   const [viewportSize, setViewportSize] = useState(() => readViewportSize());
   const [notes, setNotes] = useState(() => loadStoredNotes());
   const [searchTerm, setSearchTerm] = useState('');
@@ -918,14 +919,24 @@ export default function NotesListModal({ onClose }) {
             <h3>Your notes library</h3>
             <p className="notes-subtitle">{subtitle}</p>
           </div>
-          <button
-            type="button"
-            className="modal-close-button"
-            onClick={onClose}
-            aria-label="Close notes list"
-          >
-            &times;
-          </button>
+          <div className="notes-header__actions">
+            {onCreateNote ? (
+              <FloatingActionButton
+                ariaLabel="Capture a new note"
+                onClick={onCreateNote}
+                title="Capture a new note"
+                className="notes-header__add-button"
+              />
+            ) : null}
+            <button
+              type="button"
+              className="modal-close-button"
+              onClick={onClose}
+              aria-label="Close notes list"
+            >
+              &times;
+            </button>
+          </div>
         </header>
 
         <div className="notes-controls">

--- a/floating-action-button.css
+++ b/floating-action-button.css
@@ -1,0 +1,66 @@
+.floating-action-button {
+  border: none;
+  border-radius: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #f8fafc;
+  font-size: 1.85rem;
+  line-height: 1;
+  box-shadow: 0 20px 40px rgba(88, 28, 135, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  backdrop-filter: blur(8px);
+  position: relative;
+}
+
+.floating-action-button--medium {
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+}
+
+.floating-action-button--small {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  font-size: 1.45rem;
+}
+
+.floating-action-button--large {
+  width: 76px;
+  height: 76px;
+  border-radius: 22px;
+  font-size: 2rem;
+}
+
+.floating-action-button--primary {
+  background: linear-gradient(135deg, #4c1d95, #5b21b6 45%, #6d28d9);
+}
+
+.floating-action-button--neutral {
+  background: linear-gradient(135deg, #1e293b, #334155);
+}
+
+.floating-action-button__icon {
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.floating-action-button:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 30px 50px rgba(88, 28, 135, 0.55);
+  filter: brightness(1.05);
+}
+
+.floating-action-button:active {
+  transform: translateY(0);
+  box-shadow: 0 15px 30px rgba(88, 28, 135, 0.45);
+}
+
+.floating-action-button:focus-visible {
+  outline: 3px solid rgba(99, 102, 241, 0.85);
+  outline-offset: 4px;
+}

--- a/note-modal.css
+++ b/note-modal.css
@@ -238,6 +238,16 @@
   gap: 18px;
 }
 
+.notes-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.notes-header__add-button {
+  box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+}
+
 .note-editor__subtitle,
 .notes-subtitle {
   margin: 6px 0 0;


### PR DESCRIPTION
## Summary
- add a reusable FloatingActionButton component with shared styling
- show the button in the Notes library header so it can open the capture modal from the Fifth layer
- reuse a helper in FifthMain so keyboard and UI interactions launch the same composer flow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b32c279188322ab7f0c2441a03be5)