### PR TITLE
Float only the library controls

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -3283,7 +3283,35 @@ export default function Library({ onBack }) {
             Back
           </button>
           <h2>Library</h2>
-          <div className="library-actions">
+        </div>
+        <div className="library-toolbar">
+            <div className="library-tabs">
+              <button
+                className={activeTab === 'all' ? 'active' : ''}
+                onClick={() => setActiveTab('all')}
+              >
+                All ({totalCount})
+              </button>
+              <button
+                className={activeTab === 'images' ? 'active' : ''}
+                onClick={() => setActiveTab('images')}
+              >
+                Images ({imageCount})
+              </button>
+              <button
+                className={activeTab === 'words' ? 'active' : ''}
+                onClick={() => setActiveTab('words')}
+              >
+                Words ({wordCount})
+              </button>
+              <button
+                className={activeTab === 'sounds' ? 'active' : ''}
+                onClick={() => setActiveTab('sounds')}
+              >
+                Sounds ({soundCount})
+              </button>
+            </div>
+            <div className="library-actions">
             <div className="library-view-selector">
               <button
                 type="button"
@@ -3575,31 +3603,6 @@ export default function Library({ onBack }) {
             </div>
           </div>
         </div>
-        <div className="library-tabs">
-          <button
-            className={activeTab === 'all' ? 'active' : ''}
-            onClick={() => setActiveTab('all')}
-          >
-            All ({totalCount})
-          </button>
-          <button
-            className={activeTab === 'images' ? 'active' : ''}
-            onClick={() => setActiveTab('images')}
-          >
-            Images ({imageCount})
-          </button>
-          <button
-            className={activeTab === 'words' ? 'active' : ''}
-            onClick={() => setActiveTab('words')}
-          >
-            Words ({wordCount})
-          </button>
-          <button
-            className={activeTab === 'sounds' ? 'active' : ''}
-            onClick={() => setActiveTab('sounds')}
-          >
-            Sounds ({soundCount})
-          </button>
         </div>
         {(activeTab === 'all' || activeTab === 'images') &&
           (libraryView === 'tri'

--- a/src/library.css
+++ b/src/library.css
@@ -118,7 +118,7 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
 }
 
 .library-header h2 {
@@ -128,6 +128,7 @@
   font-size: 1.5rem;
   letter-spacing: 1px;
   color: var(--library-text);
+  line-height: 1.2;
 }
 
 .back-button {
@@ -620,17 +621,48 @@
   opacity: 0.75;
 }
 
+.library-toolbar {
+  position: sticky;
+  top: 12px;
+  z-index: 25;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 16px;
+  row-gap: 8px;
+  margin-bottom: 18px;
+  padding: 10px 16px 12px;
+  background: color-mix(in srgb, var(--library-bg) 88%, transparent);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--library-surface-border);
+  border-radius: 20px;
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.3);
+}
+
+.library-container.light-mode .library-toolbar {
+  background: color-mix(
+    in srgb,
+    var(--library-bg) 80%,
+    rgba(255, 255, 255, 0.8)
+  );
+  box-shadow: 0 22px 32px rgba(90, 96, 255, 0.12);
+}
+
 .library-tabs {
   display: flex;
-  gap: 10px;
-  margin-bottom: 20px;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 0;
+  flex: 1 1 260px;
+  align-items: center;
+  align-self: flex-start;
 }
 
 .library-tabs button {
   background: var(--library-button-bg);
   border: 1px solid var(--library-button-border);
   color: var(--library-button-text);
-  padding: 6px 12px;
+  padding: 4px 14px 6px;
   cursor: pointer;
   transition: background 0.3s ease, color 0.3s ease,
     border-color 0.3s ease, box-shadow 0.3s ease;


### PR DESCRIPTION
## Summary
- remove the sticky `library-top-controls` wrapper so the back button and title return to the standard flow
- make the tab/filter toolbar itself sticky with a lightweight floating treatment so only the buttons stay visible when scrolling

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: Electron requires system libraries such as libatk-1.0.so.0 that are unavailable in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b70e6f0308322898d42ac63724c61)