### PR TITLE
Keep library controls accessible while scrolling

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -3278,7 +3278,8 @@ export default function Library({ onBack }) {
       {isDragging && <div className="drop-overlay">Upload Media</div>}
       {uploading && <div className="upload-status">Uploading…</div>}
       <div className="library-manager">
-        <div className="library-header">
+        <div className="library-top-controls">
+          <div className="library-header">
           <button onClick={onBack} className="back-button" type="button">
             Back
           </button>
@@ -3575,7 +3576,7 @@ export default function Library({ onBack }) {
             </div>
           </div>
         </div>
-        <div className="library-tabs">
+          <div className="library-tabs">
           <button
             className={activeTab === 'all' ? 'active' : ''}
             onClick={() => setActiveTab('all')}
@@ -3600,6 +3601,7 @@ export default function Library({ onBack }) {
           >
             Sounds ({soundCount})
           </button>
+        </div>
         </div>
         {(activeTab === 'all' || activeTab === 'images') &&
           (libraryView === 'tri'

--- a/src/library.css
+++ b/src/library.css
@@ -114,6 +114,29 @@
   box-sizing: border-box;
 }
 
+.library-top-controls {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  margin: -20px -20px 20px;
+  padding: 16px 20px 12px;
+  background: var(--library-bg);
+  background: color-mix(in srgb, var(--library-bg) 92%, transparent);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--library-surface-border);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+
+.library-container.light-mode .library-top-controls {
+  box-shadow: 0 12px 28px rgba(90, 96, 255, 0.12);
+  background: var(--library-bg);
+  background: color-mix(
+    in srgb,
+    var(--library-bg) 85%,
+    rgba(255, 255, 255, 0.85)
+  );
+}
+
 .library-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- wrap the library header and tab buttons in a dedicated container so the navigation, view, settings, and order controls stay grouped together
- style the new container to stick to the top of the viewport with a translucent background and shadow so the controls remain visible while scrolling through library entries

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b70e6f0308322898d42ac63724c61)