### PR TITLE
Offset floating action button in notes

### DIFF
--- a/note-modal.css
+++ b/note-modal.css
@@ -178,7 +178,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
-  overflow: hidden;
+  overflow: visible;
   position: relative;
 }
 
@@ -242,10 +242,13 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  padding-right: 30px;
+  overflow: visible;
 }
 
 .notes-header__add-button {
   box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+  margin-right: -30px;
 }
 
 .note-editor__subtitle,


### PR DESCRIPTION
## Summary
- allow the notes modal to expose overflow so the floating action button can extend beyond the base UI
- shift the floating action button 30px to the right while preserving spacing for the close button

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9045fc2883228c6e6894817514bf)