### PR TITLE
Reposition note editor controls

### DIFF
--- a/NoteModal.jsx
+++ b/NoteModal.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useId, useRef, useState } from 'react';
+import FloatingActionButton from './FloatingActionButton.jsx';
 import './note-modal.css';
 
 const TAGS = ['II', 'IE', 'EI', 'EE', 'form', 'semi-formless', 'formless'];
@@ -199,14 +200,23 @@ export default function NoteModal({ onClose }) {
               find when you revisit your reflections.
             </p>
           </div>
-          <button
-            type="button"
-            className="modal-close-button"
-            onClick={onClose}
-            aria-label="Close note editor"
-          >
-            &times;
-          </button>
+          <div className="note-editor__header-actions">
+            <FloatingActionButton
+              ariaLabel="Quick save note"
+              title="Save note"
+              size="small"
+              className="note-editor__add-button"
+              onClick={handleSave}
+            />
+            <button
+              type="button"
+              className="modal-close-button note-editor__close-button"
+              onClick={onClose}
+              aria-label="Close note editor"
+            >
+              &times;
+            </button>
+          </div>
         </header>
 
         <div className="note-editor__fields">

--- a/note-modal.css
+++ b/note-modal.css
@@ -185,6 +185,7 @@
 .note-editor-modal {
   width: min(720px, calc(100vw - 48px));
   gap: 24px;
+  overflow: visible;
 }
 
 .notes-list-modal {
@@ -238,6 +239,20 @@
   gap: 18px;
 }
 
+.note-editor__header {
+  position: relative;
+}
+
+.note-editor__header-actions {
+  position: absolute;
+  top: -32px;
+  right: -32px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 28px;
+}
+
 .notes-header__actions {
   display: flex;
   align-items: center;
@@ -246,6 +261,45 @@
 
 .notes-header__add-button {
   box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+}
+
+.note-editor__add-button {
+  box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+  transform: translateX(150px);
+}
+
+.note-editor__close-button {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.3), rgba(37, 99, 235, 0.2));
+  color: #f8fafc;
+  font-size: 1.8rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 35px 60px -30px rgba(59, 130, 246, 0.8);
+}
+
+@media (max-width: 1024px) {
+  .note-editor__header-actions {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+  }
+
+  .note-editor__add-button {
+    transform: none;
+  }
+
+  .note-editor__close-button {
+    width: 48px;
+    height: 48px;
+  }
 }
 
 .note-editor__subtitle,

--- a/src/NoteModal.jsx
+++ b/src/NoteModal.jsx
@@ -210,7 +210,7 @@ export default function NoteModal({ onClose }) {
             />
             <button
               type="button"
-              className="modal-close-button"
+              className="modal-close-button note-editor__close-button"
               onClick={onClose}
               aria-label="Close note editor"
             >

--- a/src/note-modal.css
+++ b/src/note-modal.css
@@ -185,6 +185,7 @@
 .note-editor-modal {
   width: min(720px, calc(100vw - 48px));
   gap: 24px;
+  overflow: visible;
 }
 
 .notes-list-modal {
@@ -230,12 +231,27 @@
   color: #f8fafc;
 }
 
+
 .note-editor__header,
 .notes-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 18px;
+}
+
+.note-editor__header {
+  position: relative;
+}
+
+.note-editor__header-actions {
+  position: absolute;
+  top: -32px;
+  right: -32px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 28px;
 }
 
 .notes-header__actions {
@@ -258,6 +274,45 @@
 .notes-header__add-button:hover {
   border-color: rgba(148, 163, 184, 0.55);
   background: rgba(15, 23, 42, 0.92);
+}
+
+.note-editor__add-button {
+  box-shadow: 0 28px 55px rgba(76, 29, 149, 0.5);
+  transform: translateX(150px);
+}
+
+.note-editor__close-button {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.3), rgba(37, 99, 235, 0.2));
+  color: #f8fafc;
+  font-size: 1.8rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 35px 60px -30px rgba(59, 130, 246, 0.8);
+}
+
+@media (max-width: 1024px) {
+  .note-editor__header-actions {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+  }
+
+  .note-editor__add-button {
+    transform: none;
+  }
+
+  .note-editor__close-button {
+    width: 48px;
+    height: 48px;
+  }
 }
 
 .note-editor__subtitle,


### PR DESCRIPTION
## Summary
- add the floating action button to the legacy note editor component so both builds share the quick-save affordance
- anchor the header action stack to the top-right corner of the note editor and give the quick save button an extra horizontal translation so it sits where the mockup indicates
- introduce a dedicated close-button treatment that mirrors the requested blue badge while keeping responsive fallbacks for narrow layouts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9045fc2883228c6e6894817514bf)