### PR TITLE
Increase note editor FAB offset

### DIFF
--- a/note-modal.css
+++ b/note-modal.css
@@ -185,6 +185,7 @@
 .note-editor-modal {
   width: min(720px, calc(100vw - 48px));
   gap: 24px;
+  overflow: visible;
 }
 
 .notes-list-modal {
@@ -238,14 +239,25 @@
   gap: 18px;
 }
 
+.note-editor__header-actions,
 .notes-header__actions {
   display: flex;
   align-items: center;
   gap: 12px;
 }
 
+.note-editor__header-actions {
+  padding-right: 150px;
+  overflow: visible;
+}
+
 .notes-header__add-button {
   box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+}
+
+.note-editor__add-button {
+  box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+  margin-right: -150px;
 }
 
 .note-editor__subtitle,

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -185,6 +185,7 @@
 .note-editor-modal {
   width: min(720px, calc(100vw - 48px));
   gap: 24px;
+  overflow: visible;
 }
 
 .notes-list-modal {
@@ -238,10 +239,16 @@
   gap: 18px;
 }
 
+.note-editor__header-actions,
 .notes-header__actions {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+.note-editor__header-actions {
+  padding-right: 150px;
+  overflow: visible;
 }
 
 .notes-header__add-button {
@@ -258,6 +265,11 @@
 .notes-header__add-button:hover {
   border-color: rgba(148, 163, 184, 0.55);
   background: rgba(15, 23, 42, 0.92);
+}
+
+.note-editor__add-button {
+  box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+  margin-right: -150px;
 }
 
 .note-editor__subtitle,


### PR DESCRIPTION
## Summary
- push the note editor header actions padding so its floating action button has room to extend further outside the editor shell
- shift the note editor add button 150px to the right to better align with the requested position

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9045fc2883228c6e6894817514bf)