### PR TITLE
Add resource columns and migration backfill

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -10,13 +10,13 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 
 3. Open the SQL editor in Supabase and run these scripts in order:
    - `profiles.sql`
+   - `migration_resource_r.sql` (to backfill existing resource totals)
    - `supabase-tables.sql`
    - `friendships.sql`
    - `auth-trigger.sql`
 
    These create all required tables and columns and ensure a profile row is
    created automatically for each new user.
-a
 
 4. If row level security is enabled on `profiles`, allow public read access so username lookups work during login:
 

--- a/migration_resource_r.sql
+++ b/migration_resource_r.sql
@@ -1,0 +1,8 @@
+-- Ensure new resource columns exist and copy prior resource values
+alter table profiles
+  add column if not exists resource_r int default 0,
+  add column if not exists resource_x int default 0;
+
+update profiles
+set resource_r = resources
+where resources is not null;

--- a/profiles.sql
+++ b/profiles.sql
@@ -4,6 +4,8 @@ create table if not exists profiles (
   username text unique not null,
   avatar_url text,
   resources int default 0,
+  resource_r int default 0,
+  resource_x int default 0,
   streaks int default 0,
   stats jsonb default '[5,5,5,5]'
 );
@@ -11,7 +13,9 @@ create table if not exists profiles (
 alter table profiles
   add column if not exists mbti text,
   add column if not exists enneagram text,
-  add column if not exists instinct text;
+  add column if not exists instinct text,
+  add column if not exists resource_r int default 0,
+  add column if not exists resource_x int default 0;
 
 -- Upgrade existing installations
 alter table profiles


### PR DESCRIPTION
## Summary
- add resource_r and resource_x columns with defaults to the profiles schema
- include a migration script to backfill resource_r from existing resources data
- update the Supabase setup guide to run the new migration during SQL setup

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921aafabb28832295ac944f22be1ab4)