### PR TITLE
Make library filters the only sticky controls

### DIFF
--- a/src/Library.jsx
+++ b/src/Library.jsx
@@ -3277,12 +3277,34 @@ export default function Library({ onBack }) {
     >
       {isDragging && <div className="drop-overlay">Upload Media</div>}
       {uploading && <div className="upload-status">Uploading…</div>}
-      <div className="library-manager">
-        <div className="library-header">
-          <button onClick={onBack} className="back-button" type="button">
-            Back
-          </button>
-          <h2>Library</h2>
+      <div className="library-floating-controls" aria-label="Library filters and view controls">
+        <div className="library-toolbar">
+          <div className="library-tabs">
+            <button
+              className={activeTab === 'all' ? 'active' : ''}
+              onClick={() => setActiveTab('all')}
+            >
+              All ({totalCount})
+            </button>
+            <button
+              className={activeTab === 'images' ? 'active' : ''}
+              onClick={() => setActiveTab('images')}
+            >
+              Images ({imageCount})
+            </button>
+            <button
+              className={activeTab === 'words' ? 'active' : ''}
+              onClick={() => setActiveTab('words')}
+            >
+              Words ({wordCount})
+            </button>
+            <button
+              className={activeTab === 'sounds' ? 'active' : ''}
+              onClick={() => setActiveTab('sounds')}
+            >
+              Sounds ({soundCount})
+            </button>
+          </div>
           <div className="library-actions">
             <div className="library-view-selector">
               <button
@@ -3493,8 +3515,17 @@ export default function Library({ onBack }) {
                         </span>
                       )}
                     </button>
-                  </div>
-                </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="library-manager">
+        <div className="library-header">
+          <button onClick={onBack} className="back-button" type="button">
+            Back
+          </button>
+          <h2>Library</h2>
+        </div>
               )}
             </div>
             <div className="sort-dropdown">
@@ -3575,31 +3606,6 @@ export default function Library({ onBack }) {
             </div>
           </div>
         </div>
-        <div className="library-tabs">
-          <button
-            className={activeTab === 'all' ? 'active' : ''}
-            onClick={() => setActiveTab('all')}
-          >
-            All ({totalCount})
-          </button>
-          <button
-            className={activeTab === 'images' ? 'active' : ''}
-            onClick={() => setActiveTab('images')}
-          >
-            Images ({imageCount})
-          </button>
-          <button
-            className={activeTab === 'words' ? 'active' : ''}
-            onClick={() => setActiveTab('words')}
-          >
-            Words ({wordCount})
-          </button>
-          <button
-            className={activeTab === 'sounds' ? 'active' : ''}
-            onClick={() => setActiveTab('sounds')}
-          >
-            Sounds ({soundCount})
-          </button>
         </div>
         {(activeTab === 'all' || activeTab === 'images') &&
           (libraryView === 'tri'

--- a/src/library.css
+++ b/src/library.css
@@ -118,7 +118,7 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 20px;
+  margin-bottom: 12px;
 }
 
 .library-header h2 {
@@ -128,6 +128,7 @@
   font-size: 1.5rem;
   letter-spacing: 1px;
   color: var(--library-text);
+  line-height: 1.2;
 }
 
 .back-button {
@@ -620,18 +621,50 @@
   opacity: 0.75;
 }
 
+.library-floating-controls {
+  position: sticky;
+  top: 12px;
+  z-index: 30;
+  padding: 0 20px;
+}
+
+.library-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  margin-bottom: 18px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
 .library-tabs {
   display: flex;
-  gap: 10px;
-  margin-bottom: 20px;
+  flex: 1 1 auto;
+  gap: 8px;
+  margin: 0;
+  align-items: center;
+  min-width: 0;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.library-tabs::-webkit-scrollbar {
+  display: none;
 }
 
 .library-tabs button {
   background: var(--library-button-bg);
   border: 1px solid var(--library-button-border);
   color: var(--library-button-text);
-  padding: 6px 12px;
+  padding: 4px 14px 6px;
   cursor: pointer;
+  white-space: nowrap;
   transition: background 0.3s ease, color 0.3s ease,
     border-color 0.3s ease, box-shadow 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- wrap the tab and action buttons in a new floating controls container so they are the only sticky element while the Library header scrolls normally
- tighten the toolbar styling so the All/Images/Words/Sounds row stays on a single horizontal plane with the View/Settings/Order buttons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b70e6f0308322898d42ac63724c61)