### PR TITLE
Fix Orb import path in App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,7 @@ import ProfileModal from './ProfileModal.jsx';
 import TodoGoals from './TodoGoals.jsx';
 import ActivityApp from './ActivityApp.jsx';
 import ActivityLog from './ActivityLog.jsx';
-import Orb from '../Orb.jsx';
+import Orb from './Orb.jsx';
 import IdeaBoard from './IdeaBoard.jsx';
 import ImplementationIdeas from './ImplementationIdeas.jsx';
 import Tips from './Tips.jsx';


### PR DESCRIPTION
## Summary
- update the `Orb` import in `src/App.jsx` to point at the component that now lives alongside the other imports
- verified there are no remaining references to the removed root-level `Orb.jsx`

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "lightweight-charts" from TimelineBar.jsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dcf17335883228ae00656b871f6da)