### PR TITLE
Sync resource_r and resource_x with Supabase

### DIFF
--- a/AcceptedQuestList.jsx
+++ b/AcceptedQuestList.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RIcon } from './ResourceIcons.jsx';
+import { RIcon, XIcon } from './ResourceIcons.jsx';
 import { useQuests } from './QuestContext.jsx';
 import './world.css';
 
@@ -21,28 +21,42 @@ export default function AcceptedQuestList() {
         <div key={type}>
           <h5>{type.charAt(0).toUpperCase() + type.slice(1)} Quests</h5>
           <div className="quest-list">
-            {list.map((q) => (
-              <div key={q.id} className="quest-banner">
-                <div className="quest-info">
-                  <div className="quest-name">{q.name}</div>
-                  <div className="quest-quadrant">{q.quadrant}</div>
-                  <div className="quest-rarity">{q.rarity || 'C'}</div>
-                  {q.urgent && <div className="quest-urgent">Urgent</div>}
-                  {q.resource !== 0 && (
-                    <div className="quest-resource">
-                  {q.resource > 0 ? '+' : ''}
-                      {q.resource} <RIcon />
-                    </div>
-                  )}
+            {list.map((q) => {
+              const rewardR = q.resource_r ?? q.resource ?? 0;
+              const rewardX = q.resource_x ?? 0;
+              return (
+                <div key={q.id} className="quest-banner">
+                  <div className="quest-info">
+                    <div className="quest-name">{q.name}</div>
+                    <div className="quest-quadrant">{q.quadrant}</div>
+                    <div className="quest-rarity">{q.rarity || 'C'}</div>
+                    {q.urgent && <div className="quest-urgent">Urgent</div>}
+                    {(rewardR !== 0 || rewardX !== 0) && (
+                      <div className="quest-resource">
+                        {rewardR !== 0 && (
+                          <span>
+                            {rewardR > 0 ? '+' : ''}
+                            {rewardR} <RIcon />
+                          </span>
+                        )}
+                        {rewardX !== 0 && (
+                          <span>
+                            {rewardX > 0 ? '+' : ''}
+                            {rewardX} <XIcon />
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    className="accept-button"
+                    onClick={() => completeQuest(q.id)}
+                  >
+                    Complete
+                  </button>
                 </div>
-                <button
-                  className="accept-button"
-                  onClick={() => completeQuest(q.id)}
-                >
-                  Complete
-                </button>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       ))}

--- a/Auth.jsx
+++ b/Auth.jsx
@@ -76,6 +76,8 @@ export default function Auth() {
           username: cleanName,
           avatar_url: null,
           resources: 0,
+          resource_r: 0,
+          resource_x: 0,
           streaks: 0,
           stats: [5, 5, 5, 5],
         });

--- a/QuestContext.jsx
+++ b/QuestContext.jsx
@@ -10,6 +10,38 @@ export function QuestProvider({ children }) {
   });
   const [userId, setUserId] = useState(null);
 
+  const normalizeQuest = (quest) => ({
+    ...quest,
+    resource_r:
+      typeof quest.resource_r === 'number'
+        ? quest.resource_r
+        : typeof quest.resource === 'number'
+          ? quest.resource
+          : 0,
+    resource_x: typeof quest.resource_x === 'number' ? quest.resource_x : 0,
+    resource:
+      typeof quest.resource === 'number'
+        ? quest.resource
+        : typeof quest.resource_r === 'number'
+          ? quest.resource_r
+          : 0,
+  });
+
+  const buildQuestPayload = (quest) => ({
+    id: quest.id,
+    user_id: userId,
+    type: quest.type || 'user',
+    name: quest.name,
+    description: quest.description,
+    quadrant: quest.quadrant,
+    resource_r: quest.resource_r,
+    resource_x: quest.resource_x,
+    rarity: quest.rarity,
+    urgent: quest.urgent,
+    accepted: quest.accepted,
+    completed: quest.completed,
+  });
+
   useEffect(() => {
     const load = async () => {
       if (!navigator.onLine) return;
@@ -23,8 +55,9 @@ export function QuestProvider({ children }) {
         .select('*')
         .eq('user_id', user.id);
       if (data) {
-        setQuests(data);
-        localStorage.setItem('quests', JSON.stringify(data));
+        const normalized = data.map(normalizeQuest);
+        setQuests(normalized);
+        localStorage.setItem('quests', JSON.stringify(normalized));
       }
     };
     load();
@@ -36,21 +69,21 @@ export function QuestProvider({ children }) {
     if (userId && navigator.onLine) {
       quests.forEach((q) => {
         if (q.type === 'main' || q.urgent) {
-          supabaseClient.from('quests').upsert({ ...q, user_id: userId });
+          supabaseClient.from('quests').upsert(buildQuestPayload(q));
         }
       });
     }
   }, [quests, userId]);
 
   const addQuest = (q) => {
-    const quest = {
+    const quest = normalizeQuest({
       rarity: 'C',
       urgent: false,
       ...q,
-    };
+    });
     setQuests((prev) => [...prev, quest]);
     if (userId && navigator.onLine && (quest.type === 'main' || quest.urgent)) {
-      supabaseClient.from('quests').insert({ ...quest, user_id: userId });
+      supabaseClient.from('quests').insert(buildQuestPayload(quest));
     }
   };
 
@@ -74,15 +107,29 @@ export function QuestProvider({ children }) {
     setQuests((prev) =>
       prev.map((q) => {
         if (q.id === id) {
-          const newResource =
-            parseInt(localStorage.getItem('resourceR') || '0', 10) +
-            (q.resource || 0);
-          localStorage.setItem('resourceR', newResource);
+          const deltaR =
+            typeof q.resource_r === 'number'
+              ? q.resource_r
+              : typeof q.resource === 'number'
+                ? q.resource
+                : 0;
+          const deltaX = typeof q.resource_x === 'number' ? q.resource_x : 0;
+          const currentR = parseInt(localStorage.getItem('resourceR') || '0', 10);
+          const currentX = parseInt(localStorage.getItem('resourceX') || '0', 10);
+          const newResourceR = currentR + deltaR;
+          const newResourceX = currentX + deltaX;
+          localStorage.setItem('resourceR', newResourceR);
+          localStorage.setItem('resourceX', newResourceX);
           if (userId && navigator.onLine) {
-            supabaseClient.from('profiles').update({ resources: newResource }).eq('id', userId);
+            supabaseClient
+              .from('profiles')
+              .update({ resource_r: newResourceR, resource_x: newResourceX })
+              .eq('id', userId);
           }
           window.dispatchEvent(
-            new CustomEvent('resourceChange', { detail: { resource: newResource } })
+            new CustomEvent('resourceChange', {
+              detail: { resource: newResourceR, resourceX: newResourceX },
+            })
           );
           return { ...q, completed: true };
         }

--- a/QuestModal.jsx
+++ b/QuestModal.jsx
@@ -6,6 +6,7 @@ export default function QuestModal({ onAdd, onClose }) {
   const [description, setDescription] = useState('');
   const [quadrant, setQuadrant] = useState('II');
   const [resource, setResource] = useState(0);
+  const [resourceX, setResourceX] = useState(0);
   const [rarity, setRarity] = useState('C');
   const [urgent, setUrgent] = useState(false);
 
@@ -16,6 +17,8 @@ export default function QuestModal({ onAdd, onClose }) {
       description,
       quadrant,
       resource: parseInt(resource, 10) || 0,
+      resource_r: parseInt(resource, 10) || 0,
+      resource_x: parseInt(resourceX, 10) || 0,
       rarity,
       urgent,
       accepted: true,
@@ -56,6 +59,13 @@ export default function QuestModal({ onAdd, onClose }) {
           placeholder="Resource (+/-)"
           value={resource}
           onChange={(e) => setResource(e.target.value)}
+        />
+        <input
+          className="note-title"
+          type="number"
+          placeholder="Resource X (+/-)"
+          value={resourceX}
+          onChange={(e) => setResourceX(e.target.value)}
         />
         <label className="note-label">
           Rarity

--- a/profiles.sql
+++ b/profiles.sql
@@ -4,6 +4,8 @@ create table if not exists profiles (
   username text unique not null,
   avatar_url text,
   resources int default 0,
+  resource_r int default 0,
+  resource_x int default 0,
   streaks int default 0,
   stats jsonb default '[5,5,5,5]'
 );
@@ -12,6 +14,18 @@ alter table profiles
   add column if not exists mbti text,
   add column if not exists enneagram text,
   add column if not exists instinct text;
+
+alter table profiles
+  add column if not exists resource_r int default 0,
+  add column if not exists resource_x int default 0;
+
+update profiles
+set resource_r = coalesce(resource_r, resources, 0)
+where resource_r is null;
+
+update profiles
+set resource_x = coalesce(resource_x, 0)
+where resource_x is null;
 
 -- Upgrade existing installations
 alter table profiles

--- a/src/AcceptedQuestList.jsx
+++ b/src/AcceptedQuestList.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { RIcon } from './ResourceIcons.jsx';
+import { RIcon, XIcon } from './ResourceIcons.jsx';
 import { useQuests } from './QuestContext.jsx';
 import './world.css';
 
@@ -22,45 +22,59 @@ export default function AcceptedQuestList() {
         <div key={type}>
           <h5>{type.charAt(0).toUpperCase() + type.slice(1)} Quests</h5>
           <div className="quest-list">
-            {list.map((q) => (
-              <div key={q.id}>
-                <div className="quest-banner">
-                  <div className="quest-info">
-                    <div className="quest-name">{q.name}</div>
-                    <div className="quest-quadrant">{q.quadrant}</div>
-                    <div className="quest-rarity">{q.rarity || 'C'}</div>
-                    {q.urgent && <div className="quest-urgent">Urgent</div>}
-                    {q.resource !== 0 && (
-                      <div className="quest-resource">
-                        {q.resource > 0 ? '+' : ''}
-                        {q.resource} <RIcon />
-                      </div>
-                    )}
-                  </div>
-                  <div style={{ display: 'flex', gap: '4px' }}>
-                    {q.description && (
+            {list.map((q) => {
+              const rewardR = q.resource_r ?? q.resource ?? 0;
+              const rewardX = q.resource_x ?? 0;
+              return (
+                <div key={q.id}>
+                  <div className="quest-banner">
+                    <div className="quest-info">
+                      <div className="quest-name">{q.name}</div>
+                      <div className="quest-quadrant">{q.quadrant}</div>
+                      <div className="quest-rarity">{q.rarity || 'C'}</div>
+                      {q.urgent && <div className="quest-urgent">Urgent</div>}
+                      {(rewardR !== 0 || rewardX !== 0) && (
+                        <div className="quest-resource">
+                          {rewardR !== 0 && (
+                            <span>
+                              {rewardR > 0 ? '+' : ''}
+                              {rewardR} <RIcon />
+                            </span>
+                          )}
+                          {rewardX !== 0 && (
+                            <span>
+                              {rewardX > 0 ? '+' : ''}
+                              {rewardX} <XIcon />
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <div style={{ display: 'flex', gap: '4px' }}>
+                      {q.description && (
+                        <button
+                          className="info-button"
+                          onClick={() =>
+                            setExpanded(expanded === q.id ? null : q.id)
+                          }
+                        >
+                          i
+                        </button>
+                      )}
                       <button
-                        className="info-button"
-                        onClick={() =>
-                          setExpanded(expanded === q.id ? null : q.id)
-                        }
+                        className="accept-button"
+                        onClick={() => completeQuest(q.id)}
                       >
-                        i
+                        Complete
                       </button>
-                    )}
-                    <button
-                      className="accept-button"
-                      onClick={() => completeQuest(q.id)}
-                    >
-                      Complete
-                    </button>
+                    </div>
                   </div>
+                  {expanded === q.id && q.description && (
+                    <div className="quest-log">{q.description}</div>
+                  )}
                 </div>
-                {expanded === q.id && q.description && (
-                  <div className="quest-log">{q.description}</div>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       ))}

--- a/src/Auth.jsx
+++ b/src/Auth.jsx
@@ -76,6 +76,8 @@ export default function Auth() {
           username: cleanName,
           avatar_url: null,
           resources: 0,
+          resource_r: 0,
+          resource_x: 0,
           streaks: 0,
           stats: [5, 5, 5, 5],
         });

--- a/src/QuestContext.jsx
+++ b/src/QuestContext.jsx
@@ -10,6 +10,38 @@ export function QuestProvider({ children }) {
   });
   const [userId, setUserId] = useState(null);
 
+  const normalizeQuest = (quest) => ({
+    ...quest,
+    resource_r:
+      typeof quest.resource_r === 'number'
+        ? quest.resource_r
+        : typeof quest.resource === 'number'
+          ? quest.resource
+          : 0,
+    resource_x: typeof quest.resource_x === 'number' ? quest.resource_x : 0,
+    resource:
+      typeof quest.resource === 'number'
+        ? quest.resource
+        : typeof quest.resource_r === 'number'
+          ? quest.resource_r
+          : 0,
+  });
+
+  const buildQuestPayload = (quest) => ({
+    id: quest.id,
+    user_id: userId,
+    type: quest.type || 'user',
+    name: quest.name,
+    description: quest.description,
+    quadrant: quest.quadrant,
+    resource_r: quest.resource_r,
+    resource_x: quest.resource_x,
+    rarity: quest.rarity,
+    urgent: quest.urgent,
+    accepted: quest.accepted,
+    completed: quest.completed,
+  });
+
   useEffect(() => {
     const load = async () => {
       if (!navigator.onLine) return;
@@ -23,8 +55,9 @@ export function QuestProvider({ children }) {
         .select('*')
         .eq('user_id', user.id);
       if (data) {
-        setQuests(data);
-        localStorage.setItem('quests', JSON.stringify(data));
+        const normalized = data.map(normalizeQuest);
+        setQuests(normalized);
+        localStorage.setItem('quests', JSON.stringify(normalized));
       }
     };
     load();
@@ -36,21 +69,21 @@ export function QuestProvider({ children }) {
     if (userId && navigator.onLine) {
       quests.forEach((q) => {
         if (q.type === 'main' || q.urgent) {
-          supabaseClient.from('quests').upsert({ ...q, user_id: userId });
+          supabaseClient.from('quests').upsert(buildQuestPayload(q));
         }
       });
     }
   }, [quests, userId]);
 
   const addQuest = (q) => {
-    const quest = {
+    const quest = normalizeQuest({
       rarity: 'C',
       urgent: false,
       ...q,
-    };
+    });
     setQuests((prev) => [...prev, quest]);
     if (userId && navigator.onLine && (quest.type === 'main' || quest.urgent)) {
-      supabaseClient.from('quests').insert({ ...quest, user_id: userId });
+      supabaseClient.from('quests').insert(buildQuestPayload(quest));
     }
   };
 
@@ -76,13 +109,22 @@ export function QuestProvider({ children }) {
         if (q.id === id) {
           const newResource =
             parseInt(localStorage.getItem('resourceR') || '0', 10) +
-            (q.resource || 0);
+            (q.resource || q.resource_r || 0);
+          const newResourceX =
+            parseInt(localStorage.getItem('resourceX') || '0', 10) +
+            (q.resource_x || 0);
           localStorage.setItem('resourceR', newResource);
+          localStorage.setItem('resourceX', newResourceX);
           if (userId && navigator.onLine) {
-            supabaseClient.from('profiles').update({ resources: newResource }).eq('id', userId);
+            supabaseClient
+              .from('profiles')
+              .update({ resource_r: newResource, resource_x: newResourceX })
+              .eq('id', userId);
           }
           window.dispatchEvent(
-            new CustomEvent('resourceChange', { detail: { resource: newResource } })
+            new CustomEvent('resourceChange', {
+              detail: { resource: newResource, resourceX: newResourceX },
+            })
           );
           return { ...q, completed: true };
         }

--- a/src/QuestModal.jsx
+++ b/src/QuestModal.jsx
@@ -6,6 +6,7 @@ export default function QuestModal({ onAdd, onClose }) {
   const [description, setDescription] = useState('');
   const [quadrant, setQuadrant] = useState('II');
   const [resource, setResource] = useState(0);
+  const [resourceX, setResourceX] = useState(0);
   const [rarity, setRarity] = useState('C');
   const [urgent, setUrgent] = useState(false);
 
@@ -16,6 +17,8 @@ export default function QuestModal({ onAdd, onClose }) {
       description,
       quadrant,
       resource: parseInt(resource, 10) || 0,
+      resource_r: parseInt(resource, 10) || 0,
+      resource_x: parseInt(resourceX, 10) || 0,
       rarity,
       urgent,
       accepted: true,
@@ -56,6 +59,13 @@ export default function QuestModal({ onAdd, onClose }) {
           placeholder="Resource (+/-)"
           value={resource}
           onChange={(e) => setResource(e.target.value)}
+        />
+        <input
+          className="note-title"
+          type="number"
+          placeholder="Resource X (+/-)"
+          value={resourceX}
+          onChange={(e) => setResourceX(e.target.value)}
         />
         <label className="note-label">
           Rarity

--- a/src/World.jsx
+++ b/src/World.jsx
@@ -106,12 +106,17 @@ export default function World({ activeLayer = "Form" }) {
       setUserId(user.id);
       const { data: profileData } = await supabaseClient
         .from("profiles")
-        .select("resources, mbti, enneagram, instinct")
+        .select("resource_r, resource_x, resources, mbti, enneagram, instinct")
         .eq("id", user.id)
         .single();
       if (profileData) {
-        if (typeof profileData.resources === "number") {
+        if (typeof profileData.resource_r === "number") {
+          setResource(profileData.resource_r);
+        } else if (typeof profileData.resources === "number") {
           setResource(profileData.resources);
+        }
+        if (typeof profileData.resource_x === "number") {
+          setXResource(profileData.resource_x);
         }
         setProfile(profileData);
         setNeedsMainQuest(!profileData.mbti || !profileData.enneagram);
@@ -126,6 +131,9 @@ export default function World({ activeLayer = "Form" }) {
       if (e.detail && typeof e.detail.resource === "number") {
         setResource(e.detail.resource);
       }
+      if (e.detail && typeof e.detail.resourceX === "number") {
+        setXResource(e.detail.resourceX);
+      }
     };
     window.addEventListener("resourceChange", handler);
     return () => window.removeEventListener("resourceChange", handler);
@@ -133,17 +141,19 @@ export default function World({ activeLayer = "Form" }) {
 
   useEffect(() => {
     localStorage.setItem("resourceR", resource);
-    if (userId && navigator.onLine) {
-      supabaseClient
-        .from("profiles")
-        .update({ resources: resource })
-        .eq("id", userId);
-    }
-  }, [resource, userId]);
+  }, [resource]);
 
   useEffect(() => {
     localStorage.setItem("resourceX", xResource);
   }, [xResource]);
+
+  useEffect(() => {
+    if (!userId || !navigator.onLine) return;
+    supabaseClient
+      .from("profiles")
+      .update({ resource_r: resource, resource_x: xResource })
+      .eq("id", userId);
+  }, [resource, userId, xResource]);
 
   useEffect(() => {
     document.body.classList.add("world-page");
@@ -253,43 +263,57 @@ export default function World({ activeLayer = "Form" }) {
         )}
         {quests
           .filter((q) => !q.accepted && !q.completed)
-          .map((q) => (
-            <div key={q.id}>
-              <div className="quest-banner">
-                <div className="quest-info">
-                  <div className="quest-name">{q.name}</div>
-                  <div className="quest-quadrant">{q.quadrant}</div>
-                  {q.resource !== 0 && (
-                    <div className="quest-resource">
-                      {q.resource > 0 ? "+" : ""}
-                      {q.resource} <RIcon />
-                    </div>
-                  )}
-                </div>
-                <div style={{ display: 'flex', gap: '4px' }}>
-                  {q.description && (
+          .map((q) => {
+            const rewardR = q.resource_r ?? q.resource ?? 0;
+            const rewardX = q.resource_x ?? 0;
+            return (
+              <div key={q.id}>
+                <div className="quest-banner">
+                  <div className="quest-info">
+                    <div className="quest-name">{q.name}</div>
+                    <div className="quest-quadrant">{q.quadrant}</div>
+                    {(rewardR !== 0 || rewardX !== 0) && (
+                      <div className="quest-resource">
+                        {rewardR !== 0 && (
+                          <span>
+                            {rewardR > 0 ? "+" : ""}
+                            {rewardR} <RIcon />
+                          </span>
+                        )}
+                        {rewardX !== 0 && (
+                          <span>
+                            {rewardX > 0 ? "+" : ""}
+                            {rewardX} <XIcon />
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <div style={{ display: 'flex', gap: '4px' }}>
+                    {q.description && (
+                      <button
+                        className="info-button"
+                        onClick={() =>
+                          setExpanded(expanded === q.id ? null : q.id)
+                        }
+                      >
+                        i
+                      </button>
+                    )}
                     <button
-                      className="info-button"
-                      onClick={() =>
-                        setExpanded(expanded === q.id ? null : q.id)
-                      }
+                      className="accept-button"
+                      onClick={() => acceptQuest(q.id)}
                     >
-                      i
+                      ✔
                     </button>
-                  )}
-                  <button
-                    className="accept-button"
-                    onClick={() => acceptQuest(q.id)}
-                  >
-                    ✔
-                  </button>
+                  </div>
                 </div>
+                {expanded === q.id && q.description && (
+                  <div className="quest-log">{q.description}</div>
+                )}
               </div>
-              {expanded === q.id && q.description && (
-                <div className="quest-log">{q.description}</div>
-              )}
-            </div>
-          ))}
+            );
+          })}
       </div>
       {showModal && (
         <QuestModal

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = '0.5.6';
+export const APP_VERSION = '0.5.7';

--- a/supabase-tables.sql
+++ b/supabase-tables.sql
@@ -7,12 +7,34 @@ create table if not exists quests (
   name text,
   description text,
   quadrant text,
-  resource int default 0,
+  resource_r int default 0,
+  resource_x int default 0,
   rarity text default 'C',
   urgent boolean default false,
   accepted boolean default false,
   completed boolean default false
 );
+
+alter table quests
+  add column if not exists resource_r int default 0,
+  add column if not exists resource_x int default 0;
+
+update quests
+set resource_r = coalesce(resource_r, 0)
+where resource_r is null;
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.columns
+    where table_name = 'quests' and column_name = 'resource'
+  ) then
+    update quests
+    set resource_r = coalesce(resource_r, resource, 0)
+    where resource_r is null;
+  end if;
+end $$;
 
 create table if not exists runs (
   id uuid primary key default gen_random_uuid(),


### PR DESCRIPTION
## Summary
- add resource_r/resource_x columns to Supabase schemas and seed profiles with the new fields
- load and persist both resource pools when signing up, completing quests, and rendering quest rewards
- hydrate resource values from Supabase so world state and quest UI reflect saved R/X balances

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ab01261c8322ac0780b217314464)