### PR TITLE
Align library filters with view controls

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -3278,12 +3278,41 @@ export default function Library({ onBack }) {
       {isDragging && <div className="drop-overlay">Upload Media</div>}
       {uploading && <div className="upload-status">Uploading…</div>}
       <div className="library-manager">
-        <div className="library-header">
-          <button onClick={onBack} className="back-button" type="button">
-            Back
-          </button>
-          <h2>Library</h2>
-          <div className="library-actions">
+        <div className="library-top-controls">
+          <div className="library-header">
+            <button onClick={onBack} className="back-button" type="button">
+              Back
+            </button>
+            <h2>Library</h2>
+          </div>
+          <div className="library-toolbar">
+            <div className="library-tabs">
+              <button
+                className={activeTab === 'all' ? 'active' : ''}
+                onClick={() => setActiveTab('all')}
+              >
+                All ({totalCount})
+              </button>
+              <button
+                className={activeTab === 'images' ? 'active' : ''}
+                onClick={() => setActiveTab('images')}
+              >
+                Images ({imageCount})
+              </button>
+              <button
+                className={activeTab === 'words' ? 'active' : ''}
+                onClick={() => setActiveTab('words')}
+              >
+                Words ({wordCount})
+              </button>
+              <button
+                className={activeTab === 'sounds' ? 'active' : ''}
+                onClick={() => setActiveTab('sounds')}
+              >
+                Sounds ({soundCount})
+              </button>
+            </div>
+            <div className="library-actions">
             <div className="library-view-selector">
               <button
                 type="button"
@@ -3575,31 +3604,6 @@ export default function Library({ onBack }) {
             </div>
           </div>
         </div>
-        <div className="library-tabs">
-          <button
-            className={activeTab === 'all' ? 'active' : ''}
-            onClick={() => setActiveTab('all')}
-          >
-            All ({totalCount})
-          </button>
-          <button
-            className={activeTab === 'images' ? 'active' : ''}
-            onClick={() => setActiveTab('images')}
-          >
-            Images ({imageCount})
-          </button>
-          <button
-            className={activeTab === 'words' ? 'active' : ''}
-            onClick={() => setActiveTab('words')}
-          >
-            Words ({wordCount})
-          </button>
-          <button
-            className={activeTab === 'sounds' ? 'active' : ''}
-            onClick={() => setActiveTab('sounds')}
-          >
-            Sounds ({soundCount})
-          </button>
         </div>
         {(activeTab === 'all' || activeTab === 'images') &&
           (libraryView === 'tri'

--- a/src/library.css
+++ b/src/library.css
@@ -114,11 +114,34 @@
   box-sizing: border-box;
 }
 
+.library-top-controls {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  margin: -20px -20px 20px;
+  padding: 16px 20px;
+  background: var(--library-bg);
+  background: color-mix(in srgb, var(--library-bg) 92%, transparent);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--library-surface-border);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+}
+
+.library-container.light-mode .library-top-controls {
+  box-shadow: 0 12px 28px rgba(90, 96, 255, 0.12);
+  background: var(--library-bg);
+  background: color-mix(
+    in srgb,
+    var(--library-bg) 85%,
+    rgba(255, 255, 255, 0.85)
+  );
+}
+
 .library-header {
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
 }
 
 .library-header h2 {
@@ -620,10 +643,19 @@
   opacity: 0.75;
 }
 
+.library-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
 .library-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
+  flex: 1 1 260px;
 }
 
 .library-tabs button {


### PR DESCRIPTION
## Summary
- rearranged the library top controls so the All/Images/Words/Sounds tabs share the same row as the View, Settings, and Order buttons for consistent vertical alignment
- introduced a shared toolbar wrapper and tightened the sticky header padding/margins to shorten the header height while keeping the controls grouped when scrolling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b70e6f0308322898d42ac63724c61)