### PR TITLE
Sync resource values with Supabase

### DIFF
--- a/src/QuestContext.jsx
+++ b/src/QuestContext.jsx
@@ -71,26 +71,37 @@ export function QuestProvider({ children }) {
   };
 
   const completeQuest = (id) => {
+    const quest = quests.find((q) => q.id === id);
+    const rewardR = quest?.resource || 0;
+    const rewardX = quest?.xResource || quest?.x_resource || 0;
+    const currentR = parseInt(localStorage.getItem('resourceR') || '0', 10);
+    const currentX = parseInt(localStorage.getItem('resourceX') || '0', 10);
+    const newResource = currentR + rewardR;
+    const newXResource = currentX + rewardX;
+
+    localStorage.setItem('resourceR', newResource);
+    localStorage.setItem('resourceX', newXResource);
+    if (userId && navigator.onLine) {
+      supabaseClient
+        .from('profiles')
+        .update({ resources: newResource, x_resources: newXResource })
+        .eq('id', userId);
+    }
+    window.dispatchEvent(
+      new CustomEvent('resourceChange', {
+        detail: { resource: newResource, xResource: newXResource },
+      })
+    );
+
     setQuests((prev) =>
       prev.map((q) => {
         if (q.id === id) {
-          const newResource =
-            parseInt(localStorage.getItem('resourceR') || '0', 10) +
-            (q.resource || 0);
-          localStorage.setItem('resourceR', newResource);
-          if (userId && navigator.onLine) {
-            supabaseClient.from('profiles').update({ resources: newResource }).eq('id', userId);
-          }
-          window.dispatchEvent(
-            new CustomEvent('resourceChange', { detail: { resource: newResource } })
-          );
           return { ...q, completed: true };
         }
         return q;
       })
     );
     if (userId && navigator.onLine) {
-      const quest = quests.find((q) => q.id === id);
       if (quest && (quest.type === 'main' || quest.urgent)) {
         supabaseClient
           .from('quests')

--- a/src/ResourceContext.jsx
+++ b/src/ResourceContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { supabaseClient } from './supabaseClient';
 
 const ResourceContext = createContext();
 
@@ -12,6 +13,7 @@ export function ResourceProvider({ children }) {
     const stored = localStorage.getItem('worldXResource');
     return stored ? parseInt(stored, 10) : 0;
   });
+  const [userId, setUserId] = useState(null);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -21,12 +23,53 @@ export function ResourceProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('worldResource', resource);
-  }, [resource]);
+    const load = async () => {
+      if (!navigator.onLine) return;
+      const {
+        data: { user },
+      } = await supabaseClient.auth.getUser();
+      if (!user) return;
+      setUserId(user.id);
+      const { data } = await supabaseClient
+        .from('profiles')
+        .select('resources, x_resources')
+        .eq('id', user.id)
+        .single();
+      if (data) {
+        if (typeof data.resources === 'number') {
+          setResource(data.resources);
+        }
+        if (typeof data.x_resources === 'number') {
+          setXResource(data.x_resources);
+        }
+      }
+    };
+    load();
+  }, []);
 
   useEffect(() => {
+    const handler = (event) => {
+      if (event.detail && typeof event.detail.resource === 'number') {
+        setResource(event.detail.resource);
+      }
+      if (event.detail && typeof event.detail.xResource === 'number') {
+        setXResource(event.detail.xResource);
+      }
+    };
+    window.addEventListener('resourceChange', handler);
+    return () => window.removeEventListener('resourceChange', handler);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('worldResource', resource);
     localStorage.setItem('worldXResource', xResource);
-  }, [xResource]);
+    if (userId && navigator.onLine) {
+      supabaseClient
+        .from('profiles')
+        .update({ resources: resource, x_resources: xResource })
+        .eq('id', userId);
+    }
+  }, [resource, xResource, userId]);
 
   const add = (amount) => setResource((r) => r + amount);
   const spend = (amount) => setResource((r) => Math.max(0, r - amount));

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -106,12 +106,15 @@ export default function World({ activeLayer = "Form" }) {
       setUserId(user.id);
       const { data: profileData } = await supabaseClient
         .from("profiles")
-        .select("resources, mbti, enneagram, instinct")
+        .select("resources, x_resources, mbti, enneagram, instinct")
         .eq("id", user.id)
         .single();
       if (profileData) {
         if (typeof profileData.resources === "number") {
           setResource(profileData.resources);
+        }
+        if (typeof profileData.x_resources === "number") {
+          setXResource(profileData.x_resources);
         }
         setProfile(profileData);
         setNeedsMainQuest(!profileData.mbti || !profileData.enneagram);
@@ -126,6 +129,9 @@ export default function World({ activeLayer = "Form" }) {
       if (e.detail && typeof e.detail.resource === "number") {
         setResource(e.detail.resource);
       }
+      if (e.detail && typeof e.detail.xResource === "number") {
+        setXResource(e.detail.xResource);
+      }
     };
     window.addEventListener("resourceChange", handler);
     return () => window.removeEventListener("resourceChange", handler);
@@ -133,17 +139,14 @@ export default function World({ activeLayer = "Form" }) {
 
   useEffect(() => {
     localStorage.setItem("resourceR", resource);
+    localStorage.setItem("resourceX", xResource);
     if (userId && navigator.onLine) {
       supabaseClient
         .from("profiles")
-        .update({ resources: resource })
+        .update({ resources: resource, x_resources: xResource })
         .eq("id", userId);
     }
-  }, [resource, userId]);
-
-  useEffect(() => {
-    localStorage.setItem("resourceX", xResource);
-  }, [xResource]);
+  }, [resource, xResource, userId]);
 
   useEffect(() => {
     document.body.classList.add("world-page");


### PR DESCRIPTION
## Summary
- load and persist both R and X resources from Supabase profiles in the World view
- update quest completion to award and sync both resource types locally and to Supabase
- sync ResourceContext with Supabase values and resource change events so indicators stay current

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ab0058448322a45caecf6a245e09)